### PR TITLE
Remove an unused parameter from Typography.apply

### DIFF
--- a/lib/src/styles/typography.dart
+++ b/lib/src/styles/typography.dart
@@ -140,7 +140,6 @@ class Typography with Diagnosticable {
     double fontSizeFactor = 1.0,
     double fontSizeDelta = 0.0,
     Color? displayColor,
-    Color? bodyColor,
     TextDecoration? decoration,
     Color? decorationColor,
     TextDecorationStyle? decorationStyle,


### PR DESCRIPTION
<!-- Add a description of what this PR is changing or adding, and why. Consider mentioning issues -->

Remove `bodyColor` from `Typography.apply`'s parameters since it doesn't have any relevance with `Typography` nor any effect on `Typography.apply` and may lead the confusion with `displayColor`.

## Pre-launch Checklist

<!-- Mark all that applyes -->

- [x] I have run `dartfmt` on all changed files <!-- REQUIRED --> 
- [ ] I have updated `CHANGELOG.md` with my changes <!-- REQUIRED --> 
- [ ] I have run "optimize/organize imports" on all changed files
- [x] I have addressed all analyzer warnings as best I could
- [ ] I have added/updated relevant documentation
- [x] I have run `flutter pub publish --dry-run` and addressed any warnings