### PR TITLE
Navigation view 3.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,10 @@ Date format: DD/MM/YYYY
 
 ## [next] - [##/##/2021]
 
-- Update `NavigationView` design
+- Update `NavigationView` design:
+  - **BREAKING:** Acryic is not used anymore. Consequently, `useAcrylic` method was removed.
+- Implemented `Mica`, used by the new `NavigationView`
+- Added support for horizontal tooltips. Set `Tooltip.displayHorizontally` to true to enable it.
 
 ## [2.2.1] - [26/06/2021]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 Date format: DD/MM/YYYY
 
+## [next] - [##/##/2021]
+
+- Update `NavigationView` design
+
 ## [2.2.1] - [26/06/2021]
 
 - Implement Fluent Selection Controls for `TextBox` ([#49](https://github.com/bdlukaa/fluent_ui/pull/49))

--- a/README.md
+++ b/README.md
@@ -418,8 +418,6 @@ The NavigationView control provides top-level navigation for your app. It adapts
 
 ![Navigation Panel](https://docs.microsoft.com/en-us/windows/uwp/design/controls-and-patterns/images/nav-view-header.png)
 
-The navigation view also handle the app bar and its content. You can enable the acrylic blur effect by setting `useAcrylic` to true.
-
 ### App Bar
 
 The app bar is the top app bar that every desktop nowadays have.
@@ -475,9 +473,6 @@ pane: NavigationPane(
     required BuildContext context,
     /// The current selected index
     int? index,
-    /// The y axis to take into consideration when calculating the
-    /// position
-    double? y,
     /// A function that, when executed, returns the position of all the
     /// PaneItems. This function must be called after the widget was
     /// rendered at least once
@@ -503,7 +498,6 @@ pane: NavigationPane(
       child: child,
       color: theme.highlightColor,
       curve: theme.animationCurve ?? Curves.linear,
-      y: y ?? 0,
       axis: axis,
     );
   },

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -52,7 +52,7 @@ void main() async {
   if (isDesktop)
     doWhenWindowReady(() {
       final win = appWindow;
-      win.minSize = Size(410, 640);
+      win.minSize = Size(410, 540);
       win.size = Size(755, 545);
       win.alignment = Alignment.center;
       win.title = appTitle;
@@ -122,7 +122,7 @@ class _MyHomePageState extends State<MyHomePage> {
     final appTheme = context.watch<AppTheme>();
     return NavigationView(
       appBar: NavigationAppBar(
-        height: !kIsWeb ? appWindow.titleBarHeight : 31.0,
+        // height: !kIsWeb ? appWindow.titleBarHeight : 31.0,
         title: () {
           if (kIsWeb) return Text(appTitle);
           return MoveWindow(
@@ -135,7 +135,10 @@ class _MyHomePageState extends State<MyHomePage> {
         actions: kIsWeb
             ? null
             : MoveWindow(
-                child: Row(children: [Spacer(), WindowButtons()]),
+                child: Row(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [Spacer(), WindowButtons()],
+                ),
               ),
       ),
       pane: NavigationPane(

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -194,7 +194,8 @@ class _MyHomePageState extends State<MyHomePage> {
           }
         },
         items: [
-          PaneItemHeader(header: Text('User Interaction')),
+          // It doesn't look good when resizing from compact to open
+          // PaneItemHeader(header: Text('User Interaction')),
           PaneItem(
             icon: Icon(FluentIcons.checkbox_composite),
             title: Text('Inputs'),
@@ -208,7 +209,11 @@ class _MyHomePageState extends State<MyHomePage> {
           ),
           PaneItem(icon: Icon(FluentIcons.cell_phone), title: Text('Mobile')),
           PaneItem(
-            icon: Icon(FluentIcons.more_vertical),
+            icon: Icon(
+              appTheme.displayMode == PaneDisplayMode.top
+                  ? FluentIcons.more
+                  : FluentIcons.more_vertical,
+            ),
             title: Text('Others'),
           ),
         ],

--- a/lib/fluent_ui.dart
+++ b/lib/fluent_ui.dart
@@ -76,6 +76,7 @@ export 'src/controls/form/pickers/time_picker.dart';
 export 'src/styles/motion/page_transitions.dart';
 export 'src/styles/acrylic.dart';
 export 'src/styles/color.dart';
+export 'src/styles/mica.dart';
 export 'src/styles/theme.dart';
 export 'src/styles/typography.dart';
 

--- a/lib/src/controls/navigation/navigation_view/indicators.dart
+++ b/lib/src/controls/navigation/navigation_view/indicators.dart
@@ -138,16 +138,16 @@ class _EndNavigationIndicatorState
         final indicator = IgnorePointer(
           child: Container(
             margin: EdgeInsets.symmetric(
-              vertical: isTop ? 0.0 : 8.0,
+              vertical: isTop ? 0.0 : 10.0,
               horizontal: isTop ? 10.0 : 0.0,
             ),
-            width: isTop ? size.width : 4,
+            width: isTop ? size.width : 6.0,
             height: isTop ? 4 : size.height,
             color: widget.color,
           ),
         );
 
-        // print('at $offset with $size');
+        // debugPrint('at $offset with $size');
 
         if (isTop)
           return Positioned(
@@ -164,7 +164,10 @@ class _EndNavigationIndicatorState
           return Positioned(
             top: offset.dy,
             height: size.height,
-            child: indicator,
+            child: Padding(
+              padding: const EdgeInsets.only(bottom: 4.0),
+              child: indicator,
+            ),
           );
         }
       }),
@@ -260,27 +263,34 @@ class _StickyNavigationIndicatorState
 
     fetch();
 
-    final double kFactor = () {
+    final double hFactor = () {
       if (widget.axis == Axis.horizontal) {
-        return sizes![widget.index].height - 2.0;
+        return sizes![widget.index].height * 0.7;
       } else {
         // 6.0 of padding
         return sizes![widget.index].width - widget.topPadding.horizontal - 6.0;
       }
     }();
 
+    final minOffsetAxis = offsets![minIndex].fromAxis(widget.axis);
+    final maxOffsetAxis = offsets![maxIndex].fromAxis(widget.axis);
+
     if (widget.axis == Axis.horizontal) {
-      this.p1Start = offsets![minIndex].fromAxis(widget.axis) - (kFactor / 2);
-      this.p1End = offsets![maxIndex].fromAxis(widget.axis) - (kFactor / 2);
+      this.p1Start = minOffsetAxis - (hFactor / 2);
+      this.p1End = maxOffsetAxis - (hFactor / 2);
 
-      this.p2Start = offsets![minIndex].fromAxis(widget.axis);
-      this.p2End = offsets![maxIndex].fromAxis(widget.axis);
+      this.p2Start = minOffsetAxis;
+      this.p2End = maxOffsetAxis;
     } else {
-      this.p1Start = offsets![minIndex].fromAxis(widget.axis);
-      this.p1End = offsets![maxIndex].fromAxis(widget.axis);
+      this.p1Start = minOffsetAxis;
+      this.p1End = maxOffsetAxis;
 
-      this.p2Start = offsets![minIndex].fromAxis(widget.axis) + kFactor;
-      this.p2End = offsets![maxIndex].fromAxis(widget.axis) + kFactor;
+      this.p2Start = minOffsetAxis + hFactor;
+      this.p2End = maxOffsetAxis + hFactor;
+    }
+
+    double calcVelocity(double p) {
+      return widget.curve.transform(p) + 0.05;
     }
 
     if (this.p2Start > this.p2End) {
@@ -314,7 +324,7 @@ class _StickyNavigationIndicatorState
         return CustomPaint(
           foregroundPainter: _StickyPainter(
             y: widget.axis == Axis.horizontal
-                ? sizes!.first.height * 0.75
+                ? sizes!.first.height / 1.6
                 : sizes!.first.height - (indicatorPadding / 2),
             padding: widget.axis == Axis.horizontal
                 ? indicatorPadding
@@ -335,10 +345,6 @@ class _StickyNavigationIndicatorState
       },
     );
   }
-
-  double calcVelocity(double p) {
-    return widget.curve.transform(p) + 0.1;
-  }
 }
 
 class _StickyPainter extends CustomPainter {
@@ -355,6 +361,8 @@ class _StickyPainter extends CustomPainter {
 
   final Axis axis;
 
+  final double strokeWidth;
+
   const _StickyPainter({
     this.y = 0,
     required this.padding,
@@ -366,6 +374,7 @@ class _StickyPainter extends CustomPainter {
     required this.p2End,
     required this.color,
     required this.axis,
+    this.strokeWidth = 3,
   });
 
   @override
@@ -374,13 +383,13 @@ class _StickyPainter extends CustomPainter {
       ..color = color
       ..strokeJoin = StrokeJoin.round
       ..strokeCap = StrokeCap.round
-      ..strokeWidth = 2.0;
+      ..strokeWidth = strokeWidth;
     final double first = p1Start + (p1End - p1Start) * p1;
     final double second = p2Start + (p2End - p2Start) * p2;
 
     if (first.isNegative || second.isNegative) return;
 
-    // print('from $first to $second within $size');
+    // debugPrint('from $first to $second within $size');
 
     switch (axis) {
       case Axis.horizontal:

--- a/lib/src/controls/navigation/navigation_view/indicators.dart
+++ b/lib/src/controls/navigation/navigation_view/indicators.dart
@@ -217,7 +217,7 @@ class _StickyNavigationIndicatorState
 
   static const double step = 0.5;
   static const double startDelay = 8;
-  static const double indicatorPadding = 4.0;
+  static const double indicatorPadding = 8.0;
 
   double p1Start = 0.0;
   double p2Start = 0.0;
@@ -262,9 +262,10 @@ class _StickyNavigationIndicatorState
 
     final double kFactor = () {
       if (widget.axis == Axis.horizontal) {
-        return sizes![widget.index].height;
+        return sizes![widget.index].height - 2.0;
       } else {
-        return sizes![widget.index].width - widget.topPadding.horizontal;
+        // 6.0 of padding
+        return sizes![widget.index].width - widget.topPadding.horizontal - 6.0;
       }
     }();
 
@@ -314,10 +315,10 @@ class _StickyNavigationIndicatorState
           foregroundPainter: _StickyPainter(
             y: widget.axis == Axis.horizontal
                 ? sizes!.first.height * 0.75
-                : sizes!.first.height - indicatorPadding,
+                : sizes!.first.height - (indicatorPadding / 2),
             padding: widget.axis == Axis.horizontal
                 ? indicatorPadding
-                : widget.topPadding.left,
+                : widget.topPadding.left + 4.0,
             p1: p1,
             p1Start: p1Start,
             p1End: p1End,

--- a/lib/src/controls/navigation/navigation_view/pane.dart
+++ b/lib/src/controls/navigation/navigation_view/pane.dart
@@ -119,6 +119,7 @@ class PaneItem extends NavigationPaneItem {
       height: !isTop ? 41.0 : null,
       width: isCompact ? _kCompactNavigationPanelWidth : null,
       margin: const EdgeInsets.symmetric(horizontal: 6.0, vertical: 2.0),
+      alignment: Alignment.center,
       child: HoverButton(
         autofocus: autofocus,
         onPressed: onPressed,

--- a/lib/src/controls/navigation/navigation_view/pane.dart
+++ b/lib/src/controls/navigation/navigation_view/pane.dart
@@ -1,7 +1,7 @@
 part of 'view.dart';
 
-const _kCompactNavigationPanelWidth = 40.0;
-const _kOpenNavigationPanelWidth = 320.0;
+const double _kCompactNavigationPanelWidth = 50.0;
+const double _kOpenNavigationPanelWidth = 320.0;
 
 /// You can use the PaneDisplayMode property to configure different
 /// navigation styles, or display modes, for the NavigationView
@@ -114,10 +114,11 @@ class PaneItem extends NavigationPaneItem {
     final String titleText =
         title != null && title is Text ? (title! as Text).data ?? '' : '';
 
-    Widget result = SizedBox(
+    Widget result = Container(
       key: itemKey,
       height: !isTop ? 41.0 : null,
       width: isCompact ? _kCompactNavigationPanelWidth : null,
+      margin: const EdgeInsets.symmetric(horizontal: 6.0, vertical: 2.0),
       child: HoverButton(
         autofocus: autofocus,
         onPressed: onPressed,
@@ -135,8 +136,9 @@ class PaneItem extends NavigationPaneItem {
           Widget child = Flex(
             direction: isTop ? Axis.vertical : Axis.horizontal,
             textDirection: isTop ? ui.TextDirection.ltr : ui.TextDirection.rtl,
-            mainAxisAlignment:
-                isTop ? MainAxisAlignment.center : MainAxisAlignment.end,
+            mainAxisAlignment: isTop || !isOpen
+                ? MainAxisAlignment.center
+                : MainAxisAlignment.end,
             children: [
               if (isOpen) Expanded(child: textResult),
               () {
@@ -148,7 +150,7 @@ class PaneItem extends NavigationPaneItem {
                               ? style.selectedIconColor?.resolve(states)
                               : style.unselectedIconColor?.resolve(states)) ??
                           textStyle?.color,
-                      size: 18.0,
+                      size: 16.0,
                     ),
                     child: this.icon,
                   ),
@@ -166,16 +168,22 @@ class PaneItem extends NavigationPaneItem {
           child = AnimatedContainer(
             duration: style.animationDuration ?? Duration.zero,
             curve: style.animationCurve ?? standartCurve,
-            color: () {
-              final ButtonState<Color?> tileColor = style.tileColor ??
-                  ButtonState.resolveWith((states) {
-                    return ButtonThemeData.uncheckedInputColor(
-                      FluentTheme.of(context),
-                      states,
-                    );
-                  });
-              return tileColor.resolve(states);
-            }(),
+            decoration: BoxDecoration(
+              color: () {
+                final ButtonState<Color?> tileColor = style.tileColor ??
+                    ButtonState.resolveWith((states) {
+                      if (isTop) return Colors.transparent;
+                      return ButtonThemeData.uncheckedInputColor(
+                        FluentTheme.of(context),
+                        states,
+                      );
+                    });
+                return tileColor.resolve(
+                  selected ? {ButtonStates.hovering} : states,
+                );
+              }(),
+              borderRadius: BorderRadius.circular(4.0),
+            ),
             child: child,
           );
           return Semantics(
@@ -273,7 +281,7 @@ class PaneItemHeader extends NavigationPaneItem {
   }
 }
 
-extension ItemsExtension on List<NavigationPaneItem> {
+extension _ItemsExtension on List<NavigationPaneItem> {
   /// Get the all the item offets in this list
   List<Offset> getPaneItemsOffsets(GlobalKey<State<StatefulWidget>> paneKey) {
     return map((e) {

--- a/lib/src/controls/navigation/navigation_view/style.dart
+++ b/lib/src/controls/navigation/navigation_view/style.dart
@@ -131,9 +131,7 @@ class NavigationPaneThemeData with Diagnosticable {
       highlightColor: highlightColor,
       itemHeaderTextStyle: typography.base,
       selectedTextStyle: ButtonState.resolveWith((states) {
-        return states.isDisabled
-            ? disabledTextStyle
-            : typography.body!.copyWith(color: highlightColor);
+        return states.isDisabled ? disabledTextStyle : typography.body;
       }),
       unselectedTextStyle: ButtonState.resolveWith((states) {
         return states.isDisabled ? disabledTextStyle : typography.body!;
@@ -141,8 +139,6 @@ class NavigationPaneThemeData with Diagnosticable {
       cursor: inputMouseCursor,
       labelPadding: EdgeInsets.only(right: 10.0),
       iconPadding: EdgeInsets.symmetric(horizontal: 10.0),
-      selectedIconColor: ButtonState.all(highlightColor),
-      unselectedIconColor: ButtonState.all(inactiveColor),
     );
   }
 

--- a/lib/src/controls/navigation/navigation_view/style.dart
+++ b/lib/src/controls/navigation/navigation_view/style.dart
@@ -140,7 +140,7 @@ class NavigationPaneThemeData with Diagnosticable {
       }),
       cursor: inputMouseCursor,
       labelPadding: EdgeInsets.only(right: 10.0),
-      iconPadding: EdgeInsets.symmetric(horizontal: 10.0, vertical: 10.0),
+      iconPadding: EdgeInsets.symmetric(horizontal: 10.0),
       selectedIconColor: ButtonState.all(highlightColor),
       unselectedIconColor: ButtonState.all(inactiveColor),
     );

--- a/lib/src/controls/navigation/navigation_view/style.dart
+++ b/lib/src/controls/navigation/navigation_view/style.dart
@@ -140,7 +140,7 @@ class NavigationPaneThemeData with Diagnosticable {
       }),
       cursor: inputMouseCursor,
       labelPadding: EdgeInsets.only(right: 10.0),
-      iconPadding: EdgeInsets.symmetric(horizontal: 10.0),
+      iconPadding: EdgeInsets.symmetric(horizontal: 10.0, vertical: 10.0),
       selectedIconColor: ButtonState.all(highlightColor),
       unselectedIconColor: ButtonState.all(inactiveColor),
     );

--- a/lib/src/controls/navigation/navigation_view/view.dart
+++ b/lib/src/controls/navigation/navigation_view/view.dart
@@ -218,7 +218,7 @@ class NavigationViewState extends State<NavigationView> {
               ),
             );
           } else {
-            Widget content = pane.displayMode == PaneDisplayMode.minimal
+            final Widget content = pane.displayMode == PaneDisplayMode.minimal
                 ? widget.content
                 : DecoratedBox(
                     decoration: ShapeDecoration(shape: widget.contentShape),
@@ -489,7 +489,7 @@ class NavigationAppBar with Diagnosticable {
     late Widget widget;
     if (appBar.leading != null) {
       widget = Padding(
-        padding: EdgeInsets.only(left: 12.0),
+        padding: const EdgeInsets.only(left: 12.0),
         child: appBar.leading,
       );
     } else if (appBar.automaticallyImplyLeading && imply) {
@@ -513,7 +513,7 @@ class NavigationAppBar with Diagnosticable {
         )),
         child: Builder(
           builder: (context) => PaneItem(
-            icon: Icon(FluentIcons.back, size: 14.0),
+            icon: const Icon(FluentIcons.back, size: 14.0),
             title: Text(localizations.backButtonTooltip),
           ).build(
             context,
@@ -545,7 +545,6 @@ class _NavigationAppBar extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    assert(debugCheckHasFluentTheme(context));
     final PaneDisplayMode displayMode = this.displayMode ??
         _NavigationBody.maybeOf(context)?.displayMode ??
         PaneDisplayMode.top;
@@ -556,6 +555,7 @@ class _NavigationAppBar extends StatelessWidget {
     );
     final title = () {
       if (appBar.title != null) {
+        assert(debugCheckHasFluentTheme(context));
         final theme = NavigationPaneTheme.of(context);
         return AnimatedPadding(
           duration: theme.animationDuration ?? Duration.zero,

--- a/lib/src/controls/navigation/navigation_view/view.dart
+++ b/lib/src/controls/navigation/navigation_view/view.dart
@@ -515,7 +515,12 @@ class NavigationAppBar with Diagnosticable {
           builder: (context) => PaneItem(
             icon: Icon(FluentIcons.back, size: 14.0),
             title: Text(localizations.backButtonTooltip),
-          ).build(context, false, onPressed),
+          ).build(
+            context,
+            false,
+            onPressed,
+            displayMode: PaneDisplayMode.compact,
+          ),
         ),
       );
     } else {
@@ -551,7 +556,10 @@ class _NavigationAppBar extends StatelessWidget {
     );
     final title = () {
       if (appBar.title != null) {
-        return Padding(
+        final theme = NavigationPaneTheme.of(context);
+        return AnimatedPadding(
+          duration: theme.animationDuration ?? Duration.zero,
+          curve: theme.animationCurve ?? Curves.linear,
           padding: [PaneDisplayMode.minimal, PaneDisplayMode.open]
                   .contains(displayMode)
               ? EdgeInsets.zero

--- a/lib/src/controls/navigation/navigation_view/view.dart
+++ b/lib/src/controls/navigation/navigation_view/view.dart
@@ -252,6 +252,8 @@ class NavigationViewState extends State<NavigationView> {
                 ]);
                 break;
               case PaneDisplayMode.compact:
+                final appBarPadding =
+                    EdgeInsets.only(top: widget.appBar?.height ?? 0.0);
                 paneResult = Stack(children: [
                   Positioned(
                     top: widget.appBar?.height ?? 0.0,
@@ -274,13 +276,21 @@ class NavigationViewState extends State<NavigationView> {
                         ),
                       ),
                     ),
-                  appBar,
-                  Padding(
-                    padding: EdgeInsets.only(top: widget.appBar?.height ?? 0.0),
-                    child: PrimaryScrollController(
-                      controller: scrollController,
-                      child: _compactOverlayOpen
-                          ? Mica(
+                  PrimaryScrollController(
+                    controller: scrollController,
+                    child: _compactOverlayOpen
+                        ? Mica(
+                            elevation: 10.0,
+                            child: Container(
+                              decoration: BoxDecoration(
+                                border: Border.all(
+                                  color: const Color(0xFF6c6c6c),
+                                  width: 0.15,
+                                ),
+                                borderRadius: BorderRadius.circular(8.0),
+                              ),
+                              margin: const EdgeInsets.symmetric(vertical: 1.0),
+                              padding: appBarPadding,
                               child: _OpenNavigationPane(
                                 pane: pane,
                                 paneKey: _panelKey,
@@ -289,8 +299,11 @@ class NavigationViewState extends State<NavigationView> {
                                   setState(() => _compactOverlayOpen = false);
                                 },
                               ),
-                            )
-                          : Mica(
+                            ),
+                          )
+                        : Padding(
+                            padding: appBarPadding,
+                            child: Mica(
                               child: _CompactNavigationPane(
                                 pane: pane,
                                 paneKey: _panelKey,
@@ -300,8 +313,9 @@ class NavigationViewState extends State<NavigationView> {
                                 },
                               ),
                             ),
-                    ),
+                          ),
                   ),
+                  appBar,
                 ]);
                 break;
               case PaneDisplayMode.open:

--- a/lib/src/controls/surfaces/tooltip.dart
+++ b/lib/src/controls/surfaces/tooltip.dart
@@ -653,7 +653,7 @@ class _TooltipPositionDelegate extends SingleChildLayoutDelegate {
 
   @override
   Offset getPositionForChild(Size size, Size childSize) {
-    if (horizontal)
+    if (horizontal) {
       return _horizontalPositionDependentBox(
         size: size,
         childSize: childSize,
@@ -661,13 +661,15 @@ class _TooltipPositionDelegate extends SingleChildLayoutDelegate {
         verticalOffset: verticalOffset,
         preferLeft: preferBelow,
       );
-    return positionDependentBox(
-      size: size,
-      childSize: childSize,
-      target: target,
-      verticalOffset: verticalOffset,
-      preferBelow: preferBelow,
-    );
+    } else {
+      return positionDependentBox(
+        size: size,
+        childSize: childSize,
+        target: target,
+        verticalOffset: verticalOffset,
+        preferBelow: preferBelow,
+      );
+    }
   }
 
   @override

--- a/lib/src/styles/acrylic.dart
+++ b/lib/src/styles/acrylic.dart
@@ -11,7 +11,6 @@ import 'package:fluent_ui/fluent_ui.dart';
 
 const double kBlurAmount = 30.0;
 
-/// Value eyballed from Windows 10 v10.0.19041.928
 const double kDefaultAcrylicAlpha = 0.8;
 
 /// Acrylic is a type of Brush that creates a translucent texture.

--- a/lib/src/styles/mica.dart
+++ b/lib/src/styles/mica.dart
@@ -5,18 +5,20 @@ class Mica extends StatelessWidget {
     Key? key,
     required this.child,
     this.elevation = 0,
+    this.backgroundColor,
   })  : assert(elevation >= 0.0),
         super(key: key);
 
   final Widget child;
   final double elevation;
+  final Color? backgroundColor;
 
   @override
   Widget build(BuildContext context) {
     assert(debugCheckHasFluentTheme(context));
-    final bool isDark = FluentTheme.of(context).brightness == Brightness.dark;
-    final Color boxColor = isDark ? Color(0xFF202020) : Color(0xFFf3f3f3);
-    final Widget result = Container(color: boxColor, child: child);
+    final ThemeData theme = FluentTheme.of(context);
+    final Color boxColor = backgroundColor ?? theme.micaBackgroundColor;
+    final Widget result = ColoredBox(color: boxColor, child: child);
     if (elevation > 0.0)
       return PhysicalModel(
         color: boxColor,

--- a/lib/src/styles/mica.dart
+++ b/lib/src/styles/mica.dart
@@ -1,0 +1,17 @@
+import 'package:fluent_ui/fluent_ui.dart';
+
+class Mica extends StatelessWidget {
+  const Mica({Key? key, required this.child,}) : super(key: key);
+
+  final Widget child;
+
+  @override
+  Widget build(BuildContext context) {
+    assert(debugCheckHasFluentTheme(context));
+    final isDark = FluentTheme.of(context).brightness == Brightness.dark;
+    return Container(
+      color: isDark ? Color(0xFF202020) : Color(0xFFf3f3f3),
+      child: child,
+    );
+  }
+}

--- a/lib/src/styles/mica.dart
+++ b/lib/src/styles/mica.dart
@@ -1,17 +1,28 @@
 import 'package:fluent_ui/fluent_ui.dart';
 
 class Mica extends StatelessWidget {
-  const Mica({Key? key, required this.child,}) : super(key: key);
+  const Mica({
+    Key? key,
+    required this.child,
+    this.elevation = 0,
+  })  : assert(elevation >= 0.0),
+        super(key: key);
 
   final Widget child;
+  final double elevation;
 
   @override
   Widget build(BuildContext context) {
     assert(debugCheckHasFluentTheme(context));
-    final isDark = FluentTheme.of(context).brightness == Brightness.dark;
-    return Container(
-      color: isDark ? Color(0xFF202020) : Color(0xFFf3f3f3),
-      child: child,
-    );
+    final bool isDark = FluentTheme.of(context).brightness == Brightness.dark;
+    final Color boxColor = isDark ? Color(0xFF202020) : Color(0xFFf3f3f3);
+    final Widget result = Container(color: boxColor, child: child);
+    if (elevation > 0.0)
+      return PhysicalModel(
+        color: boxColor,
+        elevation: elevation,
+        child: result,
+      );
+    return result;
   }
 }

--- a/lib/src/styles/mica.dart
+++ b/lib/src/styles/mica.dart
@@ -1,6 +1,20 @@
 import 'package:fluent_ui/fluent_ui.dart';
 
+/// Mica is an opaque, dynamic material that incorporates theme
+/// and desktop wallpaper to paint the background of long-lived
+/// windows such as apps and settings. You can apply Mica to your
+/// application backdrop to delight users and create visual hierarchy,
+/// aiding productivity, by increasing clarity about which window
+/// is in focus.
+/// 
+/// See also:
+/// 
+///  * [Acrylic], a type of Brush that creates a translucent texture
+///  * <https://docs.microsoft.com/en-us/windows/apps/design/style/mica>
 class Mica extends StatelessWidget {
+  /// Creates the Mica material.
+  ///
+  /// [elevation] must be non-negative.
   const Mica({
     Key? key,
     required this.child,
@@ -9,8 +23,19 @@ class Mica extends StatelessWidget {
   })  : assert(elevation >= 0.0),
         super(key: key);
 
+  /// The widget below this widget in the tree.
+  ///
+  /// {@macro flutter.widgets.ProxyWidget.child}
   final Widget child;
+
+  /// The z-coordinate relative to the parent at which to place this physical
+  /// object.
+  ///
+  /// The value is non-negative.
   final double elevation;
+
+  /// The color to paint the background area with. If null,
+  /// [ThemeData.micaBackgroundColor] is used.
   final Color? backgroundColor;
 
   @override

--- a/lib/src/styles/mica.dart
+++ b/lib/src/styles/mica.dart
@@ -6,9 +6,9 @@ import 'package:fluent_ui/fluent_ui.dart';
 /// application backdrop to delight users and create visual hierarchy,
 /// aiding productivity, by increasing clarity about which window
 /// is in focus.
-/// 
+///
 /// See also:
-/// 
+///
 ///  * [Acrylic], a type of Brush that creates a translucent texture
 ///  * <https://docs.microsoft.com/en-us/windows/apps/design/style/mica>
 class Mica extends StatelessWidget {

--- a/lib/src/styles/theme.dart
+++ b/lib/src/styles/theme.dart
@@ -320,8 +320,8 @@ class ThemeData with Diagnosticable {
       'dark': Colors.grey[130],
     }).resolveFromBrightness(brightness);
     scaffoldBackgroundColor ??= AccentColor('normal', {
-      'normal': Colors.white,
-      'dark': Colors.black,
+      'normal': Color(0xFFf9f9f9),
+      'dark': Color(0xFF272727),
     }).resolveFromBrightness(brightness);
     acrylicBackgroundColor ??= AccentColor('normal', {
       'normal': Color.fromARGB(204, 255, 255, 255),

--- a/lib/src/styles/theme.dart
+++ b/lib/src/styles/theme.dart
@@ -168,6 +168,7 @@ class ThemeData with Diagnosticable {
   final Color shadowColor;
   final Color scaffoldBackgroundColor;
   final Color acrylicBackgroundColor;
+  final Color micaBackgroundColor;
 
   final Duration fasterAnimationDuration;
   final Duration fastAnimationDuration;
@@ -223,6 +224,7 @@ class ThemeData with Diagnosticable {
     required this.visualDensity,
     required this.scaffoldBackgroundColor,
     required this.acrylicBackgroundColor,
+    required this.micaBackgroundColor,
     required this.buttonTheme,
     required this.checkboxTheme,
     required this.chipTheme,
@@ -266,6 +268,7 @@ class ThemeData with Diagnosticable {
     Color? disabledColor,
     Color? scaffoldBackgroundColor,
     Color? acrylicBackgroundColor,
+    Color? micaBackgroundColor,
     Color? shadowColor,
     ButtonState<MouseCursor>? inputMouseCursor,
     Duration? fasterAnimationDuration,
@@ -295,6 +298,9 @@ class ThemeData with Diagnosticable {
     SnackbarThemeData? snackbarTheme,
   }) {
     brightness ??= Brightness.light;
+
+    final bool isLight = brightness == Brightness.light;
+
     visualDensity ??= VisualDensity.adaptivePlatformDensity;
     fasterAnimationDuration ??= Duration(milliseconds: 90);
     fastAnimationDuration ??= Duration(milliseconds: 150);
@@ -303,30 +309,15 @@ class ThemeData with Diagnosticable {
     animationCurve ??= standartCurve;
     accentColor ??= Colors.blue;
     activeColor ??= Colors.white;
-    inactiveColor ??= AccentColor('normal', {
-      'normal': Colors.black,
-      'dark': Colors.white,
-    }).resolveFromBrightness(brightness);
-    inactiveBackgroundColor ??= AccentColor('normal', {
-      'normal': Color(0xFFd6d6d6),
-      'dark': Color(0xFF292929),
-    }).resolveFromBrightness(brightness);
-    disabledColor ??= AccentColor('normal', {
-      'normal': const Color(0xFF838383),
-      'dark': Colors.grey[80].withOpacity(0.6)
-    });
-    shadowColor ??= AccentColor('normal', {
-      'normal': Colors.black,
-      'dark': Colors.grey[130],
-    }).resolveFromBrightness(brightness);
-    scaffoldBackgroundColor ??= AccentColor('normal', {
-      'normal': Color(0xFFf9f9f9),
-      'dark': Color(0xFF272727),
-    }).resolveFromBrightness(brightness);
-    acrylicBackgroundColor ??= AccentColor('normal', {
-      'normal': Color.fromARGB(204, 255, 255, 255),
-      'dark': Color(0x7F1e1e1e),
-    }).resolveFromBrightness(brightness);
+    inactiveColor ??= isLight ? Colors.black : Colors.white;
+    inactiveBackgroundColor ??= isLight ? Color(0xFFd6d6d6) : Color(0xFF292929);
+    disabledColor ??=
+        isLight ? const Color(0xFF838383) : Colors.grey[80].withOpacity(0.6);
+    shadowColor ??= isLight ? Colors.black : Colors.grey[130];
+    scaffoldBackgroundColor ??= isLight ? Color(0xFFf9f9f9) : Color(0xFF272727);
+    acrylicBackgroundColor ??=
+        isLight ? Color.fromARGB(204, 255, 255, 255) : Color(0x7F1e1e1e);
+    micaBackgroundColor ??= isLight ? Color(0xFFf3f3f3) : Color(0xFF202020);
     typography = Typography.standard(brightness: brightness)
         .merge(typography)
         .apply(fontFamily: fontFamily);
@@ -346,9 +337,9 @@ class ThemeData with Diagnosticable {
     chipTheme ??= const ChipThemeData();
     toggleButtonTheme ??= const ToggleButtonThemeData();
     toggleSwitchTheme ??= const ToggleSwitchThemeData();
-    iconTheme ??= brightness.isDark
-        ? const IconThemeData(color: Colors.white, size: 18.0)
-        : const IconThemeData(color: Colors.black, size: 18.0);
+    iconTheme ??= isLight
+        ? const IconThemeData(color: Colors.black, size: 18.0)
+        : const IconThemeData(color: Colors.white, size: 18.0);
     splitButtonTheme ??= const SplitButtonThemeData();
     dialogTheme ??= const ContentDialogThemeData();
     tooltipTheme ??= const TooltipThemeData();
@@ -356,7 +347,7 @@ class ThemeData with Diagnosticable {
     navigationPaneTheme ??= NavigationPaneThemeData.standard(
       animationCurve: animationCurve,
       animationDuration: fastAnimationDuration,
-      backgroundColor: acrylicBackgroundColor,
+      backgroundColor: micaBackgroundColor,
       disabledColor: disabledColor,
       highlightColor: accentColor,
       inputMouseCursor: inputMouseCursor,
@@ -386,6 +377,7 @@ class ThemeData with Diagnosticable {
       disabledColor: disabledColor,
       scaffoldBackgroundColor: scaffoldBackgroundColor,
       acrylicBackgroundColor: acrylicBackgroundColor,
+      micaBackgroundColor: micaBackgroundColor,
       shadowColor: shadowColor,
       bottomNavigationTheme: bottomNavigationTheme,
       buttonTheme: buttonTheme,
@@ -427,6 +419,8 @@ class ThemeData with Diagnosticable {
           Color.lerp(a.scaffoldBackgroundColor, b.scaffoldBackgroundColor, t)!,
       acrylicBackgroundColor:
           Color.lerp(a.acrylicBackgroundColor, b.acrylicBackgroundColor, t)!,
+      micaBackgroundColor:
+          Color.lerp(a.micaBackgroundColor, b.micaBackgroundColor, t)!,
       shadowColor: Color.lerp(a.shadowColor, b.shadowColor, t)!,
       fasterAnimationDuration:
           lerpDuration(a.fasterAnimationDuration, b.fasterAnimationDuration, t),
@@ -483,6 +477,7 @@ class ThemeData with Diagnosticable {
     Color? disabledColor,
     Color? scaffoldBackgroundColor,
     Color? acrylicBackgroundColor,
+    Color? micaBackgroundColor,
     Color? shadowColor,
     Duration? fasterAnimationDuration,
     Duration? fastAnimationDuration,
@@ -526,6 +521,7 @@ class ThemeData with Diagnosticable {
           scaffoldBackgroundColor ?? this.scaffoldBackgroundColor,
       acrylicBackgroundColor:
           acrylicBackgroundColor ?? this.acrylicBackgroundColor,
+      micaBackgroundColor: micaBackgroundColor ?? this.micaBackgroundColor,
       fasterAnimationDuration:
           fasterAnimationDuration ?? this.fasterAnimationDuration,
       fastAnimationDuration:
@@ -563,20 +559,16 @@ class ThemeData with Diagnosticable {
   @override
   void debugFillProperties(DiagnosticPropertiesBuilder properties) {
     super.debugFillProperties(properties);
-    properties.add(ColorProperty('accentColor', accentColor));
-    properties.add(ColorProperty('activeColor', activeColor));
-    properties.add(ColorProperty('inactiveColor', inactiveColor));
-    properties.add(
-      ColorProperty('inactiveBackgroundColor', inactiveBackgroundColor),
-    );
-    properties.add(ColorProperty('disabledColor', disabledColor));
-    properties.add(
-      ColorProperty('scaffoldBackgroundColor', scaffoldBackgroundColor),
-    );
-    properties.add(ColorProperty(
-      'acrylicBackgroundColor',
-      acrylicBackgroundColor,
-    ));
+    properties
+      ..add(ColorProperty('accentColor', accentColor))
+      ..add(ColorProperty('activeColor', activeColor))
+      ..add(ColorProperty('inactiveColor', inactiveColor))
+      ..add(ColorProperty('inactiveBackgroundColor', inactiveBackgroundColor))
+      ..add(ColorProperty('disabledColor', disabledColor))
+      ..add(ColorProperty('shadowColor', shadowColor))
+      ..add(ColorProperty('scaffoldBackgroundColor', scaffoldBackgroundColor))
+      ..add(ColorProperty('acrylicBackgroundColor', acrylicBackgroundColor))
+      ..add(ColorProperty('micaBackgroundColor', micaBackgroundColor));
     properties.add(EnumProperty('brightness', brightness));
     properties.add(DiagnosticsProperty<Duration>(
       'slowAnimationDuration',

--- a/lib/src/utils.dart
+++ b/lib/src/utils.dart
@@ -54,8 +54,9 @@ bool debugCheckHasFluentLocalizations(BuildContext context) {
           'to be provided by a Localizations widget ancestor.',
         ),
         ErrorDescription(
-            'The material library uses Localizations to generate messages, '
-            'labels, and abbreviations.'),
+          'The fluent library uses Localizations to generate messages, '
+          'labels, and abbreviations.',
+        ),
         ErrorHint(
           'To introduce a FluentLocalizations, either use a '
           'FluentApp at the root of your application to include them '


### PR DESCRIPTION
<!-- Add a description of what this PR is changing or adding, and why. Consider mentioning issues -->

This PR reworks the NavigationView to match the latest looking from Windows 10:

- The minimal pane mode is no longer an overlay
- The pane and appbar background color is handled by the `NavigationView` itself.
- Indicators were also updated to match the new design, but they will likely need some rework on the future

It also implements:

- `Mica`, the new Windows 11 material. This is meant to be updated on the future. The current version is just a quick preview
- `Tooltip.displayHorizontally`. If true, the tooltip is displayed horizontally. 

See #50 

## Pre-launch Checklist

<!-- Mark all that applyes -->

- [x] I have run `dartfmt` on all changed files <!-- REQUIRED --> 
- [x] I have updated `CHANGELOG.md` with my changes <!-- REQUIRED --> 
- [ ] I have run "optimize/organize imports" on all changed files
- [x] I have addressed all analyzer warnings as best I could
- [x] I have added/updated relevant documentation
- [ ] I have run `flutter pub publish --dry-run` and addressed any warnings