### PR TITLE
fix opened pane opacity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ Date format: DD/MM/YYYY
 - Ensure `NavigationAppBar.actions` are rendered on the top of the other widgets ([#177](https://github.com/bdlukaa/fluent_ui/issues/177))
 - All Form widgets now have the same height by default
 - Only show one scrollbar on `ComboBox` overlay
+- Fix opened pane opacity
 
 ## [3.9.0] - Fidelity - [10/02/2022]
 

--- a/lib/src/controls/navigation/navigation_view/view.dart
+++ b/lib/src/controls/navigation/navigation_view/view.dart
@@ -340,7 +340,7 @@ class NavigationViewState extends State<NavigationView> {
                         );
                       } else if (_compactOverlayOpen) {
                         return Mica(
-                          backgroundColor: theme.backgroundColor,
+                          backgroundColor: theme.backgroundColor?.withAlpha(255),
                           elevation: 10.0,
                           child: Container(
                             decoration: BoxDecoration(
@@ -435,7 +435,7 @@ class NavigationViewState extends State<NavigationView> {
                     child: PrimaryScrollController(
                       controller: scrollController,
                       child: Mica(
-                        backgroundColor: theme.backgroundColor,
+                        backgroundColor: theme.backgroundColor?.withAlpha(255),
                         elevation: 10.0,
                         child: Container(
                           decoration: BoxDecoration(


### PR DESCRIPTION
When using micaBackgroundColor transparency to display window effects, the compact menu becomes unreadable. This fix ignores the transparency settings for the background.

before
![a](https://user-images.githubusercontent.com/39363044/155052187-15912367-3de0-457e-848e-f7c8cbad5210.png)

after
![b](https://user-images.githubusercontent.com/39363044/155052209-3d42cdce-9f92-44ad-b8aa-43c61bbf4031.png)

## Pre-launch Checklist

- [x] I have run `dartfmt` on all changed files <!-- REQUIRED --> 
- [x] I have updated `CHANGELOG.md` with my changes <!-- REQUIRED --> 
- [ ] I have run "optimize/organize imports" on all changed files
- [ ] I have addressed all analyzer warnings as best I could
- [ ] I have added/updated relevant documentation
- [ ] I have run `flutter pub publish --dry-run` and addressed any warnings