### PR TITLE
Added native implementation to retrieve system theme.

### DIFF
--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -120,7 +120,7 @@ packages:
       name: source_span
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.8.0"
+    version: "1.8.1"
   stack_trace:
     dependency: transitive
     description:

--- a/example/windows/flutter/generated_plugin_registrant.cc
+++ b/example/windows/flutter/generated_plugin_registrant.cc
@@ -2,8 +2,13 @@
 //  Generated file. Do not edit.
 //
 
+// clang-format off
+
 #include "generated_plugin_registrant.h"
 
+#include <fluent_ui/fluent_ui_plugin.h>
 
 void RegisterPlugins(flutter::PluginRegistry* registry) {
+  FluentUiPluginRegisterWithRegistrar(
+      registry->GetRegistrarForPlugin("FluentUiPlugin"));
 }

--- a/example/windows/flutter/generated_plugin_registrant.h
+++ b/example/windows/flutter/generated_plugin_registrant.h
@@ -2,6 +2,8 @@
 //  Generated file. Do not edit.
 //
 
+// clang-format off
+
 #ifndef GENERATED_PLUGIN_REGISTRANT_
 #define GENERATED_PLUGIN_REGISTRANT_
 

--- a/example/windows/flutter/generated_plugins.cmake
+++ b/example/windows/flutter/generated_plugins.cmake
@@ -3,6 +3,7 @@
 #
 
 list(APPEND FLUTTER_PLUGIN_LIST
+  fluent_ui
 )
 
 set(PLUGIN_BUNDLED_LIBRARIES)

