### PR TITLE
Fix sliders (#116)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@ Date format: DD/MM/YYYY
 
 ## [3.5.3] - [DD/MM/YYYY]
 
-- Fix sliders ([#116](https://github.com/bdlukaa/fluent_ui/issues/116))
+- Fix `Slider` and `RatingBar` ([#116](https://github.com/bdlukaa/fluent_ui/issues/116))
 
 ## [3.5.2] - [17/12/2021]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 Date format: DD/MM/YYYY
 
+## [3.5.3] - [DD/MM/YYYY]
+
+- Fix sliders ([#116](https://github.com/bdlukaa/fluent_ui/issues/116))
+
 ## [3.5.2] - [17/12/2021]
 
 - **BREAKING** Removed `ThemeData.inputMouseCursor`

--- a/lib/src/controls/inputs/rating.dart
+++ b/lib/src/controls/inputs/rating.dart
@@ -235,7 +235,7 @@ class _RatingBarState extends State<RatingBar> {
               _handleUpdate(d.localPosition.dx, size),
           child: FocusBorder(
             focused: widget.onChanged != null && _showFocusHighlight,
-            useStackApproach: false,
+            useStackApproach: true,
             child: TweenAnimationBuilder<double>(
               builder: (context, value, child) {
                 double v = value + 1;

--- a/lib/src/controls/inputs/slider.dart
+++ b/lib/src/controls/inputs/slider.dart
@@ -200,7 +200,7 @@ class _SliderState extends m.State<Slider> {
       onShowFocusHighlight: (v) => setState(() => _showFocusHighlight = v),
       child: FocusBorder(
         focused: _showFocusHighlight && (_focusNode.hasPrimaryFocus),
-        useStackApproach: false,
+        useStackApproach: true,
         child: child,
       ),
     );


### PR DESCRIPTION
<!-- Add a description of what this PR is changing or adding, and why. Consider mentioning issues -->

Fixes #116 

## Pre-launch Checklist

<!-- Mark all that applyes -->

- [x] ~~I have run `dartfmt` on all changed files~~ <!-- REQUIRED -->
- [x] I have updated `CHANGELOG.md` with my changes <!-- REQUIRED -->
- [x] ~~I have run "optimize/organize imports" on all changed files~~
- [x] ~~I have addressed all analyzer warnings as best I could~~
- [x] ~~I have added/updated relevant documentation~~
- [x] ~~I have run `flutter pub publish --dry-run` and addressed any warnings~~


As the documentation says:

```dart
  /// Whether wrapping the widget in a stack is the approach
  /// that is goind to be used to render the box. If false,
  /// a transparent border is created around the [child] as a
  /// placeholder, and the real border is only displayed when
  /// [focused] is true.
  ///
  /// Using the stack approach is recommended for widgets that
  /// have a defined size (height and width). You should not use
  /// it with widgets that require dragging.
  ///
  /// This property is disabled by default on the following widgets:
  ///   - [Slider]
```

This property should be true, and, when this is true, the sliders work (and when we focus with keyboard, no layout move are visible)