### PR TITLE
Fix linux build

### DIFF
--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -32,8 +32,6 @@ bool get isDesktop {
 void main() async {
   WidgetsFlutterBinding.ensureInitialized();
 
-  SystemTheme.accentInstance;
-
   setPathUrlStrategy();
 
   if (isDesktop) {

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -16,7 +16,7 @@ dependencies:
   provider: ^6.0.1
   system_theme: ^1.0.1
   bitsdojo_window: ^0.1.1+1
-  flutter_acrylic: ^0.1.0
+  flutter_acrylic: ^1.0.0+1
   url_strategy: ^0.2.0
   url_launcher: ^6.0.15
   clipboard: ^0.1.3


### PR DESCRIPTION
With this fix, the app can be build.

![image](https://user-images.githubusercontent.com/8223773/154810388-115c05e4-bb5e-4151-9d15-8f594e89b2da.png)

But there is some bug on the example app for linux:

- Windows cross are shown
- The app is transparent some seconds after start (not tested in release, only in debug)