### PR TITLE
Add borderRadius and shape field to the Mica widget

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@ Date format: DD/MM/YYYY
 
 ## [3.5.1] - [DD/MM/YYYY]
 
+- Add the `borderRadius` and `shape` attributes to the `Mica` widget
 - Implement `DropDownButton` ([#85](https://github.com/bdlukaa/fluent_ui/issues/85))
 
 ## [3.5.0] - Flutter 2.8 - [09/12/2021]

--- a/lib/src/styles/mica.dart
+++ b/lib/src/styles/mica.dart
@@ -20,6 +20,8 @@ class Mica extends StatelessWidget {
     required this.child,
     this.elevation = 0,
     this.backgroundColor,
+    this.borderRadius,
+    this.shape = BoxShape.rectangle,
   })  : assert(elevation >= 0.0),
         super(key: key);
 
@@ -38,17 +40,33 @@ class Mica extends StatelessWidget {
   /// [ThemeData.micaBackgroundColor] is used.
   final Color? backgroundColor;
 
+  /// The border radius applied to the area.
+  final BorderRadius? borderRadius;
+
+  /// The box shape applied to the area.
+  /// By default, the value of shape is [BoxShape.rectangle]
+  final BoxShape shape;
+
   @override
   Widget build(BuildContext context) {
     assert(debugCheckHasFluentTheme(context));
     final ThemeData theme = FluentTheme.of(context);
     final Color boxColor = backgroundColor ?? theme.micaBackgroundColor;
-    final Widget result = ColoredBox(color: boxColor, child: child);
+    final Widget result = Container(
+      child: child,
+      decoration: BoxDecoration(
+        color: boxColor,
+        borderRadius: borderRadius,
+        shape: shape,
+      ),
+    );
     if (elevation > 0.0) {
       return PhysicalModel(
         color: boxColor,
         elevation: elevation,
         child: result,
+        borderRadius: borderRadius,
+        shape: shape,
       );
     }
     return result;


### PR DESCRIPTION
<!-- Add a description of what this PR is changing or adding, and why. Consider mentioning issues -->

Add borderRadius and shape field to the Mica widget

![image](https://user-images.githubusercontent.com/8223773/145980466-c028dace-95c2-496a-b03d-2e1674fe1522.png)


## Pre-launch Checklist

<!-- Mark all that applyes -->

- [x] I have run `dartfmt` on all changed files <!-- REQUIRED --> 
- [x] I have updated `CHANGELOG.md` with my changes <!-- REQUIRED --> 
- [x] I have run "optimize/organize imports" on all changed files
- [x] I have addressed all analyzer warnings as best I could
- [x] I have added/updated relevant documentation
- [x] I have run `flutter pub publish --dry-run` and addressed any warnings