### PR TITLE
Add `useInheritedMediaQuery` to `FluentApp`

### DIFF
--- a/lib/src/app.dart
+++ b/lib/src/app.dart
@@ -71,6 +71,7 @@ class FluentApp extends StatefulWidget {
     this.themeMode,
     this.restorationScopeId,
     this.scrollBehavior = const FluentScrollBehavior(),
+    this.useInheritedMediaQuery = false,
   })  : routeInformationProvider = null,
         routeInformationParser = null,
         routerDelegate = null,
@@ -105,6 +106,7 @@ class FluentApp extends StatefulWidget {
     this.actions,
     this.restorationScopeId,
     this.scrollBehavior = const FluentScrollBehavior(),
+    this.useInheritedMediaQuery = false,
   })  : assert(routeInformationParser != null && routerDelegate != null,
             'The routeInformationParser and routerDelegate cannot be null.'),
         assert(supportedLocales.isNotEmpty),
@@ -344,6 +346,14 @@ class FluentApp extends StatefulWidget {
 
   static bool debugAllowBannerOverride = true;
 
+  /// {@template flutter.widgets.widgetsApp.useInheritedMediaQuery}
+  /// If true, an inherited MediaQuery will be used. If one is not available,
+  /// or this is false, one will be built from the window.
+  ///
+  /// Cannot be null, defaults to false.
+  /// {@endtemplate}
+  final bool useInheritedMediaQuery;
+
   @override
   _FluentAppState createState() => _FluentAppState();
 }
@@ -469,6 +479,7 @@ class _FluentAppState extends State<FluentApp> {
         actions: widget.actions,
         restorationScopeId: widget.restorationScopeId,
         localizationsDelegates: _localizationsDelegates,
+        useInheritedMediaQuery: widget.useInheritedMediaQuery
       );
     }
 
@@ -499,6 +510,7 @@ class _FluentAppState extends State<FluentApp> {
       actions: widget.actions,
       restorationScopeId: widget.restorationScopeId,
       localizationsDelegates: _localizationsDelegates,
+      useInheritedMediaQuery: widget.useInheritedMediaQuery,
       pageRouteBuilder: <T>(RouteSettings settings, WidgetBuilder builder) {
         return FluentPageRoute<T>(settings: settings, builder: builder);
       },

--- a/lib/src/app.dart
+++ b/lib/src/app.dart
@@ -346,12 +346,7 @@ class FluentApp extends StatefulWidget {
 
   static bool debugAllowBannerOverride = true;
 
-  /// {@template flutter.widgets.widgetsApp.useInheritedMediaQuery}
-  /// If true, an inherited MediaQuery will be used. If one is not available,
-  /// or this is false, one will be built from the window.
-  ///
-  /// Cannot be null, defaults to false.
-  /// {@endtemplate}
+  /// {@macro flutter.widgets.widgetsApp.useInheritedMediaQuery}
   final bool useInheritedMediaQuery;
 
   @override


### PR DESCRIPTION
A simple one. Just add `useInheritedMediaQuery` to `FluentApp`

Motivation: Use with `device_preview` package (https://pub.dev/packages/device_preview)

## Pre-launch Checklist

<!-- Mark all that applyes -->

- [x] I have run `dartfmt` on all changed files
- [x] I have updated `CHANGELOG.md` with my changes 
- [x] I have run "optimize/organize imports" on all changed files
- [x] I have addressed all analyzer warnings as best I could
- [ ] I have added/updated relevant documentation
- [ ] I have run `flutter pub publish --dry-run` and addressed any warnings