### PR TITLE
Add materialTheme field to ThemeData

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 Date format: DD/MM/YYYY
 
+## [unreleased] - TBD - [04/02/2022]
+
+- Ability to specify custom material theme ([#152](https://github.com/bdlukaa/fluent_ui/issues/152))
+
 ## [3.8.0] - Flutter Favorite - [03/02/2022]
 
 - Tests ([#142](https://github.com/bdlukaa/fluent_ui/pull/142))

--- a/lib/src/app.dart
+++ b/lib/src/app.dart
@@ -406,7 +406,8 @@ class _FluentAppState extends State<FluentApp> {
   Widget _builder(BuildContext context, Widget? child) {
     final themeData = theme(context);
     return m.Theme(
-      data: m.ThemeData(brightness: themeData.brightness),
+      data: themeData.materialTheme ??
+          m.ThemeData(brightness: themeData.brightness),
       child: AnimatedFluentTheme(
         curve: themeData.animationCurve,
         data: themeData,

--- a/lib/src/styles/theme.dart
+++ b/lib/src/styles/theme.dart
@@ -1,6 +1,6 @@
 import 'package:fluent_ui/fluent_ui.dart';
-
 import 'package:flutter/foundation.dart';
+import 'package:flutter/material.dart' as m;
 import 'package:flutter/rendering.dart';
 
 class FluentTheme extends StatelessWidget {
@@ -204,6 +204,8 @@ class ThemeData with Diagnosticable {
 
   final ButtonThemeData buttonTheme;
 
+  final m.ThemeData? materialTheme;
+
   const ThemeData.raw({
     required this.typography,
     required this.accentColor,
@@ -245,6 +247,7 @@ class ThemeData with Diagnosticable {
     required this.snackbarTheme,
     required this.pillButtonBarTheme,
     required this.bottomSheetTheme,
+    required this.materialTheme,
   });
 
   static ThemeData light() {
@@ -297,6 +300,7 @@ class ThemeData with Diagnosticable {
     FocusThemeData? focusTheme,
     ScrollbarThemeData? scrollbarTheme,
     SnackbarThemeData? snackbarTheme,
+    m.ThemeData? materialTheme,
   }) {
     brightness ??= Brightness.light;
 
@@ -411,6 +415,7 @@ class ThemeData with Diagnosticable {
       snackbarTheme: snackbarTheme,
       pillButtonBarTheme: pillButtonBarTheme,
       bottomSheetTheme: bottomSheetTheme,
+      materialTheme: materialTheme,
     );
   }
 
@@ -475,6 +480,7 @@ class ThemeData with Diagnosticable {
           a.pillButtonBarTheme, b.pillButtonBarTheme, t),
       bottomSheetTheme:
           BottomSheetThemeData.lerp(a.bottomSheetTheme, b.bottomSheetTheme, t),
+      materialTheme: t < 0.5 ? a.materialTheme : b.materialTheme,
     );
   }
 
@@ -519,6 +525,7 @@ class ThemeData with Diagnosticable {
     FocusThemeData? focusTheme,
     ScrollbarThemeData? scrollbarTheme,
     SnackbarThemeData? snackbarTheme,
+    m.ThemeData? materialTheme,
   }) {
     return ThemeData.raw(
       brightness: brightness ?? this.brightness,
@@ -569,6 +576,7 @@ class ThemeData with Diagnosticable {
       toggleSwitchTheme: this.toggleSwitchTheme.merge(toggleSwitchTheme),
       tooltipTheme: this.tooltipTheme.merge(tooltipTheme),
       snackbarTheme: this.snackbarTheme.merge(snackbarTheme),
+      materialTheme: materialTheme ?? this.materialTheme,
     );
   }
 


### PR DESCRIPTION
Commit 2e94931 automatically adds a Material theme to the widget tree. However, this overrides any custom Material theme that might have been specified above the widget tree. Many apps might still use a mix of material and fluent_ui widgets. Now that a Material theme is always automatically added, allow a custom Material theme to be specified as part of `fluent_ui.ThemeData` with the optional `materialTheme` field. 

If this field is not specified, the behavior is the same as before (it will generate a Material theme with the appropriate brightness based on the brightness of the fluent_ui theme).

Fixes #152.

## Pre-launch Checklist

- [X] I have run `dartfmt` on all changed files <!-- REQUIRED --> 
- [X] I have updated `CHANGELOG.md` with my changes <!-- REQUIRED --> 
- [X] I have run "optimize/organize imports" on all changed files
- [X] I have addressed all analyzer warnings as best I could
- [ ] I have added/updated relevant documentation
- [X] I have run `flutter pub publish --dry-run` and addressed any warnings