--- a/lib/src/styles/theme.dart
+++ b/lib/src/styles/theme.dart
@@ -209,7 +209,8 @@ class Style with Diagnosticable {
       animationCurve: other.animationCurve ?? animationCurve,
       disabledColor: other.disabledColor ?? disabledColor,
       typography: other.typography ?? typography,
-      fasterAnimationDuration: other.fastAnimationDuration ?? fasterAnimationDuration,
+      fasterAnimationDuration:
+          other.fastAnimationDuration ?? fasterAnimationDuration,
       fastAnimationDuration:
           other.fastAnimationDuration ?? fastAnimationDuration,
       mediumAnimationDuration:

--- a/lib/src/system_theme.dart
+++ b/lib/src/system_theme.dart
@@ -1,0 +1,70 @@
+import 'package:fluent_ui/fluent_ui.dart';
+import 'package:flutter/services.dart';
+
+/// Platform channel handler for invoking native methods.
+final MethodChannel channel = new MethodChannel('fluent_ui');
+
+/// Class to return current system theme state on Windows.
+///
+/// [SystemTheme.darkMode] returns whether currently dark mode is enabled or not.
+///
+/// [SystemTheme.accentColor] returns the current accent color as [AccentColor].
+///
+class SystemTheme {
+  static Future<bool> get darkMode async {
+    return await channel.invokeMethod('SystemTheme.darkMode');
+  }
+
+  static AccentColor accent = new AccentColor();
+}
+
+/// Defines accent colors & its variants on Windows.
+/// Colors are cached by default, call [AccentColor.refresh] to the updated colors.
+///
+class AccentColor {
+  /// Base accent color.
+  late Color accent;
+
+  /// Light shade.
+  late Color light;
+
+  /// Lighter shade.
+  late Color lighter;
+
+  /// Lighest shade.
+  late Color lightest;
+
+  /// Darkest shade.
+  late Color dark;
+
+  /// Darker shade.
+  late Color darker;
+
+  /// Darkest shade.
+  late Color darkest;
+
+  AccentColor() {
+    refresh();
+  }
+
+  /// Updates the fetched accent colors on Windows.
+  Future<void> refresh() async {
+    dynamic colors = await channel.invokeMethod('SystemTheme.accentColor');
+    accent = _retrieve(colors['accent']);
+    light = _retrieve(colors['light']);
+    lighter = _retrieve(colors['lighter']);
+    lightest = _retrieve(colors['lightest']);
+    dark = _retrieve(colors['dark']);
+    darker = _retrieve(colors['darker']);
+    darkest = _retrieve(colors['darkest']);
+  }
+
+  Color _retrieve(dynamic map) {
+    return Color.fromRGBO(
+      map['R'],
+      map['G'],
+      map['B'],
+      1.0,
+    );
+  }
+}

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -99,7 +99,7 @@ packages:
       name: source_span
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.8.0"
+    version: "1.8.1"
   stack_trace:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -39,3 +39,8 @@ flutter:
     - family: FluentSystemIconsP7
       fonts:
         - asset: fonts/FluentSystemIconsP7.ttf
+  
+  plugin:
+    platforms:
+      windows:
+        pluginClass: FluentUiPlugin

--- a/windows/.gitignore
+++ b/windows/.gitignore
@@ -1,0 +1,17 @@
+flutter/
+
+# Visual Studio user-specific files.
+*.suo
+*.user
+*.userosscache
+*.sln.docstates
+
+# Visual Studio build-related files.
+x64/
+x86/
+
+# Visual Studio cache files
+# files ending in .cache can be ignored
+*.[Cc]ache
+# but keep track of directories ending in .cache
+!*.[Cc]ache/

--- a/windows/.gitignore
+++ b/windows/.gitignore
@@ -15,3 +15,7 @@ x86/
 *.[Cc]ache
 # but keep track of directories ending in .cache
 !*.[Cc]ache/
+
+# Fetched headers & dependencies
+
+SystemTheme

--- a/windows/CMakeLists.txt
+++ b/windows/CMakeLists.txt
@@ -1,0 +1,21 @@
+cmake_minimum_required(VERSION 3.15)
+set(PROJECT_NAME "fluent_ui")
+project(${PROJECT_NAME} LANGUAGES CXX)
+
+set(PLUGIN_NAME "fluent_ui_plugin")
+
+add_library(${PLUGIN_NAME} SHARED
+  "fluent_ui_plugin.cpp"
+)
+apply_standard_settings(${PLUGIN_NAME})
+set_target_properties(${PLUGIN_NAME} PROPERTIES
+  CXX_VISIBILITY_PRESET hidden)
+target_compile_definitions(${PLUGIN_NAME} PRIVATE FLUTTER_PLUGIN_IMPL)
+target_include_directories(${PLUGIN_NAME} INTERFACE
+  "${CMAKE_CURRENT_SOURCE_DIR}/include")
+target_link_libraries(${PLUGIN_NAME} PRIVATE flutter flutter_wrapper_plugin)
+
+set(fluent_ui_bundled_libraries
+  ""
+  PARENT_SCOPE
+)

--- a/windows/CMakeLists.txt
+++ b/windows/CMakeLists.txt
@@ -1,21 +1,63 @@
 cmake_minimum_required(VERSION 3.15)
 set(PROJECT_NAME "fluent_ui")
 project(${PROJECT_NAME} LANGUAGES CXX)
+set(CMAKE_CXX_STANDARD 17)
 
 set(PLUGIN_NAME "fluent_ui_plugin")
+
+include_directories(
+  ${PLUGIN_NAME}
+  INTERFACE
+  "${CMAKE_CURRENT_SOURCE_DIR}"
+)
+
+set(SYSTEM_THEME_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/SystemTheme")
+set(SYSTEM_THEME_DEPENDENCY "https://github.com/res2k/Windows10Colors/archive/master.zip")
+set(SYSTEM_THEME_ARCHIVE "${CMAKE_CURRENT_SOURCE_DIR}/SystemTheme/Windows10Colors.zip")
+set(SYSTEM_THEME_SOURCE "${CMAKE_CURRENT_SOURCE_DIR}/SystemTheme/Windows10Colors-master/Windows10Colors")
+if (NOT EXISTS "${SYSTEM_THEME_ARCHIVE}")
+  file(DOWNLOAD "${SYSTEM_THEME_DEPENDENCY}" "${SYSTEM_THEME_ARCHIVE}")
+endif()
+add_custom_target(EXTRACT ALL)
+add_custom_command(
+  TARGET EXTRACT PRE_BUILD
+  COMMAND ${CMAKE_COMMAND} -E tar xzf \"${SYSTEM_THEME_ARCHIVE}\"
+  WORKING_DIRECTORY "${SYSTEM_THEME_DIRECTORY}"
+  DEPENDS "${SYSTEM_THEME_ARCHIVE}"
+)
 
 add_library(${PLUGIN_NAME} SHARED
   "fluent_ui_plugin.cpp"
 )
 apply_standard_settings(${PLUGIN_NAME})
-set_target_properties(${PLUGIN_NAME} PROPERTIES
-  CXX_VISIBILITY_PRESET hidden)
-target_compile_definitions(${PLUGIN_NAME} PRIVATE FLUTTER_PLUGIN_IMPL)
-target_include_directories(${PLUGIN_NAME} INTERFACE
-  "${CMAKE_CURRENT_SOURCE_DIR}/include")
-target_link_libraries(${PLUGIN_NAME} PRIVATE flutter flutter_wrapper_plugin)
+set_target_properties(
+  ${PLUGIN_NAME}
+  PROPERTIES
+  CXX_VISIBILITY_PRESET
+  hidden
+)
+target_compile_definitions(
+  ${PLUGIN_NAME}
+  PRIVATE
+  FLUTTER_PLUGIN_IMPL
+)
+target_include_directories(
+  ${PLUGIN_NAME}
+  INTERFACE
+  "${CMAKE_CURRENT_SOURCE_DIR}/include"
+  "${SYSTEM_THEME_SOURCE}"
+)
+target_link_libraries(
+  ${PLUGIN_NAME}
+  PRIVATE
+  flutter
+  flutter_wrapper_plugin
+  "Advapi32.lib"
+)
 
 set(fluent_ui_bundled_libraries
   ""
   PARENT_SCOPE
 )
+
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /wd4458 /wd4244 /wd4701")

--- a/windows/fluent_ui_plugin.cpp
+++ b/windows/fluent_ui_plugin.cpp
@@ -1,0 +1,82 @@
+#include "include/fluent_ui/fluent_ui_plugin.h"
+
+// This must be included before many other Windows headers.
+#include <windows.h>
+
+// For getPlatformVersion; remove unless needed for your plugin implementation.
+#include <VersionHelpers.h>
+
+#include <flutter/method_channel.h>
+#include <flutter/plugin_registrar_windows.h>
+#include <flutter/standard_method_codec.h>
+
+#include <map>
+#include <memory>
+#include <sstream>
+
+namespace {
+
+class FluentUiPlugin : public flutter::Plugin {
+ public:
+  static void RegisterWithRegistrar(flutter::PluginRegistrarWindows *registrar);
+
+  FluentUiPlugin();
+
+  virtual ~FluentUiPlugin();
+
+ private:
+  // Called when a method is called on this plugin's channel from Dart.
+  void HandleMethodCall(
+      const flutter::MethodCall<flutter::EncodableValue> &method_call,
+      std::unique_ptr<flutter::MethodResult<flutter::EncodableValue>> result);
+};
+
+// static
+void FluentUiPlugin::RegisterWithRegistrar(
+    flutter::PluginRegistrarWindows *registrar) {
+  auto channel =
+      std::make_unique<flutter::MethodChannel<flutter::EncodableValue>>(
+          registrar->messenger(), "fluent_ui",
+          &flutter::StandardMethodCodec::GetInstance());
+
+  auto plugin = std::make_unique<FluentUiPlugin>();
+
+  channel->SetMethodCallHandler(
+      [plugin_pointer = plugin.get()](const auto &call, auto result) {
+        plugin_pointer->HandleMethodCall(call, std::move(result));
+      });
+
+  registrar->AddPlugin(std::move(plugin));
+}
+
+FluentUiPlugin::FluentUiPlugin() {}
+
+FluentUiPlugin::~FluentUiPlugin() {}
+
+void FluentUiPlugin::HandleMethodCall(
+    const flutter::MethodCall<flutter::EncodableValue> &method_call,
+    std::unique_ptr<flutter::MethodResult<flutter::EncodableValue>> result) {
+  if (method_call.method_name().compare("getPlatformVersion") == 0) {
+    std::ostringstream version_stream;
+    version_stream << "Windows ";
+    if (IsWindows10OrGreater()) {
+      version_stream << "10+";
+    } else if (IsWindows8OrGreater()) {
+      version_stream << "8";
+    } else if (IsWindows7OrGreater()) {
+      version_stream << "7";
+    }
+    result->Success(flutter::EncodableValue(version_stream.str()));
+  } else {
+    result->NotImplemented();
+  }
+}
+
+}  // namespace
+
+void FluentUiPluginRegisterWithRegistrar(
+    FlutterDesktopPluginRegistrarRef registrar) {
+  FluentUiPlugin::RegisterWithRegistrar(
+      flutter::PluginRegistrarManager::GetInstance()
+          ->GetRegistrar<flutter::PluginRegistrarWindows>(registrar));
+}

--- a/windows/fluent_ui_plugin.cpp
+++ b/windows/fluent_ui_plugin.cpp
@@ -1,82 +1,113 @@
-#include "include/fluent_ui/fluent_ui_plugin.h"
+#define NOMINMAX
 
-// This must be included before many other Windows headers.
+#include <string>
+#include <map>
+
 #include <windows.h>
-
-// For getPlatformVersion; remove unless needed for your plugin implementation.
-#include <VersionHelpers.h>
-
+#include "include/fluent_ui/fluent_ui_plugin.h"
 #include <flutter/method_channel.h>
 #include <flutter/plugin_registrar_windows.h>
 #include <flutter/standard_method_codec.h>
 
-#include <map>
-#include <memory>
-#include <sstream>
+#include <SystemTheme/Windows10Colors-master/Windows10Colors/Windows10Colors.cpp>
+
+
+flutter::EncodableMap getRGBA(windows10colors::RGBA _color) {
+    /* Converts windows10colors::RGBA to Flutter readable map of following structure.
+     *
+     * {
+     *      'R': 0,
+     *      'G': 120,
+     *      'B': 215,
+     *      'A': 1
+     * }
+     * 
+     */
+    using namespace windows10colors;
+    flutter::EncodableMap color = flutter::EncodableMap();
+    color[flutter::EncodableValue("R")] = flutter::EncodableValue(static_cast<int>(GetRValue(_color)));
+    color[flutter::EncodableValue("G")] = flutter::EncodableValue(static_cast<int>(GetGValue(_color)));
+    color[flutter::EncodableValue("B")] = flutter::EncodableValue(static_cast<int>(GetBValue(_color)));
+    color[flutter::EncodableValue("A")] = flutter::EncodableValue(static_cast<int>(GetAValue(_color)));
+    return color;
+}
+
 
 namespace {
 
-class FluentUiPlugin : public flutter::Plugin {
- public:
-  static void RegisterWithRegistrar(flutter::PluginRegistrarWindows *registrar);
 
-  FluentUiPlugin();
+    class FluentUiPlugin : public flutter::Plugin {
+    public:
+        static void RegisterWithRegistrar(flutter::PluginRegistrarWindows *registrar);
 
-  virtual ~FluentUiPlugin();
+        FluentUiPlugin();
 
- private:
-  // Called when a method is called on this plugin's channel from Dart.
-  void HandleMethodCall(
-      const flutter::MethodCall<flutter::EncodableValue> &method_call,
-      std::unique_ptr<flutter::MethodResult<flutter::EncodableValue>> result);
-};
+        virtual ~FluentUiPlugin();
 
-// static
-void FluentUiPlugin::RegisterWithRegistrar(
-    flutter::PluginRegistrarWindows *registrar) {
-  auto channel =
-      std::make_unique<flutter::MethodChannel<flutter::EncodableValue>>(
-          registrar->messenger(), "fluent_ui",
-          &flutter::StandardMethodCodec::GetInstance());
+        private:
+        void HandleMethodCall(const flutter::MethodCall<flutter::EncodableValue> &method_call, std::unique_ptr<flutter::MethodResult<flutter::EncodableValue>> result);
+    };
 
-  auto plugin = std::make_unique<FluentUiPlugin>();
 
-  channel->SetMethodCallHandler(
-      [plugin_pointer = plugin.get()](const auto &call, auto result) {
-        plugin_pointer->HandleMethodCall(call, std::move(result));
-      });
-
-  registrar->AddPlugin(std::move(plugin));
-}
-
-FluentUiPlugin::FluentUiPlugin() {}
-
-FluentUiPlugin::~FluentUiPlugin() {}
-
-void FluentUiPlugin::HandleMethodCall(
-    const flutter::MethodCall<flutter::EncodableValue> &method_call,
-    std::unique_ptr<flutter::MethodResult<flutter::EncodableValue>> result) {
-  if (method_call.method_name().compare("getPlatformVersion") == 0) {
-    std::ostringstream version_stream;
-    version_stream << "Windows ";
-    if (IsWindows10OrGreater()) {
-      version_stream << "10+";
-    } else if (IsWindows8OrGreater()) {
-      version_stream << "8";
-    } else if (IsWindows7OrGreater()) {
-      version_stream << "7";
+    void FluentUiPlugin::RegisterWithRegistrar(flutter::PluginRegistrarWindows *registrar) {
+        auto channel = std::make_unique<flutter::MethodChannel<flutter::EncodableValue>>(registrar->messenger(), "fluent_ui", &flutter::StandardMethodCodec::GetInstance());
+        auto plugin = std::make_unique<FluentUiPlugin>();
+        channel->SetMethodCallHandler(
+            [plugin_pointer = plugin.get()](const auto &call, auto result) {
+                plugin_pointer->HandleMethodCall(call, std::move(result));
+            }
+        );
+        registrar->AddPlugin(std::move(plugin));
     }
-    result->Success(flutter::EncodableValue(version_stream.str()));
-  } else {
-    result->NotImplemented();
-  }
+
+    FluentUiPlugin::FluentUiPlugin() {}
+
+    FluentUiPlugin::~FluentUiPlugin() {}
+
+    void FluentUiPlugin::HandleMethodCall(
+        const flutter::MethodCall<flutter::EncodableValue> &method_call, std::unique_ptr<flutter::MethodResult<flutter::EncodableValue>> result) {
+        if (method_call.method_name() == "SystemTheme.darkMode") {
+            bool darkMode = false;
+            windows10colors::GetDarkModeEnabled(darkMode);
+            result->Success(flutter::EncodableValue(darkMode));
+        }
+        else if (method_call.method_name() == "SystemTheme.accentColor") {
+            windows10colors::AccentColor accentColors;
+            windows10colors::GetAccentColor(accentColors);
+            flutter::EncodableMap colors = flutter::EncodableMap();
+            colors[flutter::EncodableValue("accent")] = flutter::EncodableValue(
+                getRGBA(accentColors.accent)
+            );
+            colors[flutter::EncodableValue("light")] = flutter::EncodableValue(
+                getRGBA(accentColors.light)
+            );
+            colors[flutter::EncodableValue("lighter")] = flutter::EncodableValue(
+                getRGBA(accentColors.lighter)
+            );
+            colors[flutter::EncodableValue("lightest")] = flutter::EncodableValue(
+                getRGBA(accentColors.lightest)
+            );
+            colors[flutter::EncodableValue("dark")] = flutter::EncodableValue(
+                getRGBA(accentColors.dark)
+            );
+            colors[flutter::EncodableValue("darker")] = flutter::EncodableValue(
+                getRGBA(accentColors.darker)
+            );
+            colors[flutter::EncodableValue("darkest")] = flutter::EncodableValue(
+                getRGBA(accentColors.darkest)
+            );
+            result->Success(flutter::EncodableValue(colors));
+        }
+        else {
+            result->NotImplemented();
+        }
+    }
+
 }
 
-}  // namespace
 
-void FluentUiPluginRegisterWithRegistrar(
-    FlutterDesktopPluginRegistrarRef registrar) {
-  FluentUiPlugin::RegisterWithRegistrar(
-      flutter::PluginRegistrarManager::GetInstance()
-          ->GetRegistrar<flutter::PluginRegistrarWindows>(registrar));
+void FluentUiPluginRegisterWithRegistrar(FlutterDesktopPluginRegistrarRef registrar) {
+    FluentUiPlugin::RegisterWithRegistrar(
+        flutter::PluginRegistrarManager::GetInstance()->GetRegistrar<flutter::PluginRegistrarWindows>(registrar)
+    );
 }

--- a/windows/include/fluent_ui/fluent_ui_plugin.h
+++ b/windows/include/fluent_ui/fluent_ui_plugin.h
@@ -1,0 +1,23 @@
+#ifndef FLUTTER_PLUGIN_FLUENT_UI_PLUGIN_H_
+#define FLUTTER_PLUGIN_FLUENT_UI_PLUGIN_H_
+
+#include <flutter_plugin_registrar.h>
+
+#ifdef FLUTTER_PLUGIN_IMPL
+#define FLUTTER_PLUGIN_EXPORT __declspec(dllexport)
+#else
+#define FLUTTER_PLUGIN_EXPORT __declspec(dllimport)
+#endif
+
+#if defined(__cplusplus)
+extern "C" {
+#endif
+
+FLUTTER_PLUGIN_EXPORT void FluentUiPluginRegisterWithRegistrar(
+    FlutterDesktopPluginRegistrarRef registrar);
+
+#if defined(__cplusplus)
+}  // extern "C"
+#endif
+
+#endif  // FLUTTER_PLUGIN_FLUENT_UI_PLUGIN_H_


### PR DESCRIPTION
- Package now has plugin interface for Windows added using command:
  - `flutter create --template=plugin --platforms=windows --org com.bdlukaa .`
- Added `SystemTheme` class with `darkMode` and `accentColor` attributes to access system theme mode & accent colors state. (Also, `AccentColor` class)
- Code is formatted using `flutter dartfmt .`.
- This is not a breaking change. I didn't import it to example, you're free to make changes to Dart code the way you want.
- Functionality of added methods/classes is checked.
- The used dependency is not included inside package, but fetched directly on developer's machine through CMake.

Thankyou.