### PR TITLE
Add Fluent selection controls

### DIFF
--- a/README.md
+++ b/README.md
@@ -1591,7 +1591,7 @@ All contributions are welcome :)
 
 Irrespective of order, thanks to all the people below for contributing with the project. It means a lot to me :)
 
-- [@HrX03](https://github.com/HrX03) for the `Acrylic` and the `FluentIcons` generator implementation.
+- [@HrX03](https://github.com/HrX03) for the `Acrylic`, `FluentIcons` generator and `_FluentTextSelectionControls` implementation.
 - [@raitonubero](https://github.com/raitonoberu) for `StickyNavigationIndicator`, `ProgressBar` and `ProgressRing`
 - [@alexmercerind](https://github.com/alexmercerind) for the [flutter_acrylic](https://github.com/alexmercerind/flutter_acrylic) plugin, used on the example app
 - [@bitsdojo](https://github.com/bitsdojo) for the [bitsdojo_window](https://github.com/bitsdojo/bitsdojo_window) plugin, used on the example app.

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -14,7 +14,7 @@ packages:
       name: async
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.6.1"
+    version: "2.7.0"
   bitsdojo_window:
     dependency: "direct main"
     description:
@@ -70,7 +70,7 @@ packages:
       name: charcode
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.2.0"
+    version: "1.3.1"
   clock:
     dependency: transitive
     description:
@@ -176,7 +176,7 @@ packages:
       name: meta
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.3.0"
+    version: "1.4.0"
   nested:
     dependency: transitive
     description:
@@ -272,7 +272,7 @@ packages:
       name: test_api
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.3.0"
+    version: "0.4.1"
   typed_data:
     dependency: transitive
     description:

--- a/example/windows/flutter/generated_plugin_registrant.cc
+++ b/example/windows/flutter/generated_plugin_registrant.cc
@@ -2,6 +2,8 @@
 //  Generated file. Do not edit.
 //
 
+// clang-format off
+
 #include "generated_plugin_registrant.h"
 
 #include <bitsdojo_window_windows/bitsdojo_window_plugin.h>

--- a/example/windows/flutter/generated_plugin_registrant.h
+++ b/example/windows/flutter/generated_plugin_registrant.h
@@ -2,6 +2,8 @@
 //  Generated file. Do not edit.
 //
 
+// clang-format off
+
 #ifndef GENERATED_PLUGIN_REGISTRANT_
 #define GENERATED_PLUGIN_REGISTRANT_
 

--- a/lib/src/controls/form/selection_controls.dart
+++ b/lib/src/controls/form/selection_controls.dart
@@ -1,0 +1,433 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:fluent_ui/fluent_ui.dart';
+import 'package:flutter/material.dart' as m;
+import 'package:flutter/rendering.dart';
+
+const double _kToolbarScreenPadding = 8.0;
+const double _kToolbarWidth = 180.0;
+
+class _FluentTextSelectionControls extends TextSelectionControls {
+  /// Fluent has no text selection handles.
+  @override
+  Size getHandleSize(double textLineHeight) {
+    return Size.zero;
+  }
+
+  /// Builder for the Material-style desktop copy/paste text selection toolbar.
+  @override
+  Widget buildToolbar(
+    BuildContext context,
+    Rect globalEditableRegion,
+    double textLineHeight,
+    Offset selectionMidpoint,
+    List<TextSelectionPoint> endpoints,
+    TextSelectionDelegate delegate,
+    ClipboardStatusNotifier clipboardStatus,
+    Offset? lastSecondaryTapDownPosition,
+  ) {
+    return _FluentTextSelectionControlsToolbar(
+      clipboardStatus: clipboardStatus,
+      endpoints: endpoints,
+      globalEditableRegion: globalEditableRegion,
+      handleCut: canCut(delegate) ? () => handleCut(delegate) : null,
+      handleCopy: canCopy(delegate)
+          ? () => handleCopy(delegate, clipboardStatus)
+          : null,
+      handlePaste: canPaste(delegate) ? () => handlePaste(delegate) : null,
+      handleSelectAll:
+          canSelectAll(delegate) ? () => handleSelectAll(delegate) : null,
+      selectionMidpoint: selectionMidpoint,
+      lastSecondaryTapDownPosition: lastSecondaryTapDownPosition,
+      textLineHeight: textLineHeight,
+    );
+  }
+
+  /// Builds the text selection handles, but desktop has none.
+  @override
+  Widget buildHandle(
+    BuildContext context,
+    TextSelectionHandleType type,
+    double textLineHeight, [
+    VoidCallback? onTap,
+  ]) {
+    return const SizedBox.shrink();
+  }
+
+  /// Gets the position for the text selection handles, but desktop has none.
+  @override
+  Offset getHandleAnchor(TextSelectionHandleType type, double textLineHeight) {
+    return Offset.zero;
+  }
+
+  @override
+  bool canSelectAll(TextSelectionDelegate delegate) {
+    // Allow SelectAll when selection is not collapsed, unless everything has
+    // already been selected. Same behavior as Android.
+    final TextEditingValue value = delegate.textEditingValue;
+    return delegate.selectAllEnabled &&
+        value.text.isNotEmpty &&
+        !(value.selection.start == 0 &&
+            value.selection.end == value.text.length);
+  }
+}
+
+/// Text selection controls that loosely follows Material design conventions.
+final TextSelectionControls fluentTextSelectionControls =
+    _FluentTextSelectionControls();
+
+// Generates the child that's passed into FluentTextSelectionToolbar.
+class _FluentTextSelectionControlsToolbar extends StatefulWidget {
+  const _FluentTextSelectionControlsToolbar({
+    Key? key,
+    required this.clipboardStatus,
+    required this.endpoints,
+    required this.globalEditableRegion,
+    required this.handleCopy,
+    required this.handleCut,
+    required this.handlePaste,
+    required this.handleSelectAll,
+    required this.selectionMidpoint,
+    required this.textLineHeight,
+    required this.lastSecondaryTapDownPosition,
+  }) : super(key: key);
+
+  final ClipboardStatusNotifier? clipboardStatus;
+  final List<TextSelectionPoint> endpoints;
+  final Rect globalEditableRegion;
+  final VoidCallback? handleCopy;
+  final VoidCallback? handleCut;
+  final VoidCallback? handlePaste;
+  final VoidCallback? handleSelectAll;
+  final Offset? lastSecondaryTapDownPosition;
+  final Offset selectionMidpoint;
+  final double textLineHeight;
+
+  @override
+  _FluentTextSelectionControlsToolbarState createState() =>
+      _FluentTextSelectionControlsToolbarState();
+}
+
+class _FluentTextSelectionControlsToolbarState
+    extends State<_FluentTextSelectionControlsToolbar>
+    with SingleTickerProviderStateMixin {
+  late AnimationController _ac;
+  ClipboardStatusNotifier? _clipboardStatus;
+
+  void _onChangedClipboardStatus() {
+    setState(() {
+      // Inform the widget that the value of clipboardStatus has changed.
+    });
+  }
+
+  @override
+  void initState() {
+    super.initState();
+    _ac = AnimationController(
+      vsync: this,
+      duration: Duration(milliseconds: 250),
+    );
+    if (widget.handlePaste != null) {
+      _clipboardStatus = widget.clipboardStatus ?? ClipboardStatusNotifier();
+      _clipboardStatus!.addListener(_onChangedClipboardStatus);
+      _clipboardStatus!.update();
+    }
+    _ac.forward();
+  }
+
+  @override
+  void didUpdateWidget(_FluentTextSelectionControlsToolbar oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (oldWidget.clipboardStatus != widget.clipboardStatus) {
+      if (_clipboardStatus != null) {
+        _clipboardStatus!.removeListener(_onChangedClipboardStatus);
+        _clipboardStatus!.dispose();
+      }
+      _clipboardStatus = widget.clipboardStatus ?? ClipboardStatusNotifier();
+      _clipboardStatus!.addListener(_onChangedClipboardStatus);
+      if (widget.handlePaste != null) {
+        _clipboardStatus!.update();
+      }
+    }
+  }
+
+  @override
+  void dispose() {
+    _ac.dispose();
+    super.dispose();
+    // When used in an Overlay, this can be disposed after its creator has
+    // already disposed _clipboardStatus.
+    if (_clipboardStatus != null && !_clipboardStatus!.disposed) {
+      _clipboardStatus!.removeListener(_onChangedClipboardStatus);
+      if (widget.clipboardStatus == null) {
+        _clipboardStatus!.dispose();
+      }
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    // Don't render the menu until the state of the clipboard is known.
+    if (widget.handlePaste != null &&
+        _clipboardStatus!.value == ClipboardStatus.unknown) {
+      return const SizedBox(width: 0.0, height: 0.0);
+    }
+
+    assert(debugCheckHasMediaQuery(context));
+    final MediaQueryData mediaQuery = MediaQuery.of(context);
+
+    final Offset midpointAnchor = Offset(
+      (widget.selectionMidpoint.dx - widget.globalEditableRegion.left).clamp(
+        mediaQuery.padding.left,
+        mediaQuery.size.width - mediaQuery.padding.right,
+      ),
+      widget.selectionMidpoint.dy - widget.globalEditableRegion.top,
+    );
+
+    assert(debugCheckHasFluentLocalizations(context));
+    final FluentLocalizations localizations = FluentLocalizations.of(context);
+    final List<Widget> items = <Widget>[];
+
+    void addToolbarButton(
+      String text,
+      IconData icon,
+      String tooltip,
+      VoidCallback onPressed,
+    ) {
+      items.add(_FluentTextSelectionToolbarButton(
+        onPressed: onPressed,
+        icon: icon,
+        tooltip: tooltip,
+        text: text,
+      ));
+    }
+
+    if (widget.handleCut != null) {
+      addToolbarButton(
+        localizations.cutButtonLabel,
+        FluentIcons.cut,
+        "Ctrl+X",
+        widget.handleCut!,
+      );
+    }
+    if (widget.handleCopy != null) {
+      addToolbarButton(
+        localizations.copyButtonLabel,
+        FluentIcons.copy,
+        "Ctrl+C",
+        widget.handleCopy!,
+      );
+    }
+    if (widget.handlePaste != null &&
+        _clipboardStatus!.value == ClipboardStatus.pasteable) {
+      addToolbarButton(
+        localizations.pasteButtonLabel,
+        FluentIcons.paste,
+        "Ctrl+V",
+        widget.handlePaste!,
+      );
+    }
+    if (widget.handleSelectAll != null) {
+      addToolbarButton(
+        localizations.selectAllButtonLabel,
+        FluentIcons.select_all,
+        "Ctrl+A",
+        widget.handleSelectAll!,
+      );
+    }
+
+    // If there is no option available, build an empty widget.
+    if (items.isEmpty) {
+      return const SizedBox(width: 0.0, height: 0.0);
+    }
+
+    return _FluentTextSelectionToolbar(
+      anchor: widget.lastSecondaryTapDownPosition ?? midpointAnchor,
+      children: items,
+      animation: CurvedAnimation(
+        parent: _ac.view,
+        curve: Curves.decelerate,
+      ),
+    );
+  }
+}
+
+/// A Material-style desktop text selection toolbar.
+///
+/// Typically displays buttons for text manipulation, e.g. copying and pasting
+/// text.
+///
+/// Tries to position itself as closesly as possible to [anchor] while remaining
+/// fully on-screen.
+///
+/// See also:
+///
+///  * [_FluentTextSelectionControls.buildToolbar], where this is used by
+///    default to build a Material-style desktop toolbar.
+///  * [TextSelectionToolbar], which is similar, but builds an Android-style
+///    toolbar.
+class _FluentTextSelectionToolbar extends StatelessWidget {
+  /// Creates an instance of _FluentTextSelectionToolbar.
+  const _FluentTextSelectionToolbar({
+    Key? key,
+    required this.anchor,
+    required this.children,
+    required this.animation,
+  })  : assert(children.length > 0),
+        super(key: key);
+
+  /// The point at which the toolbar will attempt to position itself as closely
+  /// as possible.
+  final Offset anchor;
+
+  /// {@macro flutter.material.TextSelectionToolbar.children}
+  ///
+  /// See also:
+  ///   * [FluentTextSelectionToolbarButton], which builds a default
+  ///     Material-style desktop text selection toolbar text button.
+  final List<Widget> children;
+
+  final Animation<double> animation;
+
+  @override
+  Widget build(BuildContext context) {
+    assert(debugCheckHasMediaQuery(context));
+    final MediaQueryData mediaQuery = MediaQuery.of(context);
+
+    final double paddingAbove = mediaQuery.padding.top + _kToolbarScreenPadding;
+    final Offset localAdjustment = Offset(_kToolbarScreenPadding, paddingAbove);
+    final bool isDark = FluentTheme.of(context).brightness == Brightness.dark;
+
+    return Padding(
+      padding: EdgeInsets.fromLTRB(
+        _kToolbarScreenPadding,
+        paddingAbove,
+        _kToolbarScreenPadding,
+        _kToolbarScreenPadding,
+      ),
+      child: CustomSingleChildLayout(
+        delegate: DesktopTextSelectionToolbarLayoutDelegate(
+          anchor: anchor - localAdjustment,
+        ),
+        child: AnimatedBuilder(
+          animation: animation,
+          builder: (context, child) {
+            return Acrylic(
+              shape: RoundedRectangleBorder(
+                borderRadius: BorderRadius.all(Radius.circular(4.0)),
+                side: BorderSide(
+                  width: 1,
+                  color: Colors.black.withOpacity(isDark ? 0.36 : 0.14),
+                ),
+              ),
+              elevation: 32.0,
+              tint: isDark ? Color(0xFF2F2F2F) : Color(0xFFEFEFEF),
+              child: Align(
+                alignment: Alignment.topLeft,
+                widthFactor: animation.value,
+                heightFactor: animation.value,
+                child: SizedBox(
+                  width: _kToolbarWidth,
+                  child: Padding(
+                    padding: EdgeInsets.symmetric(vertical: 4),
+                    child: Column(
+                      mainAxisSize: MainAxisSize.min,
+                      children: children,
+                    ),
+                  ),
+                ),
+              ),
+            );
+          },
+        ),
+      ),
+    );
+  }
+}
+
+const TextStyle _kToolbarButtonFontStyle = TextStyle(
+  inherit: false,
+  fontSize: 14.0,
+  letterSpacing: -0.15,
+  fontWeight: FontWeight.w400,
+);
+
+/// A [TextButton] for the Material desktop text selection toolbar.
+class _FluentTextSelectionToolbarButton extends StatelessWidget {
+  _FluentTextSelectionToolbarButton({
+    Key? key,
+    required this.onPressed,
+    required this.text,
+    required this.icon,
+    required this.tooltip,
+  }) : super(key: key);
+
+  final VoidCallback onPressed;
+  final String text;
+  final IconData icon;
+  final String tooltip;
+
+  @override
+  Widget build(BuildContext context) {
+    final ThemeData theme = FluentTheme.of(context);
+    final Brightness acrylicBrightness =
+        m.ThemeData.estimateBrightnessForColor(theme.acrylicBackgroundColor);
+    final Color primary =
+        acrylicBrightness.isDark ? Colors.white : Colors.black;
+
+    return Button(
+      style: ButtonStyle(
+        backgroundColor: ButtonState.resolveWith(
+          (states) {
+            if (states.contains(ButtonStates.pressing)) {
+              return primary.withOpacity(0.2);
+            }
+            if (states.contains(ButtonStates.hovering) ||
+                states.contains(ButtonStates.focused)) {
+              return primary.withOpacity(0.1);
+            }
+            return Colors.transparent;
+          },
+        ),
+        padding: ButtonState.all(EdgeInsets.zero),
+        zFactor: ButtonState.all(1),
+      ),
+      onPressed: onPressed,
+      child: Container(
+        constraints: BoxConstraints(
+          minWidth: kMinInteractiveDimension,
+          minHeight: 32,
+        ),
+        padding: EdgeInsets.symmetric(horizontal: 12),
+        alignment: Alignment.centerLeft,
+        child: Row(
+          children: [
+            Icon(
+              icon,
+              size: 20,
+              color: primary.withOpacity(1),
+            ),
+            SizedBox(width: 12),
+            Text(
+              text,
+              overflow: TextOverflow.ellipsis,
+              style: _kToolbarButtonFontStyle.copyWith(
+                color: primary.withOpacity(1),
+              ),
+            ),
+            Spacer(),
+            Text(
+              tooltip,
+              style: _kToolbarButtonFontStyle.copyWith(
+                color: primary.withOpacity(0.7),
+                fontSize: 12,
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/src/controls/form/text_box.dart
+++ b/lib/src/controls/form/text_box.dart
@@ -1,6 +1,7 @@
 import 'dart:ui' as ui;
 
 import 'package:fluent_ui/fluent_ui.dart';
+import 'package:fluent_ui/src/controls/form/selection_controls.dart';
 import 'package:flutter/gestures.dart';
 import 'package:flutter/rendering.dart';
 
@@ -709,6 +710,7 @@ class _TextBoxState extends State<TextBox>
             enableInteractiveSelection: widget.enableInteractiveSelection,
             autofillHints: widget.autofillHints,
             restorationId: 'editable',
+            selectionControls: fluentTextSelectionControls,
           ),
         ),
       ),

--- a/lib/src/controls/navigation/navigation_view/pane.dart
+++ b/lib/src/controls/navigation/navigation_view/pane.dart
@@ -482,7 +482,7 @@ class NavigationPane with Diagnosticable {
       margin: padding,
       child: PaneItem(
         title: itemTitle,
-        icon: Icon(FluentIcons.collapse_menu),
+        icon: Icon(FluentIcons.global_nav_button),
       ).build(
         context,
         false,

--- a/lib/src/localization.dart
+++ b/lib/src/localization.dart
@@ -41,6 +41,18 @@ abstract class FluentLocalizations {
   /// The dialog label
   String get dialogLabel;
 
+  /// The label for the cut button on the text selection controls
+  String get cutButtonLabel;
+
+  /// The label for the copy button on the text selection controls
+  String get copyButtonLabel;
+
+  /// The label for the paste button on the text selection controls
+  String get pasteButtonLabel;
+
+  /// The label for the select all button on the text selection controls
+  String get selectAllButtonLabel;
+
   /// The `FluentLocalizations` from the closest [Localizations] instance
   /// that encloses the given context.
   ///
@@ -100,6 +112,18 @@ class DefaultFluentLocalizations implements FluentLocalizations {
 
   @override
   String get dialogLabel => 'Dialog';
+
+  @override
+  String get cutButtonLabel => 'Cut';
+
+  @override
+  String get copyButtonLabel => 'Copy';
+
+  @override
+  String get pasteButtonLabel => 'Paste';
+
+  @override
+  String get selectAllButtonLabel => 'Select all';
 
   /// Creates an object that provides US English resource values for the material
   /// library widgets.

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -7,7 +7,7 @@ packages:
       name: async
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.6.1"
+    version: "2.7.0"
   boolean_selector:
     dependency: transitive
     description:
@@ -28,7 +28,7 @@ packages:
       name: charcode
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.2.0"
+    version: "1.3.1"
   clock:
     dependency: transitive
     description:
@@ -80,7 +80,7 @@ packages:
       name: meta
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.3.0"
+    version: "1.4.0"
   path:
     dependency: transitive
     description:
@@ -141,7 +141,7 @@ packages:
       name: test_api
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.3.0"
+    version: "0.4.1"
   typed_data:
     dependency: transitive
     description:


### PR DESCRIPTION
<!-- Add a description of what this PR is changing or adding, and why. Consider mentioning issues -->
This pr aims to add new text selection controls based on the fluent specification.

Light theme screenshot
![](https://i.imgur.com/57U2azn.png)

Dark theme screenshot
![](https://i.imgur.com/Yubwqw7.png)

## Pre-launch Checklist

<!-- Mark all that applyes -->

- [X] I have run `dartfmt` on all changed files <!-- REQUIRED --> 
- [ ] I have updated `CHANGELOG.md` with my changes <!-- REQUIRED --> 
- [X] I have run "optimize/organize imports" on all changed files
- [X] I have addressed all analyzer warnings as best I could
- [X] I have added/updated relevant documentation
- [ ] I have run `flutter pub publish --dry-run` and addressed any warnings