### PR TITLE
Fix IconButton hover/press color + add button mode

### DIFF
--- a/lib/src/controls/inputs/buttons/icon_button.dart
+++ b/lib/src/controls/inputs/buttons/icon_button.dart
@@ -1,5 +1,9 @@
 import 'package:fluent_ui/fluent_ui.dart';
 
+enum IconButtonMode {
+  TINY, SMALL, LARGE
+}
+
 class IconButton extends BaseButton {
   const IconButton({
     Key? key,
@@ -9,6 +13,7 @@ class IconButton extends BaseButton {
     FocusNode? focusNode,
     bool autofocus = false,
     ButtonStyle? style,
+    this.iconButtonMode,
   }) : super(
           key: key,
           child: icon,
@@ -19,21 +24,23 @@ class IconButton extends BaseButton {
           style: style,
         );
 
+  final IconButtonMode? iconButtonMode;
+
   @override
   ButtonStyle defaultStyleOf(BuildContext context) {
     assert(debugCheckHasFluentTheme(context));
     final theme = FluentTheme.of(context);
-    final isSmall = SmallIconButton.of(context) != null;
+    final isIconSmall = iconButtonMode == IconButtonMode.TINY;
+    final isSmall = iconButtonMode != null ? iconButtonMode != IconButtonMode.LARGE : SmallIconButton.of(context) != null;
     return ButtonStyle(
-      iconSize: ButtonState.all(isSmall ? 12.0 : null),
+      iconSize: ButtonState.all(isIconSmall ? 12.0 : null),
       padding: ButtonState.all(isSmall
           ? const EdgeInsets.symmetric(horizontal: 8.0, vertical: 4.0)
           : const EdgeInsets.all(8.0)),
       backgroundColor: ButtonState.resolveWith((states) {
         return states.isDisabled
             ? ButtonThemeData.buttonColor(theme.brightness, states)
-            : ButtonThemeData.uncheckedInputColor(theme, states)
-                .withOpacity(states.isNone ? 0 : 0.2);
+            : ButtonThemeData.uncheckedInputColor(theme, states);
       }),
       foregroundColor: ButtonState.resolveWith((states) {
         if (states.isDisabled) return theme.disabledColor;

--- a/lib/src/controls/inputs/buttons/icon_button.dart
+++ b/lib/src/controls/inputs/buttons/icon_button.dart
@@ -30,8 +30,8 @@ class IconButton extends BaseButton {
   ButtonStyle defaultStyleOf(BuildContext context) {
     assert(debugCheckHasFluentTheme(context));
     final theme = FluentTheme.of(context);
-    final isIconSmall = iconButtonMode == IconButtonMode.TINY;
-    final isSmall = iconButtonMode != null ? iconButtonMode != IconButtonMode.LARGE : SmallIconButton.of(context) != null;
+    final isIconSmall = iconButtonMode == IconButtonMode.tiny;
+    final isSmall = iconButtonMode != null ? iconButtonMode != IconButtonMode.large: SmallIconButton.of(context) != null;
     return ButtonStyle(
       iconSize: ButtonState.all(isIconSmall ? 12.0 : null),
       padding: ButtonState.all(isSmall

--- a/lib/src/controls/inputs/buttons/icon_button.dart
+++ b/lib/src/controls/inputs/buttons/icon_button.dart
@@ -1,7 +1,7 @@
 import 'package:fluent_ui/fluent_ui.dart';
 
 enum IconButtonMode {
-  TINY, SMALL, LARGE
+  tiny, small, large
 }
 
 class IconButton extends BaseButton {


### PR DESCRIPTION
For some reason you used to set a fixed opacity for the IconButton widget

I also added an IconButtonMode enum:

TINY: small icon and small button
SMALL: small button
LARGE: large button

<!-- Add a description of what this PR is changing or adding, and why. Consider mentioning issues -->

## Pre-launch Checklist

<!-- Mark all that applyes -->

- [ ] I have run `dartfmt` on all changed files <!-- REQUIRED --> 
- [ ] I have updated `CHANGELOG.md` with my changes <!-- REQUIRED --> 
- [ ] I have run "optimize/organize imports" on all changed files
- [ ] I have addressed all analyzer warnings as best I could
- [ ] I have added/updated relevant documentation
- [ ] I have run `flutter pub publish --dry-run` and addressed any warnings