### PR TITLE
Fix disabled color foreground on FilledButton

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 Date format: DD/MM/YYYY
 
+## [3.9.2] [dd/mm/yyyy]
+
+- Fix: [#207](https://github.com/bdlukaa/fluent_ui/pull/207) FilledButton disabled foreground
+
 ## [3.9.1] - Input Update - [25/02/2022]
 
 - `TextBox` updates: ([#179](https://github.com/bdlukaa/fluent_ui/pull/179))

--- a/example/lib/screens/inputs.dart
+++ b/example/lib/screens/inputs.dart
@@ -139,6 +139,11 @@ class _InputsPageState extends State<InputsPage> {
                   },
           ),
           spacer,
+          FilledButton(
+            child: const Text('Filled Button'),
+            onPressed: disabled ? null : () => print('pressed filled button'),
+          ),
+          spacer,
           IconButton(
             icon: const Icon(FluentIcons.add),
             onPressed: disabled ? null : () => print('pressed icon button'),

--- a/lib/src/controls/inputs/buttons/filled_button.dart
+++ b/lib/src/controls/inputs/buttons/filled_button.dart
@@ -36,14 +36,20 @@ class FilledButton extends Button {
     return ButtonStyle(backgroundColor: ButtonState.resolveWith((states) {
       return backgroundColor(theme, states);
     }), foregroundColor: ButtonState.resolveWith((states) {
-      if (states.isDisabled) return theme.disabledColor;
+      if (states.isDisabled) {
+        return theme.brightness.isDark ? theme.disabledColor : Colors.white;
+      }
       return backgroundColor(theme, states).basedOnLuminance();
     }));
   }
 
   static Color backgroundColor(ThemeData theme, Set<ButtonStates> states) {
     if (states.isDisabled) {
-      return ButtonThemeData.buttonColor(theme.brightness, states);
+      if (theme.brightness.isDark) {
+        return const Color(0xFF434343);
+      } else {
+        return const Color(0xFFBFBFBF);
+      }
     } else if (states.isPressing) {
       if (theme.brightness.isDark) {
         return theme.accentColor.darker;

--- a/lib/src/controls/inputs/buttons/filled_button.dart
+++ b/lib/src/controls/inputs/buttons/filled_button.dart
@@ -36,6 +36,7 @@ class FilledButton extends Button {
     return ButtonStyle(backgroundColor: ButtonState.resolveWith((states) {
       return backgroundColor(theme, states);
     }), foregroundColor: ButtonState.resolveWith((states) {
+      if (states.isDisabled) return theme.disabledColor;
       return backgroundColor(theme, states).basedOnLuminance();
     }));
   }


### PR DESCRIPTION
<!-- Add a description of what this PR is changing or adding, and why. Consider mentioning issues -->

## Pre-launch Checklist

<!-- Mark all that applyes -->

- [ ] I have run `dartfmt` on all changed files <!-- REQUIRED --> 
- [ ] I have updated `CHANGELOG.md` with my changes <!-- REQUIRED --> 
- [ ] I have run "optimize/organize imports" on all changed files
- [ ] I have addressed all analyzer warnings as best I could
- [ ] I have added/updated relevant documentation
- [ ] I have run `flutter pub publish --dry-run` and addressed any warnings

According to the normal button : https://github.com/bdlukaa/fluent_ui/blob/master/lib/src/controls/inputs/buttons/button.dart#L62

![image](https://user-images.githubusercontent.com/8223773/156565220-4c3fbb2d-66c0-4fa4-a169-f34ed0e9c68c.png)
