### PR TITLE
Fix ComboBox borders

### DIFF
--- a/lib/src/controls/form/combo_box.dart
+++ b/lib/src/controls/form/combo_box.dart
@@ -297,6 +297,7 @@ class _ComboboxMenuState<T> extends State<_ComboboxMenu<T>> {
     return FadeTransition(
       opacity: _fadeOpacity,
       child: Acrylic(
+        shape: const RoundedRectangleBorder(borderRadius: BorderRadius.all(Radius.circular(6.0))),
         elevation: route.elevation.toDouble(),
         child: CustomPaint(
           painter: _ComboboxMenuPainter(


### PR DESCRIPTION
ComboBox borders are not actually rounded (although black rounded borders are drawn, the Acrylic widget had no border radius)

<!-- Add a description of what this PR is changing or adding, and why. Consider mentioning issues -->

## Pre-launch Checklist

<!-- Mark all that applyes -->

- [ ] I have run `dartfmt` on all changed files <!-- REQUIRED --> 
- [ ] I have updated `CHANGELOG.md` with my changes <!-- REQUIRED --> 
- [ ] I have run "optimize/organize imports" on all changed files
- [ ] I have addressed all analyzer warnings as best I could
- [ ] I have added/updated relevant documentation
- [ ] I have run `flutter pub publish --dry-run` and addressed any warnings