### PR TITLE
chore: bump pub score

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 Date format: DD/MM/YYYY
 
+## [3.9.2]
+
+- Improves `icons.dart` formatting and its generation.
+
 ## [3.9.1] - Input Update - [25/02/2022]
 
 - `TextBox` updates: ([#179](https://github.com/bdlukaa/fluent_ui/pull/179))

--- a/bin/icon_generator.dart
+++ b/bin/icon_generator.dart
@@ -95,6 +95,8 @@ String get pathSeparator => Platform.isWindows ? "\\" : "/";
 const String fileHeader = """
 // GENERATED FILE, DO NOT EDIT
 
+// ignore_for_file: constant_identifier_names
+
 import 'package:flutter/widgets.dart' show IconData;
 
 class FluentIcons {

--- a/bin/icon_generator.dart
+++ b/bin/icon_generator.dart
@@ -38,7 +38,7 @@ void main(List<String> args) async {
   final StringBuffer dartFileBuffer = StringBuffer(fileHeader);
   for (final Glyph glyph in glyphs) {
     dartFileBuffer.writeln(
-      "  static const IconData ${glyph.name} = IconData(0x${glyph.codepoint}, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui',);",
+      "  static const IconData ${glyph.name} = IconData(0x${glyph.codepoint}, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui',);\n",
     );
   }
 

--- a/bin/icon_generator.dart
+++ b/bin/icon_generator.dart
@@ -38,7 +38,7 @@ void main(List<String> args) async {
   final StringBuffer dartFileBuffer = StringBuffer(fileHeader);
   for (final Glyph glyph in glyphs) {
     dartFileBuffer.writeln(
-      "  static const IconData ${glyph.name} = IconData(0x${glyph.codepoint}, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');",
+      "  static const IconData ${glyph.name} = IconData(0x${glyph.codepoint}, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui',);",
     );
   }
 
@@ -52,8 +52,13 @@ void main(List<String> args) async {
   dartFileBuffer.writeln("  };");
 
   dartFileBuffer.writeln("}");
-
-  await File("lib/src/icons.dart").writeAsString(dartFileBuffer.toString());
+  final outputFile = File("lib/src/icons.dart");
+  final formatProcess = await Process.start(
+    'flutter',
+    ['format', outputFile.path],
+  );
+  stdout.addStream(formatProcess.stdout);
+  await outputFile.writeAsString(dartFileBuffer.toString());
 }
 
 Glyph mapToGlyph(dynamic item) {

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -1,12 +1,11 @@
-import 'package:window_manager/window_manager.dart';
-import 'package:flutter_acrylic/flutter_acrylic.dart' as flutter_acrylic;
-import 'package:system_theme/system_theme.dart';
-
 import 'package:fluent_ui/fluent_ui.dart';
 import 'package:flutter/foundation.dart';
+import 'package:flutter_acrylic/flutter_acrylic.dart' as flutter_acrylic;
 import 'package:provider/provider.dart';
+import 'package:system_theme/system_theme.dart';
 import 'package:url_launcher/link.dart';
 import 'package:url_strategy/url_strategy.dart';
+import 'package:window_manager/window_manager.dart';
 
 import 'screens/colors.dart';
 import 'screens/forms.dart';
@@ -256,18 +255,18 @@ class _MyHomePageState extends State<MyHomePage> with WindowListener {
         context: context,
         builder: (_) {
           return ContentDialog(
-            title: Text('Confirm close'),
-            content: Text('Are you sure you want to close this window?'),
+            title: const Text('Confirm close'),
+            content: const Text('Are you sure you want to close this window?'),
             actions: [
               FilledButton(
-                child: Text('Yes'),
+                child: const Text('Yes'),
                 onPressed: () {
                   Navigator.pop(context);
                   windowManager.destroy();
                 },
               ),
               Button(
-                child: Text('No'),
+                child: const Text('No'),
                 onPressed: () {
                   Navigator.pop(context);
                 },

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -91,7 +91,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "3.9.1"
+    version: "3.9.2"
   flutter:
     dependency: "direct main"
     description: flutter

--- a/lib/src/app.dart
+++ b/lib/src/app.dart
@@ -474,7 +474,7 @@ class _FluentAppState extends State<FluentApp> {
         actions: widget.actions,
         restorationScopeId: widget.restorationScopeId,
         localizationsDelegates: _localizationsDelegates,
-        useInheritedMediaQuery: widget.useInheritedMediaQuery
+        useInheritedMediaQuery: widget.useInheritedMediaQuery,
       );
     }
 

--- a/lib/src/controls/form/text_box.dart
+++ b/lib/src/controls/form/text_box.dart
@@ -1,10 +1,8 @@
 import 'dart:ui' as ui;
 
 import 'package:fluent_ui/fluent_ui.dart';
-import 'package:fluent_ui/src/controls/form/selection_controls.dart';
 import 'package:flutter/gestures.dart';
 import 'package:flutter/rendering.dart';
-
 import 'package:flutter/services.dart';
 
 import 'pickers/pickers.dart';

--- a/lib/src/controls/navigation/navigation_view/view.dart
+++ b/lib/src/controls/navigation/navigation_view/view.dart
@@ -340,7 +340,8 @@ class NavigationViewState extends State<NavigationView> {
                         );
                       } else if (_compactOverlayOpen) {
                         return Mica(
-                          backgroundColor: theme.backgroundColor?.withAlpha(255),
+                          backgroundColor:
+                              theme.backgroundColor?.withAlpha(255),
                           elevation: 10.0,
                           child: Container(
                             decoration: BoxDecoration(

--- a/lib/src/icons.dart
+++ b/lib/src/icons.dart
@@ -10,11061 +10,13273 @@ class FluentIcons {
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData a_t_p_logo = IconData(
     0xef85,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData accept = IconData(
     0xe8fb,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData accept_medium = IconData(
     0xf78c,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData access_logo = IconData(
     0xed69,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData accessibilty_checker = IconData(
     0xf835,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData account_activity = IconData(
     0xeff4,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData account_browser = IconData(
     0xf652,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData account_management = IconData(
     0xf55c,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData accounts = IconData(
     0xe910,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData action_center = IconData(
     0xe91c,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData activate_orders = IconData(
     0xefe0,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData activity_feed = IconData(
     0xf056,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData add = IconData(
     0xe710,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData add_bookmark = IconData(
     0xf5b7,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData add_connection = IconData(
     0xf4e1,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData add_event = IconData(
     0xeeb5,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData add_favorite = IconData(
     0xf0c8,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData add_favorite_fill = IconData(
     0xf0c9,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData add_field = IconData(
     0xe4c7,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData add_friend = IconData(
     0xe8fa,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData add_group = IconData(
     0xee3d,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData add_home = IconData(
     0xf17b,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData add_in = IconData(
     0xf775,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData add_link = IconData(
     0xe35e,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData add_medium = IconData(
     0xeca1,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData add_multiple = IconData(
     0xe9c5,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData add_notes = IconData(
     0xeae3,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData add_online_meeting = IconData(
     0xed8e,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData add_phone = IconData(
     0xed96,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData add_reaction = IconData(
     0xf85d,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData add_space_after = IconData(
     0xe3df,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData add_space_before = IconData(
     0xe3de,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData add_table = IconData(
     0xe4c6,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData add_to = IconData(
     0xecc8,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData add_to_shopping_list = IconData(
     0xea9a,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData add_work = IconData(
     0xf17c,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData admin = IconData(
     0xe7ef,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData admin_a_logo32 = IconData(
     0xf4ba,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData admin_a_logo_fill32 = IconData(
     0xf4bb,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData admin_a_logo_inverse32 = IconData(
     0xed6a,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData admin_c_logo_inverse32 = IconData(
     0xed6b,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData admin_d_logo_inverse32 = IconData(
     0xed6c,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData admin_e_logo_inverse32 = IconData(
     0xed6d,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData admin_l_logo_inverse32 = IconData(
     0xed6e,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData admin_m_logo_inverse32 = IconData(
     0xed6f,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData admin_o_logo_inverse32 = IconData(
     0xed70,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData admin_p_logo_inverse32 = IconData(
     0xed71,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData admin_s_logo_inverse32 = IconData(
     0xed72,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData admin_y_logo_inverse32 = IconData(
     0xed73,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData air_tickets = IconData(
     0xef7a,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData airplane = IconData(
     0xe709,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData airplane_solid = IconData(
     0xeb4c,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData alarm_clock = IconData(
     0xe919,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData album = IconData(
     0xe7ab,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData album_remove = IconData(
     0xec62,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData alert_settings = IconData(
     0xf8b6,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData alert_solid = IconData(
     0xf331,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData align_center = IconData(
     0xe8e3,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData align_horizontal_center = IconData(
     0xf4f4,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData align_horizontal_left = IconData(
     0xf4f3,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData align_horizontal_right = IconData(
     0xf4f5,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData align_justify = IconData(
     0xf51e,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData align_left = IconData(
     0xe8e4,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData align_right = IconData(
     0xe8e2,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData align_vertical_bottom = IconData(
     0xf4f8,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData align_vertical_center = IconData(
     0xf4f7,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData align_vertical_top = IconData(
     0xf4f6,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData all_apps = IconData(
     0xe71d,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData all_apps_mirrored = IconData(
     0xea40,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData all_currency = IconData(
     0xeae4,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData alt_text = IconData(
     0xe397,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData analytics_logo = IconData(
     0xf1de,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData analytics_query = IconData(
     0xf1df,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData analytics_report = IconData(
     0xf1e1,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData analytics_view = IconData(
     0xf5f1,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData anchor_lock = IconData(
     0xf511,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData annotation = IconData(
     0xe924,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData app_icon_default = IconData(
     0xecaa,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData app_icon_default_add = IconData(
     0xefda,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData app_icon_default_edit = IconData(
     0xefdc,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData app_icon_default_list = IconData(
     0xefde,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData app_icon_secure = IconData(
     0xe657,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData apps_content = IconData(
     0xee54,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData archive = IconData(
     0xf03f,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData archive_undo = IconData(
     0xe3a1,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData area_chart = IconData(
     0xe9d2,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData arrange_bring_forward = IconData(
     0xf509,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData arrange_bring_to_front = IconData(
     0xf506,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData arrange_by_from = IconData(
     0xf678,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData arrange_send_backward = IconData(
     0xf508,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData arrange_send_to_back = IconData(
     0xf507,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData arrivals = IconData(
     0xeb34,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData arrow_down_right8 = IconData(
     0xeed5,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData arrow_down_right_mirrored8 = IconData(
     0xeef0,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData arrow_tall_down_left = IconData(
     0xf2bf,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData arrow_tall_down_right = IconData(
     0xf2c0,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData arrow_tall_up_left = IconData(
     0xf2bd,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData arrow_tall_up_right = IconData(
     0xf2be,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData arrow_up_right = IconData(
     0xf069,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData arrow_up_right8 = IconData(
     0xeed4,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData arrow_up_right_mirrored8 = IconData(
     0xeeef,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData articles = IconData(
     0xeac1,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData ascending = IconData(
     0xedc0,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData aspect_ratio = IconData(
     0xe799,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData assessment_group = IconData(
     0xf31a,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData assessment_group_template = IconData(
     0xf2b1,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData asset_library = IconData(
     0xeeb6,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData assign = IconData(
     0xe9d3,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData assign_policy = IconData(
     0xe461,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData asterisk = IconData(
     0xea38,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData asterisk_solid = IconData(
     0xf34d,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData attach = IconData(
     0xe723,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData australian_rules = IconData(
     0xee70,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData authenticator_app = IconData(
     0xf6b1,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData auto_deploy_settings = IconData(
     0xf3fa,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData auto_enhance_off = IconData(
     0xe78e,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData auto_enhance_on = IconData(
     0xe78d,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData auto_fill_template = IconData(
     0xf313,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData auto_fit_contents = IconData(
     0xe3e8,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData auto_fit_window = IconData(
     0xe3e9,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData auto_height = IconData(
     0xf512,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData auto_racing = IconData(
     0xeb24,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData automate_flow = IconData(
     0xe3f5,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData away_status = IconData(
     0xee6a,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData azure_a_p_i_management = IconData(
     0xf37f,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData azure_data_explorer = IconData(
     0xe439,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData azure_icon = IconData(
     0xeb6a,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData azure_key_vault = IconData(
     0xf3b4,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData azure_service_endpoint = IconData(
     0xf380,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData b_i_dashboard = IconData(
     0xf543,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData back = IconData(
     0xe72b,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData back_to_window = IconData(
     0xe73f,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData background_color = IconData(
     0xf42b,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData backlog = IconData(
     0xf2ac,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData backlog_board = IconData(
     0xf444,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData backlog_list = IconData(
     0xf6bf,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData badge = IconData(
     0xec1b,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData balloons = IconData(
     0xed7e,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData bank = IconData(
     0xe825,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData bank_solid = IconData(
     0xf34f,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData bar_chart4 = IconData(
     0xeae7,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData bar_chart_horizontal = IconData(
     0xe9eb,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData bar_chart_vertical = IconData(
     0xe9ec,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData bar_chart_vertical_edit = IconData(
     0xf89d,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData bar_chart_vertical_fill = IconData(
     0xf830,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData bar_chart_vertical_filter = IconData(
     0xf77e,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData bar_chart_vertical_filter_solid = IconData(
     0xf77f,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData baseball = IconData(
     0xeb20,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData beer_mug = IconData(
     0xf49e,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData bidi_ltr = IconData(
     0xe9aa,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData bidi_rtl = IconData(
     0xe9ab,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData bill = IconData(
     0xe5fa,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData bing_logo = IconData(
     0xeb6b,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData birthday_cake = IconData(
     0xef8d,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData blob_storage = IconData(
     0xe436,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData block_contact = IconData(
     0xe8f8,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData blocked = IconData(
     0xe733,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData blocked12 = IconData(
     0xf62e,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData blocked2 = IconData(
     0xece4,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData blocked2_solid = IconData(
     0xf737,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData blocked_site = IconData(
     0xe72f,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData blocked_site_solid12 = IconData(
     0xf70a,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData blocked_solid = IconData(
     0xf531,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData blog = IconData(
     0xf22b,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData blowing_snow = IconData(
     0xe9c9,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData blur = IconData(
     0xf28e,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData boards = IconData(
     0xef68,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData bold = IconData(
     0xe8dd,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData bold_bulgarian = IconData(
     0xe5c5,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData bold_f = IconData(
     0xe5b5,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData bold_g = IconData(
     0xe5b3,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData bold_k = IconData(
     0xe5c6,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData bold_kazakh = IconData(
     0xe5c9,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData bold_korean = IconData(
     0xe5bd,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData bold_n = IconData(
     0xe5b7,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData bold_p = IconData(
     0xe5c7,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData bold_russion = IconData(
     0xe5b9,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData bold_serbian = IconData(
     0xe5ca,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData bold_t = IconData(
     0xe5c8,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData book_answers = IconData(
     0xf8a4,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData bookings_logo = IconData(
     0xedc7,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData bookmark_report = IconData(
     0xf76b,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData bookmarks = IconData(
     0xe8a4,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData bookmarks_mirrored = IconData(
     0xea41,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData boolean_data = IconData(
     0xe678,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData border_all = IconData(
     0xe5f4,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData border_dash = IconData(
     0xf50a,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData border_dot = IconData(
     0xf50b,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData border_inside = IconData(
     0xe5f3,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData border_inside_horizontal = IconData(
     0xe5f2,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData border_inside_vertical = IconData(
     0xe5f1,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData border_none = IconData(
     0xe5f0,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData box_addition_solid = IconData(
     0xf2d4,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData box_checkmark_solid = IconData(
     0xf2d7,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData box_multiply_solid = IconData(
     0xf2d5,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData box_play_solid = IconData(
     0xf2d6,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData box_subtract_solid = IconData(
     0xf2d3,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData branch_commit = IconData(
     0xf293,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData branch_compare = IconData(
     0xf294,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData branch_fork = IconData(
     0xf173,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData branch_fork2 = IconData(
     0xf291,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData branch_locked = IconData(
     0xf292,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData branch_merge = IconData(
     0xf295,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData branch_pull_request = IconData(
     0xf296,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData branch_search = IconData(
     0xf297,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData branch_shelveset = IconData(
     0xf298,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData breadcrumb = IconData(
     0xef8c,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData breakfast = IconData(
     0xf49c,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData brightness = IconData(
     0xe706,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData broom = IconData(
     0xea99,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData browser_screen_shot = IconData(
     0xebed,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData browser_tab = IconData(
     0xf5d7,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData browser_tab_screenshot = IconData(
     0xf5d8,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData brunch = IconData(
     0xf49d,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData brush = IconData(
     0xecff,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData bucket_color = IconData(
     0xf1b6,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData bucket_color_fill = IconData(
     0xf1b7,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData buffer_time_after = IconData(
     0xf0d0,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData buffer_time_before = IconData(
     0xf0cf,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData buffer_time_both = IconData(
     0xf0d1,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData bug = IconData(
     0xebe8,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData bug_action = IconData(
     0xe358,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData bug_block = IconData(
     0xe400,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData bug_solid = IconData(
     0xf335,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData bug_sync = IconData(
     0xe3ff,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData bug_warning = IconData(
     0xe357,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData build = IconData(
     0xf28f,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData build_definition = IconData(
     0xf6e9,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData build_issue = IconData(
     0xf319,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData build_queue = IconData(
     0xf24f,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData build_queue_new = IconData(
     0xf250,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData bulk_page_block = IconData(
     0xe553,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData bulk_upload = IconData(
     0xf548,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData bulleted_list = IconData(
     0xe8fd,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData bulleted_list2 = IconData(
     0xf2c7,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData bulleted_list2_mirrored = IconData(
     0xf2c8,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData bulleted_list_bullet = IconData(
     0xf793,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData bulleted_list_bullet_mirrored = IconData(
     0xf795,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData bulleted_list_mirrored = IconData(
     0xea42,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData bulleted_list_text = IconData(
     0xf792,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData bulleted_list_text_mirrored = IconData(
     0xf794,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData bulleted_tree_list = IconData(
     0xf84c,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData bullseye = IconData(
     0xf272,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData bullseye_target = IconData(
     0xf5f0,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData bullseye_target_add = IconData(
     0xe664,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData bullseye_target_delete = IconData(
     0xf6c1,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData bullseye_target_edit = IconData(
     0xe319,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData bus = IconData(
     0xe806,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData bus_solid = IconData(
     0xeb47,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData business_card = IconData(
     0xe5fb,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData business_center_logo = IconData(
     0xf4b2,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData business_hours_sign = IconData(
     0xf310,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData business_rule = IconData(
     0xe562,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData button_control = IconData(
     0xf6c0,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData c_c_solid = IconData(
     0xe4f4,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData c_plus_plus = IconData(
     0xf2f4,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData c_plus_plus_language = IconData(
     0xf2f3,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData c_r_m_lead = IconData(
     0xefd6,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData c_r_m_processes = IconData(
     0xefb1,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData c_r_m_report = IconData(
     0xeffe,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData c_r_m_resource_optimization_app32 = IconData(
     0xf6ef,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData c_r_m_services = IconData(
     0xefd2,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData c_sharp = IconData(
     0xf2f0,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData c_sharp_language = IconData(
     0xf2ef,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData cafe = IconData(
     0xec32,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData cake = IconData(
     0xeca4,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData calculated_table = IconData(
     0xe4be,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData calculator = IconData(
     0xe8ef,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData calculator_addition = IconData(
     0xe948,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData calculator_delta = IconData(
     0xe406,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData calculator_equal_to = IconData(
     0xe94e,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData calculator_group = IconData(
     0xe462,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData calculator_multiply = IconData(
     0xe947,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData calculator_not_equal_to = IconData(
     0xf2d2,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData calculator_percentage = IconData(
     0xe94c,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData calculator_subtract = IconData(
     0xe949,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData calendar = IconData(
     0xe787,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData calendar_agenda = IconData(
     0xee9a,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData calendar_day = IconData(
     0xe8bf,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData calendar_mirrored = IconData(
     0xed28,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData calendar_reply = IconData(
     0xe8f5,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData calendar_settings = IconData(
     0xf558,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData calendar_settings_mirrored = IconData(
     0xf559,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData calendar_week = IconData(
     0xe8c0,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData calendar_work_week = IconData(
     0xef51,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData calendar_year = IconData(
     0xe371,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData calories = IconData(
     0xecad,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData calories_add = IconData(
     0xf172,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData camera = IconData(
     0xe722,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData campaign_template = IconData(
     0xf811,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData cancel = IconData(
     0xe711,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData canned_chat = IconData(
     0xf0f2,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData canvas_app_template32 = IconData(
     0xe5fe,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData car = IconData(
     0xe804,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData care_activity = IconData(
     0xe549,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData care_plan = IconData(
     0xe54a,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData care_plan_template = IconData(
     0xe61e,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData caret_bottom_left_center8 = IconData(
     0xf365,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData caret_bottom_left_solid8 = IconData(
     0xf121,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData caret_bottom_right_center8 = IconData(
     0xf364,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData caret_bottom_right_solid8 = IconData(
     0xf122,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData caret_down8 = IconData(
     0xedd8,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData caret_down_solid8 = IconData(
     0xeddc,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData caret_hollow = IconData(
     0xe817,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData caret_hollow_mirrored = IconData(
     0xea45,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData caret_left8 = IconData(
     0xedd5,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData caret_left_solid8 = IconData(
     0xedd9,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData caret_right = IconData(
     0xf06b,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData caret_right8 = IconData(
     0xedd6,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData caret_right_solid8 = IconData(
     0xedda,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData caret_solid = IconData(
     0xe818,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData caret_solid16 = IconData(
     0xee62,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData caret_solid_alt = IconData(
     0xe483,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData caret_solid_down = IconData(
     0xf08e,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData caret_solid_left = IconData(
     0xf08d,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData caret_solid_mirrored = IconData(
     0xea46,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData caret_solid_right = IconData(
     0xf08f,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData caret_solid_up = IconData(
     0xf090,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData caret_top_left_center8 = IconData(
     0xf367,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData caret_top_left_solid8 = IconData(
     0xef54,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData caret_top_right_center8 = IconData(
     0xf366,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData caret_top_right_solid8 = IconData(
     0xef55,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData caret_up8 = IconData(
     0xedd7,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData caret_up_solid8 = IconData(
     0xeddb,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData cat = IconData(
     0xed7f,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData category_classification = IconData(
     0xe48c,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData cc = IconData(
     0xe7f0,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData cell_phone = IconData(
     0xe8ea,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData cell_split_vertical = IconData(
     0xe66c,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData certificate = IconData(
     0xeb95,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData certified_database = IconData(
     0xf5bb,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData change_entitlements = IconData(
     0xe310,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData chart = IconData(
     0xe999,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData chart_series = IconData(
     0xf513,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData chart_template = IconData(
     0xf812,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData chart_x_angle = IconData(
     0xf514,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData chart_y_angle = IconData(
     0xf515,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData charticulator_arrange_polar = IconData(
     0xe632,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData charticulator_arrange_polar_angles = IconData(
     0xe633,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData charticulator_band = IconData(
     0xe634,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData charticulator_guide_coordinator = IconData(
     0xe635,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData charticulator_guide_x = IconData(
     0xe636,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData charticulator_guide_y = IconData(
     0xe637,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData charticulator_legend = IconData(
     0xe638,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData charticulator_line = IconData(
     0xe639,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData charticulator_line_style_dashed = IconData(
     0xe63a,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData charticulator_line_style_dotted = IconData(
     0xe63b,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData charticulator_linking_data = IconData(
     0xe63c,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData charticulator_linking_sequence = IconData(
     0xe63d,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData charticulator_order_column = IconData(
     0xe63e,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData charticulator_order_row = IconData(
     0xe63f,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData charticulator_plot_cartesian = IconData(
     0xe640,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData charticulator_plot_curve = IconData(
     0xe641,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData charticulator_polar_coordinates = IconData(
     0xe642,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData charticulator_spiral = IconData(
     0xe643,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData charticulator_stack_radial = IconData(
     0xe644,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData charticulator_stack_y = IconData(
     0xe645,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData chat = IconData(
     0xe901,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData chat_bot = IconData(
     0xf08b,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData chat_invite_friend = IconData(
     0xecfe,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData chat_settings = IconData(
     0xe600,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData chat_solid = IconData(
     0xf344,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData check_list = IconData(
     0xe9d5,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData check_list_check = IconData(
     0xf7a9,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData check_list_check_mirrored = IconData(
     0xf7ab,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData check_list_text = IconData(
     0xf7a8,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData check_list_text_mirrored = IconData(
     0xf7aa,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData check_mark = IconData(
     0xe73e,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData checkbox = IconData(
     0xe739,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData checkbox_composite = IconData(
     0xe73a,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData checkbox_composite_reversed = IconData(
     0xe73d,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData checkbox_fill = IconData(
     0xe73b,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData checkbox_indeterminate = IconData(
     0xe73c,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData checkbox_indeterminate_combo = IconData(
     0xf16e,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData checked_out_by_other12 = IconData(
     0xf630,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData checked_out_by_you12 = IconData(
     0xf631,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData chevron_down = IconData(
     0xe70d,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData chevron_down_end = IconData(
     0xf5e4,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData chevron_down_end6 = IconData(
     0xf36f,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData chevron_down_med = IconData(
     0xe972,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData chevron_down_small = IconData(
     0xe96e,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData chevron_fold10 = IconData(
     0xf36a,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData chevron_left = IconData(
     0xe76b,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData chevron_left_end6 = IconData(
     0xf371,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData chevron_left_med = IconData(
     0xe973,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData chevron_left_small = IconData(
     0xe96f,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData chevron_right = IconData(
     0xe76c,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData chevron_right_end6 = IconData(
     0xf372,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData chevron_right_med = IconData(
     0xe974,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData chevron_right_small = IconData(
     0xe970,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData chevron_unfold10 = IconData(
     0xf369,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData chevron_up = IconData(
     0xe70e,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData chevron_up_end = IconData(
     0xe55b,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData chevron_up_end6 = IconData(
     0xf370,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData chevron_up_med = IconData(
     0xe971,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData chevron_up_small = IconData(
     0xe96d,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData childof = IconData(
     0xf82d,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData choice_column = IconData(
     0xe4ae,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData chopsticks = IconData(
     0xf4a2,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData chrome_back = IconData(
     0xe830,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData chrome_back_mirrored = IconData(
     0xea47,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData chrome_close = IconData(
     0xe8bb,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData chrome_full_screen = IconData(
     0xe92d,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData chrome_minimize = IconData(
     0xe921,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData chrome_restore = IconData(
     0xe923,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData circle_addition = IconData(
     0xf2e3,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData circle_addition_solid = IconData(
     0xf2e4,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData circle_dollar = IconData(
     0xeaed,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData circle_fill = IconData(
     0xea3b,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData circle_half_full = IconData(
     0xed9e,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData circle_pause = IconData(
     0xf2d9,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData circle_pause_solid = IconData(
     0xf2d8,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData circle_plus = IconData(
     0xeaee,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData circle_ring = IconData(
     0xea3a,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData circle_shape = IconData(
     0xf1a5,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData circle_shape_solid = IconData(
     0xf63c,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData circle_stop = IconData(
     0xf2dc,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData circle_stop_solid = IconData(
     0xf2db,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData city_next = IconData(
     0xec06,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData city_next2 = IconData(
     0xec07,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData class_notebook_logo16 = IconData(
     0xf488,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData class_notebook_logo32 = IconData(
     0xf486,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData class_notebook_logo_fill16 = IconData(
     0xf489,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData class_notebook_logo_fill32 = IconData(
     0xf487,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData class_notebook_logo_inverse = IconData(
     0xedc8,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData class_notebook_logo_inverse16 = IconData(
     0xf48b,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData class_notebook_logo_inverse32 = IconData(
     0xf48a,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData classroom_logo = IconData(
     0xef75,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData clear = IconData(
     0xe894,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData clear_filter = IconData(
     0xef8f,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData clear_formatting = IconData(
     0xeddd,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData clear_formatting_a = IconData(
     0xf79d,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData clear_formatting_eraser = IconData(
     0xf79e,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData clear_night = IconData(
     0xe9c2,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData clear_selection = IconData(
     0xe8e6,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData clear_selection_mirrored = IconData(
     0xea48,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData clicked = IconData(
     0xf268,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData clinical_impression = IconData(
     0xe54b,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData clipboard_list = IconData(
     0xf0e3,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData clipboard_list_add = IconData(
     0xe4ef,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData clipboard_list_mirrored = IconData(
     0xf0e4,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData clipboard_list_question = IconData(
     0xe4f0,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData clipboard_list_reply = IconData(
     0xe4f1,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData clipboard_solid = IconData(
     0xf5dc,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData clock = IconData(
     0xe917,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData clone_to_desktop = IconData(
     0xf28c,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData close_pane = IconData(
     0xe89f,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData close_pane_mirrored = IconData(
     0xea49,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData closed_caption = IconData(
     0xef84,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData cloud = IconData(
     0xe753,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData cloud_add = IconData(
     0xeca9,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData cloud_download = IconData(
     0xebd3,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData cloud_edit = IconData(
     0xe4c8,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData cloud_flow = IconData(
     0xe5ea,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData cloud_import_export = IconData(
     0xee55,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData cloud_link = IconData(
     0xe4c9,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData cloud_not_synced = IconData(
     0xec9c,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData cloud_printer = IconData(
     0xeda6,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData cloud_search = IconData(
     0xede4,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData cloud_secure = IconData(
     0xe4d5,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData cloud_upload = IconData(
     0xec8e,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData cloud_weather = IconData(
     0xe9be,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData cloudy = IconData(
     0xe9bf,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData cocktails = IconData(
     0xea9d,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData code = IconData(
     0xe943,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData code_edit = IconData(
     0xf544,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData coffee = IconData(
     0xeaef,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData coffee_script = IconData(
     0xf2fa,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData collapse_all = IconData(
     0xf85a,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData collapse_content = IconData(
     0xf165,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData collapse_content_single = IconData(
     0xf166,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData collapse_menu = IconData(
     0xef66,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData college_football = IconData(
     0xeb26,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData college_hoops = IconData(
     0xeb25,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData color = IconData(
     0xe790,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData color_solid = IconData(
     0xf354,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData column = IconData(
     0xe438,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData column_function = IconData(
     0xe4c2,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData column_left_two_thirds = IconData(
     0xf1d6,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData column_left_two_thirds_edit = IconData(
     0xf324,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData column_options = IconData(
     0xf317,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData column_question = IconData(
     0xe4c0,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData column_question_mirrored = IconData(
     0xe4c1,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData column_right_two_thirds = IconData(
     0xf1d7,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData column_right_two_thirds_edit = IconData(
     0xf325,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData column_sigma = IconData(
     0xe4bf,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData column_vertical_section = IconData(
     0xf81e,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData column_vertical_section_edit = IconData(
     0xf806,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData combine = IconData(
     0xedbb,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData combobox = IconData(
     0xf516,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData command_prompt = IconData(
     0xe756,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData comment = IconData(
     0xe90a,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData comment_active = IconData(
     0xf804,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData comment_add = IconData(
     0xf2b3,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData comment_next = IconData(
     0xf2b4,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData comment_previous = IconData(
     0xf2b5,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData comment_solid = IconData(
     0xe30e,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData comment_urgent = IconData(
     0xf307,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData commitments = IconData(
     0xec4d,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData common_data_service_c_d_s = IconData(
     0xe377,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData communication_details = IconData(
     0xe4cf,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData communication_details_mirrored = IconData(
     0xe4d0,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData communications = IconData(
     0xe95a,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData company_directory = IconData(
     0xef0d,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData company_directory_mirrored = IconData(
     0xef2b,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData compare = IconData(
     0xf057,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData compare_uneven = IconData(
     0xe42e,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData compass_n_w = IconData(
     0xe942,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData completed = IconData(
     0xe930,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData completed12 = IconData(
     0xe559,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData completed_solid = IconData(
     0xec61,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData compliance_audit = IconData(
     0xe369,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData configuration_solid = IconData(
     0xf334,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData confirm_event = IconData(
     0xe680,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData connect_contacts = IconData(
     0xefd4,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData connect_virtual_machine = IconData(
     0xee9d,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData construction_cone = IconData(
     0xe98f,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData construction_cone_solid = IconData(
     0xf339,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData contact = IconData(
     0xe77b,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData contact_card = IconData(
     0xeebd,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData contact_card_settings = IconData(
     0xf556,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData contact_card_settings_mirrored = IconData(
     0xf557,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData contact_heart = IconData(
     0xf862,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData contact_info = IconData(
     0xe779,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData contact_info_mirrored = IconData(
     0xea4a,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData contact_link = IconData(
     0xf25f,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData contact_list = IconData(
     0xf7e5,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData contact_lock = IconData(
     0xf400,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData content_feed = IconData(
     0xe428,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData content_settings = IconData(
     0xf647,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData content_understanding_app = IconData(
     0xe4fb,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData context_menu = IconData(
     0xf37c,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData contrast = IconData(
     0xe7a1,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData copy = IconData(
     0xe8c8,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData copy_edit = IconData(
     0xe464,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData cortana_logo_beckon_inner = IconData(
     0xf4c6,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData cortana_logo_beckon_outer = IconData(
     0xf4c7,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData cortana_logo_inner = IconData(
     0xe832,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData cortana_logo_outer = IconData(
     0xe831,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData cortana_logo_ready_inner = IconData(
     0xf4c8,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData cortana_logo_ready_outer = IconData(
     0xf4c9,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData cost_contral_ledger_admin = IconData(
     0xf208,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData cost_control = IconData(
     0xf207,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData cotton = IconData(
     0xeaf3,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData count = IconData(
     0xe9ee,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData coupon = IconData(
     0xf7bc,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData create_mail_rule = IconData(
     0xf67a,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData credit_card_bill = IconData(
     0xecd6,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData cricket = IconData(
     0xeb1e,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData critical_error_solid = IconData(
     0xf5c9,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData crop = IconData(
     0xe7a8,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData crown = IconData(
     0xed01,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData crown_solid = IconData(
     0xf336,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData css = IconData(
     0xebef,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData ctrl_button = IconData(
     0xe4b8,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData cube_shape = IconData(
     0xf1aa,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData cube_shape_solid = IconData(
     0xe421,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData currency = IconData(
     0xeaf5,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData custom_activity = IconData(
     0xeff0,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData custom_entity = IconData(
     0xeff7,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData custom_list = IconData(
     0xeebe,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData custom_list_mirrored = IconData(
     0xeebf,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData customer_assets = IconData(
     0xf426,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData customize_toolbar = IconData(
     0xf828,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData cut = IconData(
     0xe8c6,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData cycling = IconData(
     0xeac7,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData d365_business_central = IconData(
     0xf833,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData d365_core_h_r = IconData(
     0xf6bd,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData d365_customer_insights = IconData(
     0xf3c8,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData d365_customer_voice_app = IconData(
     0xe4f7,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData d365_project_operations = IconData(
     0xe432,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData d365_talent_insight = IconData(
     0xf6bc,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData d365_talent_learn = IconData(
     0xf6bb,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData dashboard_add = IconData(
     0xf52d,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData data_connection_library = IconData(
     0xeeb7,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData data_enrichment = IconData(
     0xe4f5,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData data_flow = IconData(
     0xe577,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData data_management_settings = IconData(
     0xefc8,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData database = IconData(
     0xefc7,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData database_activity = IconData(
     0xe670,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData database_block = IconData(
     0xe617,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData database_refresh = IconData(
     0xe67f,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData database_source = IconData(
     0xe30a,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData database_swap = IconData(
     0xe671,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData database_sync = IconData(
     0xf842,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData database_view = IconData(
     0xe437,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData dataflows = IconData(
     0xf7dd,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData dataflows_link = IconData(
     0xe366,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData dataverse = IconData(
     0xe659,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData date_time = IconData(
     0xec92,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData date_time12 = IconData(
     0xf38f,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData date_time2 = IconData(
     0xea17,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData date_time_mirrored = IconData(
     0xee93,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData deactivate_orders = IconData(
     0xefe1,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData decimals = IconData(
     0xf218,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData decision_solid = IconData(
     0xf350,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData decline_call = IconData(
     0xf405,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData decrease_indent = IconData(
     0xe39b,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData decrease_indent_arrow = IconData(
     0xf7a3,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData decrease_indent_arrow_mirrored = IconData(
     0xf7a7,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData decrease_indent_mirrored = IconData(
     0xe39c,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData decrease_indent_text = IconData(
     0xf7a2,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData decrease_indent_text_mirrored = IconData(
     0xf7a6,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData default_ratio = IconData(
     0xf529,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData default_settings = IconData(
     0xf648,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData defect_solid = IconData(
     0xf449,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData defender_app = IconData(
     0xe83d,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData defender_badge12 = IconData(
     0xf0fb,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData defender_t_v_m = IconData(
     0xf6b3,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData delete = IconData(
     0xe74d,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData delete_columns = IconData(
     0xf64e,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData delete_rows = IconData(
     0xf64f,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData delete_rows_mirrored = IconData(
     0xf650,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData delete_table = IconData(
     0xf651,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData delivery_truck = IconData(
     0xebf4,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData delve_analytics = IconData(
     0xeeee,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData delve_analytics_logo = IconData(
     0xedca,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData delve_logo = IconData(
     0xf280,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData delve_logo_fill = IconData(
     0xf281,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData delve_logo_inverse = IconData(
     0xed76,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData density_comfy = IconData(
     0xe4ba,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData density_default = IconData(
     0xe4b9,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData dependency_add = IconData(
     0xe344,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData dependency_remove = IconData(
     0xe345,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData deploy = IconData(
     0xf29d,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData descending = IconData(
     0xedc1,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData design = IconData(
     0xeb3c,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData desktop_flow = IconData(
     0xe4f3,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData desktop_screenshot = IconData(
     0xf5d9,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData developer_tools = IconData(
     0xec7a,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData device_bug = IconData(
     0xe424,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData device_off = IconData(
     0xe402,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData device_run = IconData(
     0xe401,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData devices2 = IconData(
     0xe975,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData devices3 = IconData(
     0xea6c,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData devices4 = IconData(
     0xeb66,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData diagnostic = IconData(
     0xe9d9,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData diagnostic_data_bar_tooltip = IconData(
     0xf7df,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData diagnostic_data_viewer_app = IconData(
     0xf568,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData dialpad = IconData(
     0xe75f,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData diamond = IconData(
     0xed02,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData diamond_solid = IconData(
     0xf34c,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData diamond_user = IconData(
     0xe4f9,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData dictionary = IconData(
     0xe82d,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData dictionary_remove = IconData(
     0xf69a,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData diet_plan_notebook = IconData(
     0xeac8,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData diff_inline = IconData(
     0xf309,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData diff_side_by_side = IconData(
     0xf30a,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData diploma = IconData(
     0xf320,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData disable_updates = IconData(
     0xe8d8,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData disconnect_virtual_machine = IconData(
     0xf873,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData dislike = IconData(
     0xe8e0,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData dislike_solid = IconData(
     0xf3c0,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData distribute_down = IconData(
     0xf76a,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData doc_library = IconData(
     0xeeb8,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData dock_left = IconData(
     0xe90c,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData dock_left_mirrored = IconData(
     0xea4c,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData dock_right = IconData(
     0xe90d,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData docs_logo_inverse = IconData(
     0xedcb,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData document = IconData(
     0xe8a5,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData document_approval = IconData(
     0xf28b,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData document_management = IconData(
     0xeffc,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData document_reply = IconData(
     0xef57,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData document_search = IconData(
     0xef6c,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData document_set = IconData(
     0xeed6,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData documentation = IconData(
     0xec17,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData dom = IconData(
     0xec8d,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData donut_chart = IconData(
     0xf368,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData door = IconData(
     0xeb75,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData double_bookmark = IconData(
     0xeb8f,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData double_chevron_down = IconData(
     0xee04,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData double_chevron_down12 = IconData(
     0xee97,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData double_chevron_down8 = IconData(
     0xf36b,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData double_chevron_left = IconData(
     0xedbe,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData double_chevron_left12 = IconData(
     0xee98,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData double_chevron_left8 = IconData(
     0xf36d,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData double_chevron_left_med = IconData(
     0xe991,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData double_chevron_left_med_mirrored = IconData(
     0xea4d,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData double_chevron_right = IconData(
     0xedbf,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData double_chevron_right12 = IconData(
     0xee99,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData double_chevron_right8 = IconData(
     0xf36e,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData double_chevron_up = IconData(
     0xedbd,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData double_chevron_up12 = IconData(
     0xee96,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData double_chevron_up8 = IconData(
     0xf36c,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData double_column = IconData(
     0xf1d4,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData double_column_edit = IconData(
     0xf322,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData double_down_arrow = IconData(
     0xf769,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData down = IconData(
     0xe74b,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData download = IconData(
     0xe896,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData download_document = IconData(
     0xf549,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData drag_object = IconData(
     0xf553,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData drill_down = IconData(
     0xf532,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData drill_down_solid = IconData(
     0xf533,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData drill_expand = IconData(
     0xf534,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData drill_show = IconData(
     0xf535,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData drill_through = IconData(
     0xf5b9,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData driver_off = IconData(
     0xe3fb,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData drm = IconData(
     0xeca8,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData drop = IconData(
     0xeb42,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData drop_shape = IconData(
     0xf1a8,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData drop_shape_solid = IconData(
     0xf63f,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData dropdown = IconData(
     0xedc5,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData duplicate_row = IconData(
     0xf82a,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData duststorm = IconData(
     0xe9cd,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData dynamic_list = IconData(
     0xe491,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData dynamic_s_m_b_logo = IconData(
     0xedcd,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData dynamics365_logo = IconData(
     0xedcc,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData e_discovery = IconData(
     0xe370,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData ease_of_access = IconData(
     0xe776,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData eat_drink = IconData(
     0xe807,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData edge_logo = IconData(
     0xe3ab,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData edge_logo16 = IconData(
     0xe3aa,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData edge_old_logo = IconData(
     0xec60,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData edit = IconData(
     0xe70f,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData edit_contact = IconData(
     0xefd3,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData edit_create = IconData(
     0xf3c9,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData edit_event = IconData(
     0xf05b,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData edit_list_pencil = IconData(
     0xe61b,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData edit_mail = IconData(
     0xef61,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData edit_mirrored = IconData(
     0xeb7e,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData edit_note = IconData(
     0xed9d,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData edit_photo = IconData(
     0xef77,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData edit_solid12 = IconData(
     0xf4b5,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData edit_solid_mirrored12 = IconData(
     0xf4b6,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData edit_style = IconData(
     0xef60,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData edit_table = IconData(
     0xe4c4,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData education = IconData(
     0xe7be,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData ellipse = IconData(
     0xf4fb,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData embed = IconData(
     0xecce,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData emi = IconData(
     0xe731,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData emoji = IconData(
     0xe899,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData emoji2 = IconData(
     0xe76e,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData emoji_disappointed = IconData(
     0xea88,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData emoji_neutral = IconData(
     0xea87,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData emoji_tab_symbols = IconData(
     0xed58,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData employee_self_service = IconData(
     0xee24,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData empty_recycle_bin = IconData(
     0xef88,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData encounter = IconData(
     0xe54c,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData encryption = IconData(
     0xf69d,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData end_point_solid = IconData(
     0xeb4b,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData engineering_group = IconData(
     0xf362,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData entitlement_policy = IconData(
     0xe346,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData entitlement_redemption = IconData(
     0xe347,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData entity_extraction = IconData(
     0xe467,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData entry_decline = IconData(
     0xf555,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData entry_view = IconData(
     0xf554,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData equalizer = IconData(
     0xe9e9,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData erase_tool = IconData(
     0xe75c,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData error = IconData(
     0xe783,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData error_badge = IconData(
     0xea39,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData error_badge12 = IconData(
     0xe558,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData event = IconData(
     0xeca3,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData event12 = IconData(
     0xf763,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData event_accepted = IconData(
     0xf422,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData event_date = IconData(
     0xf059,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData event_date_missed12 = IconData(
     0xf764,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData event_declined = IconData(
     0xf425,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData event_info = IconData(
     0xed8b,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData event_tentative = IconData(
     0xf423,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData event_tentative_mirrored = IconData(
     0xf424,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData event_to_do_logo = IconData(
     0xf869,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData excel_document = IconData(
     0xef73,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData excel_logo = IconData(
     0xf1e5,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData excel_logo16 = IconData(
     0xf397,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData excel_logo_inverse = IconData(
     0xec28,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData excel_logo_inverse16 = IconData(
     0xf396,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData exchange_logo = IconData(
     0xf284,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData exchange_logo_inverse = IconData(
     0xed78,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData exercise_tracker = IconData(
     0xeacc,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData expand_all = IconData(
     0xf859,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData expand_menu = IconData(
     0xef67,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData explore_content = IconData(
     0xeccd,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData explore_content_single = IconData(
     0xf164,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData explore_data = IconData(
     0xf5b6,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData export = IconData(
     0xede1,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData export_mirrored = IconData(
     0xede2,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData express_route_circuits = IconData(
     0xe557,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData external_build = IconData(
     0xf445,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData external_t_f_v_c = IconData(
     0xf446,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData external_user = IconData(
     0xe4ca,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData external_x_a_m_l = IconData(
     0xf447,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData eye_shadow = IconData(
     0xf7eb,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData eyedropper = IconData(
     0xef3c,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData f12_dev_tools = IconData(
     0xebee,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData f_sharp = IconData(
     0xf2f6,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData f_sharp_language = IconData(
     0xf2f5,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData fabric_asset_library = IconData(
     0xf09c,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData fabric_channel_folder = IconData(
     0xe4fa,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData fabric_data_connection_library = IconData(
     0xf09d,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData fabric_doc_library = IconData(
     0xf09e,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData fabric_folder = IconData(
     0xf0a9,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData fabric_folder_confirm = IconData(
     0xf7ff,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData fabric_folder_fill = IconData(
     0xf0aa,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData fabric_folder_link = IconData(
     0xe45c,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData fabric_folder_search = IconData(
     0xf0a4,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData fabric_folder_upload = IconData(
     0xe3ac,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData fabric_form_library = IconData(
     0xf09f,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData fabric_form_library_mirrored = IconData(
     0xf0a0,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData fabric_moveto_folder = IconData(
     0xf0a5,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData fabric_network_folder = IconData(
     0xf5e6,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData fabric_new_folder = IconData(
     0xf0ab,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData fabric_open_folder_horizontal = IconData(
     0xf0a8,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData fabric_picture_library = IconData(
     0xf0ac,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData fabric_public_folder = IconData(
     0xf0a3,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData fabric_report_library = IconData(
     0xf0a1,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData fabric_report_library_mirrored = IconData(
     0xf0a2,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData fabric_sync_folder = IconData(
     0xf0a7,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData fabric_text_highlight = IconData(
     0xf79c,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData fabric_text_highlight_composite = IconData(
     0xf7da,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData fabric_unsync_folder = IconData(
     0xf0a6,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData fabric_user_folder = IconData(
     0xf5e5,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData factory = IconData(
     0xe60e,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData family = IconData(
     0xebda,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData fang_body = IconData(
     0xeceb,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData fast_forward = IconData(
     0xeb9d,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData fast_forward_eight_x = IconData(
     0xe443,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData fast_forward_four_x = IconData(
     0xe442,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData fast_forward_one_five_x = IconData(
     0xe440,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData fast_forward_one_x = IconData(
     0xe43f,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData fast_forward_point_five_x = IconData(
     0xe43e,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData fast_forward_two_x = IconData(
     0xe441,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData fast_mode = IconData(
     0xf19a,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData favicon = IconData(
     0xe737,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData favorite_block = IconData(
     0xe67e,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData favorite_list = IconData(
     0xe728,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData favorite_star = IconData(
     0xe734,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData favorite_star_fill = IconData(
     0xe735,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData fax = IconData(
     0xef5c,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData feedback = IconData(
     0xed15,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData feedback_request_mirrored_solid = IconData(
     0xf35a,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData feedback_request_solid = IconData(
     0xf359,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData feedback_response_solid = IconData(
     0xf35b,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData ferry = IconData(
     0xe7e3,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData ferry_solid = IconData(
     0xeb48,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData field_changed = IconData(
     0xf2c3,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData field_empty = IconData(
     0xf2c1,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData field_filled = IconData(
     0xf2c2,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData field_not_changed = IconData(
     0xf2c4,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData field_read_only = IconData(
     0xf442,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData field_required = IconData(
     0xf443,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData file_a_s_p_x = IconData(
     0xf2e9,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData file_bug = IconData(
     0xf30d,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData file_c_s_s = IconData(
     0xf2ea,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData file_code = IconData(
     0xf30e,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData file_comment = IconData(
     0xf30f,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData file_h_t_m_l = IconData(
     0xf2ed,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData file_image = IconData(
     0xf311,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData file_j_a_v_a = IconData(
     0xf2e8,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData file_less = IconData(
     0xf2ec,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData file_off = IconData(
     0xe3fc,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData file_p_d_b = IconData(
     0xf2e5,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData file_request = IconData(
     0xf789,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData file_s_q_l = IconData(
     0xf2e7,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData file_sass = IconData(
     0xf2eb,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData file_symlink = IconData(
     0xf312,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData file_system = IconData(
     0xe433,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData file_template = IconData(
     0xf2e6,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData file_type_solution = IconData(
     0xf387,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData file_y_m_l = IconData(
     0xf5da,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData filter = IconData(
     0xe71c,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData filter_ascending = IconData(
     0xf21a,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData filter_descending = IconData(
     0xf21b,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData filter_settings = IconData(
     0xf76c,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData filter_solid = IconData(
     0xf412,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData filters = IconData(
     0xe795,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData filters_solid = IconData(
     0xf353,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData financial = IconData(
     0xe7bb,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData financial_mirrored_solid = IconData(
     0xf347,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData financial_solid = IconData(
     0xf346,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData fingerprint = IconData(
     0xe928,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData fit_page = IconData(
     0xe9a6,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData fit_width = IconData(
     0xe9a7,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData five_tile_grid = IconData(
     0xf274,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData fixed_asset_management = IconData(
     0xef93,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData fixed_column_width = IconData(
     0xe3ea,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData flag = IconData(
     0xe7c1,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData flame_solid = IconData(
     0xf1f3,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData flash_auto = IconData(
     0xe95c,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData flash_off = IconData(
     0xea6e,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData flashlight = IconData(
     0xe754,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData flick_down = IconData(
     0xe935,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData flick_left = IconData(
     0xe937,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData flick_right = IconData(
     0xe938,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData flick_up = IconData(
     0xe936,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData flow = IconData(
     0xef90,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData flow_chart = IconData(
     0xe9d4,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData flow_template = IconData(
     0xe49c,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData flow_trigger = IconData(
     0xe60c,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData flower = IconData(
     0xf54e,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData fluid_logo = IconData(
     0xe48a,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData focal_point = IconData(
     0xf277,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData focus = IconData(
     0xea6f,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData focus_view = IconData(
     0xf1a3,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData fog = IconData(
     0xe9cb,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData folder = IconData(
     0xe8b7,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData folder_fill = IconData(
     0xe8d5,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData folder_horizontal = IconData(
     0xf12b,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData folder_list = IconData(
     0xf2ce,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData folder_list_mirrored = IconData(
     0xf2cf,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData folder_open = IconData(
     0xe838,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData folder_query = IconData(
     0xf2cd,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData folder_search = IconData(
     0xef65,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData follow_user = IconData(
     0xee05,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData font = IconData(
     0xe8d2,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData font_color = IconData(
     0xe8d3,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData font_color_a = IconData(
     0xf4ec,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData font_color_korean = IconData(
     0xe5be,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData font_color_swatch = IconData(
     0xf4ed,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData font_decrease = IconData(
     0xe8e7,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData font_increase = IconData(
     0xe8e8,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData font_size = IconData(
     0xe8e9,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData font_size2 = IconData(
     0xe3c0,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData font_style_korean = IconData(
     0xe5ba,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData footer = IconData(
     0xf82e,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData form_library = IconData(
     0xeeb9,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData form_library_mirrored = IconData(
     0xeeba,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData form_processing = IconData(
     0xe48b,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData format_painter = IconData(
     0xe3dc,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData forum = IconData(
     0xe378,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData forward = IconData(
     0xe72a,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData forward_event = IconData(
     0xed8c,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData freezing = IconData(
     0xe9ef,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData freezing_rain = IconData(
     0xe475,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData frigid = IconData(
     0xe9ca,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData front_camera = IconData(
     0xe96b,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData full_circle_mask = IconData(
     0xe91f,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData full_history = IconData(
     0xf31c,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData full_screen = IconData(
     0xe740,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData full_view = IconData(
     0xf1a2,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData full_width = IconData(
     0xf2fe,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData full_width_edit = IconData(
     0xf2ff,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData functional_manager_dashboard = IconData(
     0xf542,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData funnel_chart = IconData(
     0xe9f1,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData gallatin_logo = IconData(
     0xf496,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData game = IconData(
     0xe7fc,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData gather = IconData(
     0xe460,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData generate = IconData(
     0xe9da,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData generic_scan = IconData(
     0xee6f,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData generic_scan_filled = IconData(
     0xf7e3,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData gif = IconData(
     0xf4a9,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData gift_box_solid = IconData(
     0xf341,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData gift_card = IconData(
     0xeb8e,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData giftbox = IconData(
     0xec1f,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData giftbox_open = IconData(
     0xf133,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData git_graph = IconData(
     0xf2ca,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData glasses = IconData(
     0xea16,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData glimmer = IconData(
     0xecf4,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData global_nav_button = IconData(
     0xe700,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData global_nav_button_active = IconData(
     0xf89f,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData globe = IconData(
     0xe774,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData globe2 = IconData(
     0xf49a,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData globe_favorite = IconData(
     0xef53,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData go = IconData(
     0xe8ad,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData go_mirrored = IconData(
     0xea4f,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData go_to_dashboard = IconData(
     0xeeed,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData golf = IconData(
     0xeb1f,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData goto_today = IconData(
     0xe8d1,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData graph_symbol = IconData(
     0xe35d,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData greeting_card = IconData(
     0xf54b,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData grid_view_large = IconData(
     0xf234,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData grid_view_medium = IconData(
     0xf233,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData grid_view_small = IconData(
     0xf232,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData gripper_bar_horizontal = IconData(
     0xe76f,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData gripper_bar_vertical = IconData(
     0xe784,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData gripper_dots_vertical = IconData(
     0xf772,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData gripper_tool = IconData(
     0xe75e,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData group = IconData(
     0xe902,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData group_list = IconData(
     0xf168,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData group_object = IconData(
     0xf4f1,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData group_remove = IconData(
     0xe495,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData grouped_ascending = IconData(
     0xee67,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData grouped_descending = IconData(
     0xee66,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData grouped_list = IconData(
     0xef74,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData guid = IconData(
     0xf52b,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData guitar = IconData(
     0xf49b,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData hail_day = IconData(
     0xea00,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData hail_night = IconData(
     0xea13,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData half_alpha = IconData(
     0xe97e,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData half_circle = IconData(
     0xf501,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData hands_free = IconData(
     0xead0,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData handwriting = IconData(
     0xe929,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData hard_drive = IconData(
     0xeda2,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData hard_drive_group = IconData(
     0xf18f,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData hard_drive_lock = IconData(
     0xf55a,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData hard_drive_unlock = IconData(
     0xf55b,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData hazy_day = IconData(
     0xe46b,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData hazy_night = IconData(
     0xe479,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData header = IconData(
     0xf82f,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData header1 = IconData(
     0xea19,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData header2 = IconData(
     0xef36,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData header3 = IconData(
     0xef37,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData header4 = IconData(
     0xef38,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData headset = IconData(
     0xe95b,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData headset_solid = IconData(
     0xf348,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData health = IconData(
     0xe95e,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData health_refresh = IconData(
     0xe3bd,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData health_solid = IconData(
     0xf33f,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData heart = IconData(
     0xeb51,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData heart_broken = IconData(
     0xea92,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData heart_fill = IconData(
     0xeb52,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData help = IconData(
     0xe897,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData help_mirrored = IconData(
     0xea51,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData hexadite_investigation = IconData(
     0xe3f8,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData hexadite_investigation_cancel = IconData(
     0xe3f9,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData hexadite_investigation_semi_auto = IconData(
     0xe3fa,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData hexagon = IconData(
     0xf4fe,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData hide = IconData(
     0xed1a,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData hide2 = IconData(
     0xef89,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData hide3 = IconData(
     0xf6ac,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData hide_visual_filter = IconData(
     0xf403,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData highlight = IconData(
     0xe7e6,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData highlight_mapped_shapes = IconData(
     0xf2a1,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData hint_text = IconData(
     0xf50f,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData historical_weather = IconData(
     0xeb43,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData history = IconData(
     0xe81c,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData home = IconData(
     0xe80f,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData home_dropdown = IconData(
     0xe427,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData home_group = IconData(
     0xec26,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData home_solid = IconData(
     0xea8a,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData home_verify = IconData(
     0xf00e,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData horizontal_distribute_center = IconData(
     0xf4f9,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData horizontal_tab_key = IconData(
     0xe7fd,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData hospital = IconData(
     0xe91d,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData hot = IconData(
     0xece2,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData hotel = IconData(
     0xe824,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData hour_glass = IconData(
     0xea03,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData i_d_badge = IconData(
     0xf427,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData i_r_m_forward = IconData(
     0xf41f,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData i_r_m_forward_mirrored = IconData(
     0xf420,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData i_r_m_reply = IconData(
     0xf41d,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData i_r_m_reply_mirrored = IconData(
     0xf41e,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData ice = IconData(
     0xe473,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData icon_sets_flag = IconData(
     0xf2a4,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData ignore_conversation = IconData(
     0xe372,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData image_crosshair = IconData(
     0xf2c9,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData image_diff = IconData(
     0xf30b,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData image_in_a_r = IconData(
     0xe420,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData image_pixel = IconData(
     0xf30c,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData image_search = IconData(
     0xf4e8,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData import = IconData(
     0xe8b5,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData import_all_mirrored = IconData(
     0xea53,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData import_mirrored = IconData(
     0xea52,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData important = IconData(
     0xe8c9,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData inbox = IconData(
     0xf41c,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData inbox_active = IconData(
     0xe497,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData inbox_check = IconData(
     0xef64,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData incident_triangle = IconData(
     0xe814,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData incoming_call = IconData(
     0xe77e,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData increase_indent = IconData(
     0xe399,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData increase_indent_arrow = IconData(
     0xf7a1,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData increase_indent_arrow_mirrored = IconData(
     0xf7a5,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData increase_indent_hanging = IconData(
     0xe39d,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData increase_indent_hanging_mirrored = IconData(
     0xe39e,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData increase_indent_mirrored = IconData(
     0xe39a,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData increase_indent_text = IconData(
     0xf7a0,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData increase_indent_text_mirrored = IconData(
     0xf7a4,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData indent_first_line = IconData(
     0xe3dd,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData info = IconData(
     0xe946,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData info12 = IconData(
     0xe55a,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData info2 = IconData(
     0xea1f,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData info_solid = IconData(
     0xf167,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData information_barriers = IconData(
     0xf803,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData inking_tool = IconData(
     0xe76d,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData input_address = IconData(
     0xe41e,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData insert = IconData(
     0xf278,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData insert_columns_left = IconData(
     0xf64a,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData insert_columns_right = IconData(
     0xf64b,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData insert_rows_above = IconData(
     0xf64c,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData insert_rows_below = IconData(
     0xf64d,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData insert_signature_line = IconData(
     0xf677,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData insert_text_box = IconData(
     0xec7d,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData insert_text_box_korean = IconData(
     0xe5d3,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData insights = IconData(
     0xe3af,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData install_to_drive = IconData(
     0xf28d,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData installation = IconData(
     0xe311,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData intermittent_clouds_day = IconData(
     0xe46a,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData intermittent_clouds_night = IconData(
     0xe478,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData internal_investigation = IconData(
     0xf854,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData internet_sharing = IconData(
     0xe704,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData intersect_shape = IconData(
     0xf8fd,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData invoice = IconData(
     0xe9dc,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData io_t_secure = IconData(
     0xe4d6,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData iot = IconData(
     0xf22c,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData issue_solid = IconData(
     0xf448,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData issue_tracking = IconData(
     0xeec0,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData issue_tracking_mirrored = IconData(
     0xeec1,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData italic = IconData(
     0xe8db,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData italic_c = IconData(
     0xe5b2,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData italic_d = IconData(
     0xe5ce,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData italic_k = IconData(
     0xe5b6,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData italic_kazakh = IconData(
     0xe5d2,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData italic_korean = IconData(
     0xe5bc,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData italic_l = IconData(
     0xe5d1,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData italic_s = IconData(
     0xe5cf,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData italic_t = IconData(
     0xe5d0,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData java_script_language = IconData(
     0xf2ee,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData join_online_meeting = IconData(
     0xed8f,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData js = IconData(
     0xebf0,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData kaizala_logo = IconData(
     0xf492,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData key_phrase_extraction = IconData(
     0xe395,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData keyboard_classic = IconData(
     0xe765,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData knowledge_article = IconData(
     0xf000,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData knowledge_management_app = IconData(
     0xe4fc,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData label = IconData(
     0xe932,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData ladybug_solid = IconData(
     0xf44a,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData lamp = IconData(
     0xeb19,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData landscape_orientation = IconData(
     0xef6b,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData laptop_secure = IconData(
     0xf552,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData laptop_selected = IconData(
     0xec76,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData large_grid = IconData(
     0xeecb,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData learning_app = IconData(
     0xe5d8,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData learning_tools = IconData(
     0xf7db,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData leave = IconData(
     0xf627,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData leave_user = IconData(
     0xe3a8,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData library = IconData(
     0xe8f1,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData library_add_to = IconData(
     0xe60d,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData lifesaver = IconData(
     0xef62,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData lifesaver_lock = IconData(
     0xef63,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData light = IconData(
     0xe793,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData light_snow = IconData(
     0xea02,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData light_weight = IconData(
     0xf4ee,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData lightbulb = IconData(
     0xea80,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData lightbulb_solid = IconData(
     0xe681,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData lightning_bolt = IconData(
     0xe945,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData lightning_bolt_solid = IconData(
     0xe45f,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData lightning_secure = IconData(
     0xe4d3,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData like = IconData(
     0xe8e1,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData like_solid = IconData(
     0xf3bf,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData line = IconData(
     0xf4fc,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData line_chart = IconData(
     0xe9e6,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData line_spacing = IconData(
     0xf517,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData line_style = IconData(
     0xf50c,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData line_thickness = IconData(
     0xf50d,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData link = IconData(
     0xe71b,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData link12 = IconData(
     0xf6e3,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData linked_database = IconData(
     0xf779,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData linked_in_logo = IconData(
     0xf20a,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData list = IconData(
     0xea37,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData list_mirrored = IconData(
     0xea55,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData live_site = IconData(
     0xf6a6,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData local_admin = IconData(
     0xf1fb,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData locale_language = IconData(
     0xf2b7,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData location = IconData(
     0xe81d,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData location_circle = IconData(
     0xe80e,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData location_dot = IconData(
     0xe827,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData location_fill = IconData(
     0xe920,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData location_outline = IconData(
     0xf2d0,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData lock = IconData(
     0xe72e,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData lock12 = IconData(
     0xf6e6,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData lock_share = IconData(
     0xe455,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData lock_solid = IconData(
     0xe9a2,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData log_remove = IconData(
     0xf316,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData lookup_entities = IconData(
     0xf5b5,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData lower_brightness = IconData(
     0xec8a,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData lower_case = IconData(
     0xe5ee,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData lync_logo = IconData(
     0xed79,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData m365_invoicing_logo = IconData(
     0xf7c1,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData m_s_lists_connected = IconData(
     0xe601,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData m_s_n_logo = IconData(
     0xeb6c,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData m_s_n_videos = IconData(
     0xeb1c,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData m_s_n_videos_solid = IconData(
     0xf2da,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData m_s_n_volume = IconData(
     0xeb15,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData machine_learning = IconData(
     0xe3b8,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData mail = IconData(
     0xe715,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData mail_alert = IconData(
     0xed80,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData mail_attached = IconData(
     0xf774,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData mail_check = IconData(
     0xed81,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData mail_fill = IconData(
     0xe8a8,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData mail_forward = IconData(
     0xe89c,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData mail_forward_mirrored = IconData(
     0xea56,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData mail_link = IconData(
     0xefac,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData mail_low_importance = IconData(
     0xed82,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData mail_options = IconData(
     0xf82c,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData mail_pause = IconData(
     0xed83,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData mail_reminder = IconData(
     0xf418,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData mail_repeat = IconData(
     0xed84,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData mail_reply = IconData(
     0xe8ca,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData mail_reply_all = IconData(
     0xe8c2,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData mail_reply_all_mirrored = IconData(
     0xea58,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData mail_reply_mirrored = IconData(
     0xea57,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData mail_schedule = IconData(
     0xf72e,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData mail_secure = IconData(
     0xe4d4,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData mail_solid = IconData(
     0xf343,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData mail_tentative = IconData(
     0xf416,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData mail_tentative_mirrored = IconData(
     0xf417,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData mail_undelivered = IconData(
     0xf415,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData manager_self_service = IconData(
     0xee23,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData manufacturing = IconData(
     0xe99c,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData map_directions = IconData(
     0xe816,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData map_layers = IconData(
     0xe81e,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData map_pin = IconData(
     0xe707,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData map_pin12 = IconData(
     0xe3ae,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData map_pin_solid = IconData(
     0xf52e,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData mark_as_protected = IconData(
     0xf6ae,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData mark_down_language = IconData(
     0xf2fb,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData market = IconData(
     0xeafc,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData market_down = IconData(
     0xef42,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData master_database = IconData(
     0xf5ba,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData maximum_value = IconData(
     0xf5bc,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData medal = IconData(
     0xee38,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData medal_solid = IconData(
     0xf6b9,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData media = IconData(
     0xea69,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData media_add = IconData(
     0xf510,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData medical = IconData(
     0xead4,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData medical_care = IconData(
     0xe54d,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData medication_admin = IconData(
     0xe54e,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData medication_request = IconData(
     0xe54f,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData megaphone = IconData(
     0xe789,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData megaphone_solid = IconData(
     0xf332,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData memo = IconData(
     0xe77c,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData merge = IconData(
     0xe7d5,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData merge_case = IconData(
     0xefc9,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData merge_duplicate = IconData(
     0xf29a,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData message = IconData(
     0xe8bd,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData message_fill = IconData(
     0xec70,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData message_friend_request = IconData(
     0xf055,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData metrics_failure = IconData(
     0xe4ce,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData metrics_install = IconData(
     0xe4cd,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData metrics_usage = IconData(
     0xe4cc,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData mic_off = IconData(
     0xec54,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData mic_off2 = IconData(
     0xf781,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData microphone = IconData(
     0xe720,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData microsoft_staffhub_logo = IconData(
     0xf130,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData microsoft_translator_logo = IconData(
     0xf782,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData microsoft_translator_logo_blue = IconData(
     0xf853,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData microsoft_translator_logo_green = IconData(
     0xf852,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData mini_contract = IconData(
     0xe93b,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData mini_contract_mirrored = IconData(
     0xea59,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData mini_expand = IconData(
     0xe93a,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData mini_expand_mirrored = IconData(
     0xea5a,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData mini_link = IconData(
     0xe732,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData minimum_value = IconData(
     0xf5bd,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData mobile_angled = IconData(
     0xe463,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData mobile_report = IconData(
     0xf18a,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData mobile_selected = IconData(
     0xec75,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData model_app_template32 = IconData(
     0xe5fd,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData modeling_view = IconData(
     0xf871,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData money = IconData(
     0xeafd,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData more = IconData(
     0xe712,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData more_sports = IconData(
     0xeb22,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData more_vertical = IconData(
     0xf2bc,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData mosty_clear_night = IconData(
     0xe476,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData mosty_cloudy_flurries_day = IconData(
     0xe471,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData mosty_cloudy_flurries_night = IconData(
     0xe47d,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData mosty_cloudy_showers_day = IconData(
     0xe46d,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData mosty_cloudy_t_storms_day = IconData(
     0xe46f,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData mosty_cloudy_t_storms_night = IconData(
     0xe47b,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData mosty_sunny_day = IconData(
     0xe468,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData mountain_climbing = IconData(
     0xf6db,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData move = IconData(
     0xe7c2,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData move_to_folder = IconData(
     0xe8de,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData movers = IconData(
     0xebcd,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData multi_select = IconData(
     0xe762,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData multi_select_mirrored = IconData(
     0xea98,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData music_in_collection = IconData(
     0xe940,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData music_in_collection_fill = IconData(
     0xea36,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData music_note = IconData(
     0xec4f,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData mute_chat = IconData(
     0xf17a,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData my_movies_t_v = IconData(
     0xee6c,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData my_network = IconData(
     0xec27,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData n_u_i_face = IconData(
     0xeb68,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData nav2_d_map_view = IconData(
     0xe800,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData navigate_back = IconData(
     0xf2dd,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData navigate_back_mirrored = IconData(
     0xf2de,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData navigate_external_inline = IconData(
     0xf35f,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData navigate_forward = IconData(
     0xf2df,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData navigate_forward_mirrored = IconData(
     0xf2e0,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData navigation_flipper = IconData(
     0xf51d,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData network_device_scanning = IconData(
     0xe4f6,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData network_tower = IconData(
     0xec05,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData new_analytics_query = IconData(
     0xf1e0,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData new_folder = IconData(
     0xe8f4,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData new_mail = IconData(
     0xf7ea,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData new_team_project = IconData(
     0xf2b2,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData news = IconData(
     0xe900,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData news_search = IconData(
     0xf4e9,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData next = IconData(
     0xe893,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData normal_weight = IconData(
     0xf4ef,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData not_executed = IconData(
     0xf440,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData not_impacted_solid = IconData(
     0xf441,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData note_forward = IconData(
     0xed99,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData note_pinned = IconData(
     0xed9a,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData note_reply = IconData(
     0xed98,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData nuget_logo = IconData(
     0xf44c,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData number = IconData(
     0xf691,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData number_field = IconData(
     0xedc4,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData number_sequence = IconData(
     0xf52a,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData number_symbol = IconData(
     0xf7ac,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData numbered_list = IconData(
     0xea1c,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData numbered_list_mirrored = IconData(
     0xe398,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData numbered_list_number = IconData(
     0xf797,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData numbered_list_number_mirrored = IconData(
     0xf799,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData numbered_list_text = IconData(
     0xf796,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData numbered_list_text_mirrored = IconData(
     0xf798,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData o_d_link = IconData(
     0xe4bb,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData o_d_link12 = IconData(
     0xe4bc,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData o_d_shared_channel = IconData(
     0xe649,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData o_d_shared_channel12 = IconData(
     0xe64a,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData oauth = IconData(
     0xe5c3,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData object_recognition = IconData(
     0xe4ee,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData octagon = IconData(
     0xf4fd,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData oem = IconData(
     0xe74c,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData office_addins_logo = IconData(
     0xeec7,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData office_assistant_logo = IconData(
     0xedce,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData office_catch_up = IconData(
     0xe490,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData office_chat = IconData(
     0xf70f,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData office_chat_solid = IconData(
     0xf710,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData office_forms_logo = IconData(
     0xf434,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData office_forms_logo16 = IconData(
     0xf436,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData office_forms_logo24 = IconData(
     0xf43b,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData office_forms_logo_inverse = IconData(
     0xef86,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData office_forms_logo_inverse16 = IconData(
     0xf433,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData office_forms_logo_inverse24 = IconData(
     0xf43a,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData office_logo = IconData(
     0xeb6e,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData office_store_logo = IconData(
     0xedcf,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData office_video_logo = IconData(
     0xf282,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData office_video_logo_fill = IconData(
     0xf283,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData office_video_logo_inverse = IconData(
     0xed7a,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData offline_one_drive_parachute = IconData(
     0xeec8,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData offline_one_drive_parachute_disabled = IconData(
     0xeec9,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData offline_storage = IconData(
     0xec8c,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData offline_storage_solid = IconData(
     0xf34e,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData onboarding = IconData(
     0xf3ba,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData one_drive_add = IconData(
     0xef32,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData one_drive_folder16 = IconData(
     0xf53b,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData one_drive_logo = IconData(
     0xe941,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData one_note_doc_type = IconData(
     0xf04f,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData one_note_edu_logo_inverse = IconData(
     0xedd0,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData one_note_logo = IconData(
     0xf1e7,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData one_note_logo16 = IconData(
     0xf39a,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData one_note_logo_inverse = IconData(
     0xec0d,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData one_note_logo_inverse16 = IconData(
     0xf399,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData open_enrollment = IconData(
     0xef1c,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData open_file = IconData(
     0xe8e5,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData open_folder_horizontal = IconData(
     0xed25,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData open_in_new_tab = IconData(
     0xf6ab,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData open_in_new_window = IconData(
     0xe8a7,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData open_pane = IconData(
     0xe8a0,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData open_pane_mirrored = IconData(
     0xea5b,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData open_source = IconData(
     0xebc2,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData open_with = IconData(
     0xe7ac,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData open_with_mirrored = IconData(
     0xea5c,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData opportunities = IconData(
     0xf05f,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData order_lock = IconData(
     0xe4cb,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData org = IconData(
     0xeca6,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData orientation = IconData(
     0xe8b4,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData orientation2 = IconData(
     0xf7e1,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData out_of_office = IconData(
     0xed34,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData outlook_logo = IconData(
     0xf1e9,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData outlook_logo16 = IconData(
     0xf39d,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData outlook_logo_inverse = IconData(
     0xeb6d,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData outlook_logo_inverse16 = IconData(
     0xf39c,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData outlook_spaces_bucket = IconData(
     0xe481,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData p_a_action = IconData(
     0xe60b,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData p_b_i_anomalies_marker = IconData(
     0xe554,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData p_b_i_anomaly = IconData(
     0xe548,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData p_b_i_column = IconData(
     0xe67a,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData p_b_i_connect_points = IconData(
     0xe67b,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData p_b_i_direct_query = IconData(
     0xe4e9,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData p_b_i_dual = IconData(
     0xe4ea,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData p_b_i_gap = IconData(
     0xe67c,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData p_b_i_goal_entry = IconData(
     0xe615,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData p_b_i_goal_entry_add = IconData(
     0xe616,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData p_b_i_home_layout_default = IconData(
     0xe65b,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData p_b_i_home_layout_expanded = IconData(
     0xe65c,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData p_b_i_import = IconData(
     0xe4eb,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData p_b_i_live_connect = IconData(
     0xe4ec,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData p_b_i_perspective = IconData(
     0xe658,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData p_b_i_report_template = IconData(
     0xe5ec,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData p_b_i_zero = IconData(
     0xe67d,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData p_o_i_solid = IconData(
     0xf2d1,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData package = IconData(
     0xe7b8,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData packages = IconData(
     0xf318,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData padding = IconData(
     0xf518,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData padding_bottom = IconData(
     0xf51a,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData padding_left = IconData(
     0xf51b,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData padding_right = IconData(
     0xf51c,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData padding_top = IconData(
     0xf519,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData page = IconData(
     0xe7c3,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData page_add = IconData(
     0xea1a,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData page_arrow_right = IconData(
     0xefb8,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData page_block = IconData(
     0xefb5,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData page_checked_out = IconData(
     0xf02c,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData page_checkedin = IconData(
     0xf104,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData page_data = IconData(
     0xe31c,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData page_edit = IconData(
     0xefb6,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData page_header = IconData(
     0xecee,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData page_header_edit = IconData(
     0xe31d,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData page_left = IconData(
     0xe760,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData page_link = IconData(
     0xe302,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData page_list = IconData(
     0xf106,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData page_list_filter = IconData(
     0xf813,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData page_list_mirrored_solid = IconData(
     0xf33b,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData page_list_solid = IconData(
     0xf33a,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData page_lock = IconData(
     0xf43f,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData page_permission = IconData(
     0xe618,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData page_remove = IconData(
     0xefba,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData page_right = IconData(
     0xe761,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData page_shared = IconData(
     0xf02d,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData page_solid = IconData(
     0xe729,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData pano_indicator = IconData(
     0xe7b0,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData parachute = IconData(
     0xf351,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData parachute_solid = IconData(
     0xf352,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData parameter = IconData(
     0xf306,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData parking_location = IconData(
     0xe811,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData parking_location_mirrored = IconData(
     0xea5e,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData parking_mirrored_solid = IconData(
     0xf34b,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData parking_solid = IconData(
     0xf34a,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData partly_clear_night = IconData(
     0xe477,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData partly_cloudy_day = IconData(
     0xe9c0,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData partly_cloudy_night = IconData(
     0xe9c1,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData partly_sunny_day = IconData(
     0xe469,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData partly_sunny_flurries_day = IconData(
     0xe472,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData partly_sunny_showers_day = IconData(
     0xe46e,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData partly_sunny_showers_night = IconData(
     0xe47a,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData partly_sunny_t_storms_day = IconData(
     0xe470,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData partly_sunny_t_storms_night = IconData(
     0xe47c,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData party_leader = IconData(
     0xeca7,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData passive_authentication = IconData(
     0xf32a,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData password_field = IconData(
     0xf6aa,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData paste = IconData(
     0xe77f,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData paste_as_code = IconData(
     0xf5d6,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData paste_as_text = IconData(
     0xf5d5,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData pause = IconData(
     0xe769,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData payment_card = IconData(
     0xe8c7,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData pc1 = IconData(
     0xe977,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData pdf = IconData(
     0xea90,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData pen_workspace = IconData(
     0xedc6,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData pencil_reply = IconData(
     0xef7b,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData pentagon = IconData(
     0xf4ff,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData people = IconData(
     0xe716,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData people_add = IconData(
     0xea15,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData people_alert = IconData(
     0xed93,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData people_block = IconData(
     0xed91,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData people_external_share = IconData(
     0xe5ef,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData people_pause = IconData(
     0xed94,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData people_repeat = IconData(
     0xed92,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData permissions = IconData(
     0xe8d7,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData permissions_solid = IconData(
     0xf349,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData personalize = IconData(
     0xe771,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData phishing = IconData(
     0xf679,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData phishing_campaign = IconData(
     0xe48d,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData phishing_hook = IconData(
     0xe48e,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData phone = IconData(
     0xe717,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData photo = IconData(
     0xe91b,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData photo2 = IconData(
     0xeb9f,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData photo2_add = IconData(
     0xecab,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData photo2_fill = IconData(
     0xf79f,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData photo2_remove = IconData(
     0xecac,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData photo_block = IconData(
     0xe4c3,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData photo_collection = IconData(
     0xe7aa,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData photo_error = IconData(
     0xe3f7,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData photo_video_media = IconData(
     0xf0b1,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData picture = IconData(
     0xe8b9,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData picture_center = IconData(
     0xf522,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData picture_fill = IconData(
     0xf523,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData picture_library = IconData(
     0xeec2,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData picture_position = IconData(
     0xf524,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData picture_stretch = IconData(
     0xf525,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData picture_tile = IconData(
     0xf526,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData pie_double = IconData(
     0xeb04,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData pie_single = IconData(
     0xeb05,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData pie_single_solid = IconData(
     0xf530,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData pill = IconData(
     0xeacb,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData pin = IconData(
     0xe718,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData pin_solid12 = IconData(
     0xe352,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData pin_solid_off12 = IconData(
     0xe353,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData pin_to_tab = IconData(
     0xe5e5,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData pinned = IconData(
     0xe840,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData pinned_fill = IconData(
     0xe842,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData pinned_solid = IconData(
     0xf676,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData pivot_chart = IconData(
     0xf24c,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData plain_text = IconData(
     0xf834,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData plan_view = IconData(
     0xf360,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData planner_logo = IconData(
     0xedd1,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData play = IconData(
     0xe768,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData play_resume = IconData(
     0xf2c6,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData play_reverse = IconData(
     0xf3e5,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData play_reverse_resume = IconData(
     0xf3e4,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData play_solid = IconData(
     0xf5b0,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData playback_rate1x = IconData(
     0xec57,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData player_settings = IconData(
     0xef58,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData playlist_music = IconData(
     0xe93f,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData plug = IconData(
     0xf300,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData plug_connected = IconData(
     0xf302,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData plug_disconnected = IconData(
     0xf303,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData plug_solid = IconData(
     0xf301,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData poi = IconData(
     0xecaf,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData poll_results = IconData(
     0xf8a0,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData pop_expand = IconData(
     0xe49a,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData portal_app_template32 = IconData(
     0xe5fc,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData post_update = IconData(
     0xe8f3,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData power_apps = IconData(
     0xedd2,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData power_apps2_logo = IconData(
     0xf092,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData power_apps_logo = IconData(
     0xf091,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData power_apps_template = IconData(
     0xe4ac,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData power_automate_logo = IconData(
     0xf4b1,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData power_b_i_logo = IconData(
     0xea1e,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData power_b_i_logo16 = IconData(
     0xf790,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData power_b_i_logo_backplate16 = IconData(
     0xf791,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData power_button = IconData(
     0xe7e8,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData power_point_document = IconData(
     0xef72,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData power_point_logo = IconData(
     0xf1eb,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData power_point_logo16 = IconData(
     0xf394,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData power_point_logo_inverse = IconData(
     0xec2a,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData power_point_logo_inverse16 = IconData(
     0xf393,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData power_shell = IconData(
     0xf1fd,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData power_shell2 = IconData(
     0xf730,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData power_standby = IconData(
     0xe55c,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData power_virtual_agents_logo = IconData(
     0xe484,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData precipitation = IconData(
     0xe9cf,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData presence_chicklet_video = IconData(
     0xe979,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData presentation = IconData(
     0xf6e4,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData presentation12 = IconData(
     0xf6e5,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData preview = IconData(
     0xe8ff,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData preview_below = IconData(
     0xe5d5,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData preview_link = IconData(
     0xe8a1,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData preview_side_by_side = IconData(
     0xe5d6,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData previous = IconData(
     0xe892,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData primary_calendar = IconData(
     0xf4ae,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData print = IconData(
     0xe749,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData printfax_printer_file = IconData(
     0xe956,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData priority = IconData(
     0xe8d0,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData pro_football = IconData(
     0xeb27,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData pro_hockey = IconData(
     0xeb28,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData process = IconData(
     0xe9f3,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData process_advisor = IconData(
     0xe5e4,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData process_map = IconData(
     0xe9f6,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData process_meta_task = IconData(
     0xf290,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData processing = IconData(
     0xe9f5,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData processing_cancel = IconData(
     0xe403,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData processing_pause = IconData(
     0xe405,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData processing_run = IconData(
     0xe404,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData product = IconData(
     0xecdc,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData product_catalog = IconData(
     0xefe8,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData product_list = IconData(
     0xe31e,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData product_release = IconData(
     0xee2e,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData product_variant = IconData(
     0xee30,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData product_warning = IconData(
     0xe5c0,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData production_floor_management = IconData(
     0xee29,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData profile_search = IconData(
     0xef35,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData progress_loop_inner = IconData(
     0xecde,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData progress_loop_outer = IconData(
     0xecdf,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData progress_ring5 = IconData(
     0xedf6,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData progress_ring_dots = IconData(
     0xf16a,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData project_collection = IconData(
     0xf363,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData project_document = IconData(
     0xf759,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData project_logo16 = IconData(
     0xf480,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData project_logo32 = IconData(
     0xf47e,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData project_logo_inverse = IconData(
     0xedd4,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData project_management = IconData(
     0xe9de,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData promoted_database = IconData(
     0xf77d,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData pronouns = IconData(
     0xe556,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData protect_restrict = IconData(
     0xf22a,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData protected_document = IconData(
     0xe8a6,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData protection_center_logo32 = IconData(
     0xf494,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData provisioning_package = IconData(
     0xe835,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData public_calendar = IconData(
     0xef6d,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData public_contact_card = IconData(
     0xef6e,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData public_contact_card_mirrored = IconData(
     0xf230,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData public_email = IconData(
     0xef6f,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData public_folder = IconData(
     0xef70,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData publish_content = IconData(
     0xf0d4,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData publish_course = IconData(
     0xf699,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData publisher_logo = IconData(
     0xf1ed,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData publisher_logo16 = IconData(
     0xf3a0,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData publisher_logo_inverse16 = IconData(
     0xf39f,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData puzzle = IconData(
     0xea86,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData py = IconData(
     0xf2f9,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData python_language = IconData(
     0xf2f8,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData q_r_code = IconData(
     0xed14,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData qand_a = IconData(
     0xf8a2,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData qand_a_mirror = IconData(
     0xf8a3,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData quad_column = IconData(
     0xf66f,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData quantity = IconData(
     0xe9f8,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData quarter_circle = IconData(
     0xf502,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData query_list = IconData(
     0xf2b8,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData questionnaire = IconData(
     0xee19,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData questionnaire_mirrored = IconData(
     0xee4b,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData queue_advanced = IconData(
     0xe62e,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData quick_note = IconData(
     0xe70b,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData quick_note_solid = IconData(
     0xf338,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData quotes = IconData(
     0xf067,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData r = IconData(
     0xf4eb,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData radio_btn_off = IconData(
     0xecca,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData radio_btn_on = IconData(
     0xeccb,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData radio_bullet = IconData(
     0xe915,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData rain = IconData(
     0xe9c4,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData rain_showers_day = IconData(
     0xe9c3,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData rain_showers_night = IconData(
     0xea0f,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData rain_snow = IconData(
     0xe9c7,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData rate = IconData(
     0xeb07,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData raw_source = IconData(
     0xf299,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData read = IconData(
     0xe8c3,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData read_out_loud = IconData(
     0xf112,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData reading_mode = IconData(
     0xe736,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData reading_mode_solid = IconData(
     0xf33d,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData real_estate = IconData(
     0xe758,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData receipt_check = IconData(
     0xef5b,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData receipt_forward = IconData(
     0xef59,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData receipt_processing = IconData(
     0xe496,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData receipt_reply = IconData(
     0xef5a,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData receipt_tentative = IconData(
     0xf41a,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData receipt_tentative_mirrored = IconData(
     0xf41b,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData receipt_undelivered = IconData(
     0xf419,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData recent = IconData(
     0xe823,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData record2 = IconData(
     0xea3f,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData record_routing = IconData(
     0xe62d,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData recruitment_management = IconData(
     0xee12,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData rectangle_shape = IconData(
     0xf1a9,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData rectangle_shape_solid = IconData(
     0xf640,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData rectangular_clipping = IconData(
     0xf407,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData recurring_event = IconData(
     0xef5d,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData recurring_task = IconData(
     0xedb2,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData recycle_bin = IconData(
     0xef87,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData red_eye = IconData(
     0xe7b3,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData red_eye12 = IconData(
     0xe3ad,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData redeploy = IconData(
     0xf29e,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData redo = IconData(
     0xe7a6,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData refresh = IconData(
     0xe72c,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData registry_editor = IconData(
     0xf1ff,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData relationship = IconData(
     0xf003,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData release_definition = IconData(
     0xf6ea,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData release_gate = IconData(
     0xf7be,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData release_gate_check = IconData(
     0xf7bf,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData release_gate_error = IconData(
     0xf7c0,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData reminder_group = IconData(
     0xebf8,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData reminder_person = IconData(
     0xebf7,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData reminder_time = IconData(
     0xebf9,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData remote = IconData(
     0xe8af,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData remote_application = IconData(
     0xf621,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData remove = IconData(
     0xe738,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData remove_content = IconData(
     0xecc7,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData remove_event = IconData(
     0xed8a,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData remove_filter = IconData(
     0xeb08,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData remove_from_shopping_list = IconData(
     0xf7d5,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData remove_from_trash = IconData(
     0xf82b,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData remove_link = IconData(
     0xed90,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData remove_link_chain = IconData(
     0xf79a,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData remove_link_x = IconData(
     0xf79b,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData remove_occurrence = IconData(
     0xed9b,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData rename = IconData(
     0xe8ac,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData renewal_current = IconData(
     0xf545,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData renewal_future = IconData(
     0xf546,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData reopen_pages = IconData(
     0xed50,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData repair = IconData(
     0xe90f,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData repeat_all = IconData(
     0xe8ee,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData repeat_header_rows = IconData(
     0xe3eb,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData repeat_one = IconData(
     0xe8ed,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData reply = IconData(
     0xe97a,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData reply_all = IconData(
     0xee0a,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData reply_all_alt = IconData(
     0xef5f,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData reply_all_mirrored = IconData(
     0xee36,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData reply_alt = IconData(
     0xef5e,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData reply_mirrored = IconData(
     0xee35,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData repo = IconData(
     0xf2cb,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData repo_solid = IconData(
     0xf2cc,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData report_add = IconData(
     0xf52c,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData report_alert = IconData(
     0xf721,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData report_alert_mirrored = IconData(
     0xf722,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData report_document = IconData(
     0xe9f9,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData report_hacked = IconData(
     0xe730,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData report_library = IconData(
     0xeebb,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData report_library_mirrored = IconData(
     0xeebc,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData report_lock = IconData(
     0xf875,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData report_trophy = IconData(
     0xe614,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData report_warning = IconData(
     0xf569,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData rerun = IconData(
     0xf8a1,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData reservation_orders = IconData(
     0xf845,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData reset = IconData(
     0xe423,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData reset_device = IconData(
     0xed10,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData responses_menu = IconData(
     0xf768,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData return_key = IconData(
     0xe751,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData return_to_session = IconData(
     0xed24,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData rev_toggle_key = IconData(
     0xe845,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData revenue_management = IconData(
     0xf85e,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData review_request_mirrored_solid = IconData(
     0xf357,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData review_request_solid = IconData(
     0xf356,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData review_response_solid = IconData(
     0xf358,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData review_solid = IconData(
     0xf355,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData rewards_logo = IconData(
     0xed4e,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData rewards_logo_art64 = IconData(
     0xeef2,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData rewards_logo_solid = IconData(
     0xed4f,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData rewind = IconData(
     0xeb9e,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData rewind_eight_x = IconData(
     0xe449,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData rewind_four_x = IconData(
     0xe448,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData rewind_one_five_x = IconData(
     0xe446,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData rewind_one_x = IconData(
     0xe445,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData rewind_point_five_x = IconData(
     0xe444,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData rewind_two_x = IconData(
     0xe447,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData ribbon = IconData(
     0xe9d1,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData ribbon2 = IconData(
     0xf19b,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData ribbon_solid = IconData(
     0xf345,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData right_double_quote = IconData(
     0xe9b1,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData right_triangle = IconData(
     0xf500,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData ringer = IconData(
     0xea8f,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData ringer_active = IconData(
     0xe498,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData ringer_off = IconData(
     0xf2c5,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData ringer_remove = IconData(
     0xf279,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData ringer_solid = IconData(
     0xef3a,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData robot = IconData(
     0xe99a,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData rocket = IconData(
     0xf3b3,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData room = IconData(
     0xed9f,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData rotate = IconData(
     0xe7ad,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData rotate90_clockwise = IconData(
     0xf80d,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData rotate90_counter_clockwise = IconData(
     0xf80e,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData rows_child = IconData(
     0xf29c,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData rows_group = IconData(
     0xf29b,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData rugby = IconData(
     0xeb2d,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData running = IconData(
     0xeada,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData s_d_card = IconData(
     0xe7f1,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData s_i_p_move = IconData(
     0xe759,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData s_q_l_analytics_pool = IconData(
     0xe434,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData s_q_l_server_logo = IconData(
     0xe61a,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData sad = IconData(
     0xe757,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData sad_solid = IconData(
     0xf33e,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData samsung_gallery = IconData(
     0xe4e2,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData save = IconData(
     0xe74e,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData save_all = IconData(
     0xf203,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData save_and_close = IconData(
     0xf038,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData save_as = IconData(
     0xe792,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData save_template = IconData(
     0xf6ec,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData save_to_mobile = IconData(
     0xf7e0,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData saved_offline = IconData(
     0xe546,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData savings = IconData(
     0xeb0b,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData scale_up = IconData(
     0xed09,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData scale_volume = IconData(
     0xf18c,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData scatter_chart = IconData(
     0xefeb,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData schedule_event_action = IconData(
     0xf1ef,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData school_data_sync_logo = IconData(
     0xe34c,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData scope_template = IconData(
     0xf2b0,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData screen = IconData(
     0xef39,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData screen_cast = IconData(
     0xf7e2,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData screen_preview_on = IconData(
     0xf11e,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData screen_time = IconData(
     0xf182,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData script = IconData(
     0xf03a,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData scroll_up_down = IconData(
     0xec8f,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData search = IconData(
     0xe721,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData search_and_apps = IconData(
     0xe773,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData search_art64 = IconData(
     0xeef5,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData search_bookmark = IconData(
     0xf5b8,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData search_calendar = IconData(
     0xf4af,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData search_data = IconData(
     0xf3f1,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData search_issue = IconData(
     0xf09a,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData search_issue_mirrored = IconData(
     0xf09b,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData search_nearby = IconData(
     0xe820,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData secondary_nav = IconData(
     0xf814,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData section = IconData(
     0xec0c,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData sections = IconData(
     0xef76,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData security_camera = IconData(
     0xeb35,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData security_group = IconData(
     0xed85,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData security_test = IconData(
     0xe48f,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData see_do = IconData(
     0xe808,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData select_all = IconData(
     0xe8b3,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData sell = IconData(
     0xeb0c,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData semibold_weight = IconData(
     0xf4f0,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData send = IconData(
     0xe724,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData send_mirrored = IconData(
     0xea63,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData sentiment_analysis = IconData(
     0xe393,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData separator = IconData(
     0xf35e,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData server = IconData(
     0xf201,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData server_enviroment = IconData(
     0xf29f,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData server_processes = IconData(
     0xf1fe,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData service_activity = IconData(
     0xeff1,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData service_off = IconData(
     0xe3fd,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData set_action = IconData(
     0xf071,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData settings = IconData(
     0xe713,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData settings_add = IconData(
     0xe35a,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData settings_secure = IconData(
     0xe4d2,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData settings_sync = IconData(
     0xe359,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData shake_device = IconData(
     0xf80a,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData shape_solid = IconData(
     0xe422,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData shapes = IconData(
     0xec7c,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData share = IconData(
     0xe72d,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData shared_database = IconData(
     0xe3d9,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData shared_notes = IconData(
     0xf481,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData sharei_o_s = IconData(
     0xef79,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData sharepoint2013_logo_inverse = IconData(
     0xe480,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData sharepoint_app_icon16 = IconData(
     0xe365,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData sharepoint_logo = IconData(
     0xf27e,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData sharepoint_logo_inverse = IconData(
     0xed18,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData shield = IconData(
     0xea18,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData shield_alert = IconData(
     0xf7d7,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData shield_solid = IconData(
     0xf340,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData shirt = IconData(
     0xed00,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData shop = IconData(
     0xe719,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData shop_server = IconData(
     0xf2b6,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData shopping_cart = IconData(
     0xe7bf,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData shopping_cart_solid = IconData(
     0xf342,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData show_grid = IconData(
     0xf7de,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData show_results = IconData(
     0xe8bc,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData show_results_mirrored = IconData(
     0xea65,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData show_time_as = IconData(
     0xf787,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData show_visual_filter = IconData(
     0xf4de,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData showers = IconData(
     0xe46c,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData side_panel = IconData(
     0xef52,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData side_panel_mirrored = IconData(
     0xf221,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData sign_out = IconData(
     0xf3b1,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData signin = IconData(
     0xf286,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData simplified_view = IconData(
     0xe5c1,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData single_bookmark = IconData(
     0xedff,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData single_bookmark_solid = IconData(
     0xee00,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData single_column = IconData(
     0xf1d3,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData single_column_edit = IconData(
     0xf321,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData site_scan = IconData(
     0xebec,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData six_point_star = IconData(
     0xf504,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData size_legacy = IconData(
     0xe2b2,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData ski_resorts = IconData(
     0xeb45,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData skip_back10 = IconData(
     0xed3c,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData skip_forward30 = IconData(
     0xed3d,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData skype_arrow = IconData(
     0xf748,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData skype_check = IconData(
     0xef80,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData skype_circle_arrow = IconData(
     0xf747,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData skype_circle_check = IconData(
     0xef7d,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData skype_circle_clock = IconData(
     0xef7e,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData skype_circle_minus = IconData(
     0xef7f,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData skype_circle_slash = IconData(
     0xf825,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData skype_clock = IconData(
     0xef81,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData skype_for_business_logo = IconData(
     0xf0fc,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData skype_for_business_logo16 = IconData(
     0xf40f,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData skype_for_business_logo_fill = IconData(
     0xf27d,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData skype_for_business_logo_fill16 = IconData(
     0xf410,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData skype_logo = IconData(
     0xeb6f,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData skype_logo16 = IconData(
     0xf40e,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData skype_message = IconData(
     0xef83,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData skype_minus = IconData(
     0xef82,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData skype_slash = IconData(
     0xf826,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData sleet = IconData(
     0xe474,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData slider = IconData(
     0xf527,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData slider_handle_size = IconData(
     0xf528,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData slider_thumb = IconData(
     0xec13,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData slideshow = IconData(
     0xe786,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData smart_glass_remote = IconData(
     0xf80b,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData snap_to_grid = IconData(
     0xf7e4,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData snooze = IconData(
     0xf4bd,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData snow = IconData(
     0xe9c8,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData snow_shower_day = IconData(
     0xe9fd,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData snow_shower_night = IconData(
     0xea11,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData snowflake = IconData(
     0xeb46,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData soccer = IconData(
     0xeb21,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData social_listening_logo = IconData(
     0xed7c,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData sort = IconData(
     0xe8cb,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData sort_down = IconData(
     0xee69,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData sort_lines = IconData(
     0xe9d0,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData sort_lines_ascending = IconData(
     0xe43a,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData sort_up = IconData(
     0xee68,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData source = IconData(
     0xeb1b,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData spacer = IconData(
     0xf40d,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData speakers = IconData(
     0xe7f5,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData special_event = IconData(
     0xf536,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData speech = IconData(
     0xefa9,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData speech_off = IconData(
     0xf8ba,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData speed_high = IconData(
     0xec4a,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData spelling = IconData(
     0xf87b,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData split = IconData(
     0xedbc,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData split_object = IconData(
     0xf547,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData sprint = IconData(
     0xf3b0,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData squalls = IconData(
     0xe9cc,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData square_shape = IconData(
     0xf1a6,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData square_shape_solid = IconData(
     0xf63d,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData stack = IconData(
     0xf26f,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData stack_column_chart = IconData(
     0xe9fc,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData stack_indicator = IconData(
     0xe7ff,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData stacked_bar_chart = IconData(
     0xf24d,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData stacked_bar_chart_full = IconData(
     0xf668,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData stacked_column_chart2 = IconData(
     0xf666,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData stacked_column_chart2_fill = IconData(
     0xf831,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData stacked_line_chart = IconData(
     0xf24e,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData staff_notebook_logo16 = IconData(
     0xf48e,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData staff_notebook_logo32 = IconData(
     0xf48c,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData staff_notebook_logo_fill16 = IconData(
     0xf48f,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData staff_notebook_logo_fill32 = IconData(
     0xf48d,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData staff_notebook_logo_inverted16 = IconData(
     0xf491,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData staff_notebook_logo_inverted32 = IconData(
     0xf490,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData starburst = IconData(
     0xef78,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData starburst_solid = IconData(
     0xf33c,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData status_circle_block = IconData(
     0xf140,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData status_circle_block2 = IconData(
     0xf141,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData status_circle_checkmark = IconData(
     0xf13e,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData status_circle_error_x = IconData(
     0xf13d,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData status_circle_exclamation = IconData(
     0xf13c,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData status_circle_info = IconData(
     0xf13f,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData status_circle_inner = IconData(
     0xf137,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData status_circle_outer = IconData(
     0xf136,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData status_circle_question_mark = IconData(
     0xf142,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData status_circle_ring = IconData(
     0xf138,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData status_circle_sync = IconData(
     0xf143,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData status_error_full = IconData(
     0xeb90,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData status_triangle = IconData(
     0xea82,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData status_triangle_exclamation = IconData(
     0xf13b,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData status_triangle_inner = IconData(
     0xf13a,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData status_triangle_outer = IconData(
     0xf139,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData step = IconData(
     0xf241,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData step_insert = IconData(
     0xf242,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData step_shared = IconData(
     0xf243,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData step_shared_add = IconData(
     0xf244,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData step_shared_insert = IconData(
     0xf245,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData sticky_notes_outline_app_icon = IconData(
     0xe36a,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData sticky_notes_solid_app_icon = IconData(
     0xe36b,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData stock_down = IconData(
     0xeb0f,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData stock_up = IconData(
     0xeb11,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData stop = IconData(
     0xe71a,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData stop_solid = IconData(
     0xee95,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData stopwatch = IconData(
     0xe916,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData storage_acount = IconData(
     0xe435,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData storage_optical = IconData(
     0xe958,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData store_logo16 = IconData(
     0xea96,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData store_logo_med20 = IconData(
     0xea04,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData storyboard = IconData(
     0xf308,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData stream_discover = IconData(
     0xf7d9,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData stream_logo = IconData(
     0xf329,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData stream_playlist = IconData(
     0xe669,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData streaming = IconData(
     0xe93e,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData streaming_dataflow = IconData(
     0xe668,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData streaming_dataset = IconData(
     0xe667,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData streaming_off = IconData(
     0xf2bb,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData street = IconData(
     0xe913,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData streetside_split_minimize = IconData(
     0xe802,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData strikethrough = IconData(
     0xede0,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData strikethrough_korean = IconData(
     0xe5d4,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData subscribe = IconData(
     0xeda1,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData subscript = IconData(
     0xeddf,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData substitutions_in = IconData(
     0xeb31,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData subtract_shape = IconData(
     0xf8fc,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData suitcase = IconData(
     0xedd3,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData summary_chart = IconData(
     0xe9fe,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData sun_add = IconData(
     0xef69,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData sun_question_mark = IconData(
     0xef6a,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData sunny = IconData(
     0xe9bd,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData superscript = IconData(
     0xedde,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData survey_question_response = IconData(
     0xe4f2,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData survey_questions = IconData(
     0xf01b,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData sway_logo16 = IconData(
     0xf484,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData sway_logo32 = IconData(
     0xf482,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData sway_logo_fill16 = IconData(
     0xf485,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData sway_logo_fill32 = IconData(
     0xf483,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData sway_logo_inverse = IconData(
     0xed29,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData switch_user = IconData(
     0xe748,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData switch_widget = IconData(
     0xe8ab,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData switcher_start_end = IconData(
     0xe810,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData sync = IconData(
     0xe895,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData sync_error = IconData(
     0xea6a,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData sync_folder = IconData(
     0xe8f7,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData sync_occurence = IconData(
     0xf4a3,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData sync_occurence_cancel = IconData(
     0xf7e7,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData sync_status = IconData(
     0xf751,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData sync_status_solid = IconData(
     0xf752,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData sync_to_p_c = IconData(
     0xee6e,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData system = IconData(
     0xe770,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData t_f_v_c_logo = IconData(
     0xf44d,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData t_v_monitor = IconData(
     0xe7f4,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData t_v_monitor_selected = IconData(
     0xec77,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData tab = IconData(
     0xe7e9,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData tab_center = IconData(
     0xf100,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData tab_one_column = IconData(
     0xf849,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData tab_three_column = IconData(
     0xf84b,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData tab_two_column = IconData(
     0xf84a,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData table = IconData(
     0xed86,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData table_branded_column = IconData(
     0xe3f1,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData table_branded_row = IconData(
     0xe3ee,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData table_column = IconData(
     0xe4bd,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData table_computed = IconData(
     0xf8f5,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData table_first_column = IconData(
     0xe3ef,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData table_group = IconData(
     0xf6d9,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData table_header_row = IconData(
     0xe3ec,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData table_last_column = IconData(
     0xe3f0,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData table_link = IconData(
     0xf77a,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData table_permission = IconData(
     0xe619,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData table_total_row = IconData(
     0xe3ed,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData tablet = IconData(
     0xe70a,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData tablet_mode = IconData(
     0xebfc,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData tablet_selected = IconData(
     0xec74,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData tag = IconData(
     0xe8ec,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData tag_group = IconData(
     0xe3f6,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData tag_solid = IconData(
     0xf70e,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData tag_unknown = IconData(
     0xf6df,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData tag_unknown12 = IconData(
     0xf6e1,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData tag_unknown12_mirror = IconData(
     0xf6e2,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData tag_unknown_mirror = IconData(
     0xf6e0,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData task_add = IconData(
     0xe4fd,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData task_group = IconData(
     0xf2ae,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData task_group_mirrored = IconData(
     0xf2af,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData task_list = IconData(
     0xe3b6,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData task_logo = IconData(
     0xf493,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData task_manager = IconData(
     0xedb7,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData task_manager_mirrored = IconData(
     0xedb8,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData task_solid = IconData(
     0xf333,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData taskboard = IconData(
     0xf1c2,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData taxi = IconData(
     0xf4a1,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData team_favorite = IconData(
     0xf2ad,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData teams_logo = IconData(
     0xf27b,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData teams_logo16 = IconData(
     0xf40a,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData teams_logo_inverse = IconData(
     0xf27a,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData teamwork = IconData(
     0xea12,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData teeth = IconData(
     0xf4a0,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData telemarketer = IconData(
     0xe7b9,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData temporary_access_pass = IconData(
     0xe4ad,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData temporary_user = IconData(
     0xee58,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData tennis = IconData(
     0xeb33,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData test_add = IconData(
     0xe4dc,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData test_auto_solid = IconData(
     0xf3a8,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData test_beaker = IconData(
     0xf3a5,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData test_beaker_solid = IconData(
     0xf3a6,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData test_case = IconData(
     0xf3af,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData test_explore_solid = IconData(
     0xf3a7,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData test_impact_solid = IconData(
     0xf3aa,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData test_parameter = IconData(
     0xf3ad,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData test_plan = IconData(
     0xf3ab,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData test_remove = IconData(
     0xe4e1,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData test_step = IconData(
     0xf3ac,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData test_suite = IconData(
     0xf3ae,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData test_user_solid = IconData(
     0xf3a9,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData text_align_bottom = IconData(
     0xe3e2,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData text_align_middle = IconData(
     0xe3e1,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData text_align_top = IconData(
     0xe3e0,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData text_box = IconData(
     0xedc2,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData text_callout = IconData(
     0xf2a2,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData text_document = IconData(
     0xf029,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData text_document_edit = IconData(
     0xe43b,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData text_document_settings = IconData(
     0xe4aa,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData text_document_shared = IconData(
     0xf02b,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData text_field = IconData(
     0xedc3,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData text_overflow = IconData(
     0xf51f,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData text_paragraph_option = IconData(
     0xe3e3,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData text_recognition = IconData(
     0xe394,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData text_rotate270_degrees = IconData(
     0xe3e7,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData text_rotate90_degrees = IconData(
     0xe3e6,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData text_rotate_horizontal = IconData(
     0xe3e5,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData text_rotation = IconData(
     0xe3e4,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData this_p_c = IconData(
     0xec4e,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData three_quarter_circle = IconData(
     0xf503,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData thumbnail_view = IconData(
     0xe7b6,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData thumbnail_view_mirrored = IconData(
     0xea67,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData thunderstorms = IconData(
     0xe9c6,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData ticket = IconData(
     0xeb54,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData tiles = IconData(
     0xeca5,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData tiles2 = IconData(
     0xef7c,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData time_entry = IconData(
     0xef95,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData time_picker = IconData(
     0xe367,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData time_sheet = IconData(
     0xea05,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData timeline = IconData(
     0xed9c,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData timeline_delivery = IconData(
     0xf2ab,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData timeline_matrix_view = IconData(
     0xf361,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData timeline_progress = IconData(
     0xf2aa,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData timer = IconData(
     0xe91e,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData title = IconData(
     0xf23b,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData title_mirrored = IconData(
     0xf23c,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData to_do_logo_bottom = IconData(
     0xf4b3,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData to_do_logo_inverse = IconData(
     0xf4bc,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData to_do_logo_outline = IconData(
     0xf75b,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData to_do_logo_top = IconData(
     0xf4b4,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData toggle_border = IconData(
     0xec12,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData toggle_filled = IconData(
     0xec11,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData toggle_left = IconData(
     0xf19e,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData toggle_right = IconData(
     0xf19f,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData toggle_thumb = IconData(
     0xec14,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData toll = IconData(
     0xf160,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData toolbox = IconData(
     0xeced,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData total = IconData(
     0xe9df,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData touch = IconData(
     0xe815,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData touch_pointer = IconData(
     0xe7c9,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData trackers = IconData(
     0xeadf,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData trackers_mirrored = IconData(
     0xee92,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData train = IconData(
     0xe7c0,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData train_solid = IconData(
     0xeb4d,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData transfer_call = IconData(
     0xed95,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData transition = IconData(
     0xf3bc,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData transition_effect = IconData(
     0xf5b4,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData transition_pop = IconData(
     0xf5b2,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData transition_push = IconData(
     0xf5b3,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData translate = IconData(
     0xe7b2,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData transportation = IconData(
     0xebf1,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData trending12 = IconData(
     0xf62d,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData triangle_down12 = IconData(
     0xeed1,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData triangle_left12 = IconData(
     0xeed2,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData triangle_right12 = IconData(
     0xeed3,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData triangle_shape = IconData(
     0xf1a7,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData triangle_shape_solid = IconData(
     0xf63e,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData triangle_solid = IconData(
     0xea08,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData triangle_solid_down12 = IconData(
     0xeecd,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData triangle_solid_left12 = IconData(
     0xeece,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData triangle_solid_right12 = IconData(
     0xeecf,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData triangle_solid_up12 = IconData(
     0xeecc,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData triangle_up12 = IconData(
     0xeed0,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData trigger_approval = IconData(
     0xf3b2,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData trigger_auto = IconData(
     0xf24a,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData trigger_phrase = IconData(
     0xe5ff,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData trigger_user = IconData(
     0xf24b,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData trim = IconData(
     0xe78a,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData trim_end = IconData(
     0xf8bc,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData trim_start = IconData(
     0xf8bb,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData triple_column = IconData(
     0xf1d5,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData triple_column_edit = IconData(
     0xf323,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData triple_column_wide = IconData(
     0xf66e,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData trophy = IconData(
     0xed3f,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData trophy2 = IconData(
     0xf1ae,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData trophy2_solid = IconData(
     0xf337,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData turn_right = IconData(
     0xe7db,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData twelve_point_star = IconData(
     0xf505,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData type_script_language = IconData(
     0xf2f7,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData u_r_l_block = IconData(
     0xe3fe,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData umbrella = IconData(
     0xec04,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData un_set_color = IconData(
     0xf3f9,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData unavailable_offline = IconData(
     0xe545,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData underline = IconData(
     0xe8dc,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData underline_a = IconData(
     0xe5cc,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData underline_korean = IconData(
     0xe5bb,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData underline_p = IconData(
     0xe5cd,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData underline_russian = IconData(
     0xe5b8,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData underline_s = IconData(
     0xe5b4,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData underline_serbian = IconData(
     0xe5cb,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData undo = IconData(
     0xe7a7,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData uneditable = IconData(
     0xed1d,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData uneditable2 = IconData(
     0xf876,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData uneditable2_mirrored = IconData(
     0xf877,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData uneditable_mirrored = IconData(
     0xf4b9,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData uneditable_solid12 = IconData(
     0xf4b7,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData uneditable_solid_mirrored12 = IconData(
     0xf4b8,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData unfavorite = IconData(
     0xe8d9,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData ungroup_object = IconData(
     0xf4f2,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData unite_shape = IconData(
     0xf8fb,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData unknown = IconData(
     0xe9ce,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData unknown_call = IconData(
     0xed97,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData unknown_mirrored = IconData(
     0xf22e,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData unknown_mirrored_solid = IconData(
     0xf2e2,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData unknown_solid = IconData(
     0xf2e1,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData unlock = IconData(
     0xe785,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData unlock_solid = IconData(
     0xf304,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData unpin = IconData(
     0xe77a,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData unpublish_content = IconData(
     0xe31f,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData unstack_selected = IconData(
     0xe7fe,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData unsubscribe = IconData(
     0xeda0,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData unsync_folder = IconData(
     0xe8f6,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData unsync_occurence = IconData(
     0xf4a4,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData untag = IconData(
     0xf60b,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData up = IconData(
     0xe74a,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData update_restore = IconData(
     0xe777,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData upgrade_analysis = IconData(
     0xea0b,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData upload = IconData(
     0xe898,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData upper_case = IconData(
     0xe5ed,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData usb = IconData(
     0xe88e,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData user_clapper = IconData(
     0xe666,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData user_event = IconData(
     0xf69c,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData user_followed = IconData(
     0xf25c,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData user_gauge = IconData(
     0xf6ed,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData user_optional = IconData(
     0xf767,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData user_pause = IconData(
     0xf2ba,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData user_remove = IconData(
     0xf69b,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData user_sync = IconData(
     0xf2b9,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData user_warning = IconData(
     0xe368,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData user_window = IconData(
     0xe4ed,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData v_s_t_s_alt_logo1 = IconData(
     0xf382,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData v_s_t_s_alt_logo2 = IconData(
     0xf383,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData v_s_t_s_logo = IconData(
     0xf381,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData vacation = IconData(
     0xf49f,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData vaccination = IconData(
     0xeae0,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData vaccination_recent = IconData(
     0xe550,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData variable = IconData(
     0xf305,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData variable2 = IconData(
     0xf86d,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData variable3 = IconData(
     0xe4d1,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData variable_group = IconData(
     0xf31b,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData vb = IconData(
     0xf2f2,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData venn_diagram = IconData(
     0xf273,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData verified_brand = IconData(
     0xf7bd,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData verified_brand_solid = IconData(
     0xf6ad,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData version_control_push = IconData(
     0xf664,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData vertical_distribute_center = IconData(
     0xf4fa,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData video = IconData(
     0xe714,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData video360_generic = IconData(
     0xf609,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData video_add = IconData(
     0xe430,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData video_light_off = IconData(
     0xea74,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData video_off = IconData(
     0xf4b0,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData video_off2 = IconData(
     0xe43c,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData video_search = IconData(
     0xf4ea,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData video_solid = IconData(
     0xea0c,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData view = IconData(
     0xe890,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData view_all = IconData(
     0xe8a9,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData view_all2 = IconData(
     0xef56,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData view_dashboard = IconData(
     0xf246,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData view_in_a_r = IconData(
     0xe41f,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData view_list = IconData(
     0xf247,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData view_list_group = IconData(
     0xf248,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData view_list_tree = IconData(
     0xf249,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData view_original = IconData(
     0xe7b4,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData virtual_network = IconData(
     0xf815,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData visio_diagram = IconData(
     0xf2a0,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData visio_diagram_sync = IconData(
     0xf762,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData visio_document = IconData(
     0xf2a9,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData visio_logo = IconData(
     0xf2a7,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData visio_logo16 = IconData(
     0xf3a3,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData visio_logo_inverse = IconData(
     0xed7d,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData visio_logo_inverse16 = IconData(
     0xf3a2,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData visual_basic_language = IconData(
     0xf2f1,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData visual_studio_for_windows = IconData(
     0xf5d0,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData visual_studio_for_windows_alt = IconData(
     0xec22,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData visually_impaired = IconData(
     0xf866,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData visuals_folder = IconData(
     0xf520,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData visuals_store = IconData(
     0xf521,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData voicemail_forward = IconData(
     0xed87,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData voicemail_i_r_m = IconData(
     0xf421,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData voicemail_reply = IconData(
     0xed88,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData volume0 = IconData(
     0xe992,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData volume1 = IconData(
     0xe993,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData volume2 = IconData(
     0xe994,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData volume3 = IconData(
     0xe995,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData volume_disabled = IconData(
     0xea85,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData waffle = IconData(
     0xed89,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData waffle_office365 = IconData(
     0xf4e0,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData waitlist_confirm = IconData(
     0xf550,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData waitlist_confirm_mirrored = IconData(
     0xf551,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const IconData warning = IconData(
     0xe7ba,
     fontFamily: 'FluentIcons',
     fontPackage: 'fluent_ui',
   );
+
   static const Map<String, IconData> allIcons = {
     'a_a_d_logo': a_a_d_logo,
     'a_t_p_logo': a_t_p_logo,

--- a/lib/src/icons.dart
+++ b/lib/src/icons.dart
@@ -1,5 +1,7 @@
 // GENERATED FILE, DO NOT EDIT
 
+// ignore_for_file: constant_identifier_names
+
 import 'package:flutter/widgets.dart' show IconData;
 
 class FluentIcons {

--- a/lib/src/icons.dart
+++ b/lib/src/icons.dart
@@ -1,2225 +1,11071 @@
 // GENERATED FILE, DO NOT EDIT
 
-// ignore_for_file: constant_identifier_names
-
 import 'package:flutter/widgets.dart' show IconData;
 
 class FluentIcons {
   const FluentIcons._();
 
-  static const IconData a_a_d_logo = IconData(0xed68, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData a_t_p_logo = IconData(0xef85, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData accept = IconData(0xe8fb, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData accept_medium = IconData(0xf78c, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData access_logo = IconData(0xed69, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData accessibilty_checker = IconData(0xf835, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData account_activity = IconData(0xeff4, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData account_browser = IconData(0xf652, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData account_management = IconData(0xf55c, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData accounts = IconData(0xe910, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData action_center = IconData(0xe91c, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData activate_orders = IconData(0xefe0, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData activity_feed = IconData(0xf056, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData add = IconData(0xe710, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData add_bookmark = IconData(0xf5b7, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData add_connection = IconData(0xf4e1, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData add_event = IconData(0xeeb5, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData add_favorite = IconData(0xf0c8, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData add_favorite_fill = IconData(0xf0c9, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData add_field = IconData(0xe4c7, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData add_friend = IconData(0xe8fa, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData add_group = IconData(0xee3d, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData add_home = IconData(0xf17b, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData add_in = IconData(0xf775, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData add_link = IconData(0xe35e, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData add_medium = IconData(0xeca1, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData add_multiple = IconData(0xe9c5, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData add_notes = IconData(0xeae3, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData add_online_meeting = IconData(0xed8e, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData add_phone = IconData(0xed96, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData add_reaction = IconData(0xf85d, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData add_space_after = IconData(0xe3df, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData add_space_before = IconData(0xe3de, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData add_table = IconData(0xe4c6, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData add_to = IconData(0xecc8, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData add_to_shopping_list = IconData(0xea9a, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData add_work = IconData(0xf17c, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData admin = IconData(0xe7ef, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData admin_a_logo32 = IconData(0xf4ba, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData admin_a_logo_fill32 = IconData(0xf4bb, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData admin_a_logo_inverse32 = IconData(0xed6a, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData admin_c_logo_inverse32 = IconData(0xed6b, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData admin_d_logo_inverse32 = IconData(0xed6c, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData admin_e_logo_inverse32 = IconData(0xed6d, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData admin_l_logo_inverse32 = IconData(0xed6e, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData admin_m_logo_inverse32 = IconData(0xed6f, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData admin_o_logo_inverse32 = IconData(0xed70, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData admin_p_logo_inverse32 = IconData(0xed71, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData admin_s_logo_inverse32 = IconData(0xed72, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData admin_y_logo_inverse32 = IconData(0xed73, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData air_tickets = IconData(0xef7a, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData airplane = IconData(0xe709, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData airplane_solid = IconData(0xeb4c, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData alarm_clock = IconData(0xe919, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData album = IconData(0xe7ab, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData album_remove = IconData(0xec62, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData alert_settings = IconData(0xf8b6, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData alert_solid = IconData(0xf331, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData align_center = IconData(0xe8e3, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData align_horizontal_center = IconData(0xf4f4, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData align_horizontal_left = IconData(0xf4f3, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData align_horizontal_right = IconData(0xf4f5, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData align_justify = IconData(0xf51e, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData align_left = IconData(0xe8e4, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData align_right = IconData(0xe8e2, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData align_vertical_bottom = IconData(0xf4f8, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData align_vertical_center = IconData(0xf4f7, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData align_vertical_top = IconData(0xf4f6, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData all_apps = IconData(0xe71d, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData all_apps_mirrored = IconData(0xea40, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData all_currency = IconData(0xeae4, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData alt_text = IconData(0xe397, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData analytics_logo = IconData(0xf1de, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData analytics_query = IconData(0xf1df, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData analytics_report = IconData(0xf1e1, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData analytics_view = IconData(0xf5f1, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData anchor_lock = IconData(0xf511, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData annotation = IconData(0xe924, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData app_icon_default = IconData(0xecaa, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData app_icon_default_add = IconData(0xefda, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData app_icon_default_edit = IconData(0xefdc, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData app_icon_default_list = IconData(0xefde, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData app_icon_secure = IconData(0xe657, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData apps_content = IconData(0xee54, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData archive = IconData(0xf03f, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData archive_undo = IconData(0xe3a1, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData area_chart = IconData(0xe9d2, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData arrange_bring_forward = IconData(0xf509, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData arrange_bring_to_front = IconData(0xf506, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData arrange_by_from = IconData(0xf678, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData arrange_send_backward = IconData(0xf508, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData arrange_send_to_back = IconData(0xf507, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData arrivals = IconData(0xeb34, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData arrow_down_right8 = IconData(0xeed5, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData arrow_down_right_mirrored8 = IconData(0xeef0, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData arrow_tall_down_left = IconData(0xf2bf, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData arrow_tall_down_right = IconData(0xf2c0, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData arrow_tall_up_left = IconData(0xf2bd, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData arrow_tall_up_right = IconData(0xf2be, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData arrow_up_right = IconData(0xf069, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData arrow_up_right8 = IconData(0xeed4, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData arrow_up_right_mirrored8 = IconData(0xeeef, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData articles = IconData(0xeac1, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData ascending = IconData(0xedc0, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData aspect_ratio = IconData(0xe799, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData assessment_group = IconData(0xf31a, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData assessment_group_template = IconData(0xf2b1, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData asset_library = IconData(0xeeb6, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData assign = IconData(0xe9d3, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData assign_policy = IconData(0xe461, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData asterisk = IconData(0xea38, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData asterisk_solid = IconData(0xf34d, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData attach = IconData(0xe723, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData australian_rules = IconData(0xee70, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData authenticator_app = IconData(0xf6b1, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData auto_deploy_settings = IconData(0xf3fa, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData auto_enhance_off = IconData(0xe78e, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData auto_enhance_on = IconData(0xe78d, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData auto_fill_template = IconData(0xf313, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData auto_fit_contents = IconData(0xe3e8, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData auto_fit_window = IconData(0xe3e9, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData auto_height = IconData(0xf512, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData auto_racing = IconData(0xeb24, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData automate_flow = IconData(0xe3f5, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData away_status = IconData(0xee6a, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData azure_a_p_i_management = IconData(0xf37f, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData azure_data_explorer = IconData(0xe439, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData azure_icon = IconData(0xeb6a, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData azure_key_vault = IconData(0xf3b4, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData azure_service_endpoint = IconData(0xf380, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData b_i_dashboard = IconData(0xf543, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData back = IconData(0xe72b, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData back_to_window = IconData(0xe73f, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData background_color = IconData(0xf42b, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData backlog = IconData(0xf2ac, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData backlog_board = IconData(0xf444, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData backlog_list = IconData(0xf6bf, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData badge = IconData(0xec1b, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData balloons = IconData(0xed7e, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData bank = IconData(0xe825, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData bank_solid = IconData(0xf34f, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData bar_chart4 = IconData(0xeae7, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData bar_chart_horizontal = IconData(0xe9eb, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData bar_chart_vertical = IconData(0xe9ec, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData bar_chart_vertical_edit = IconData(0xf89d, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData bar_chart_vertical_fill = IconData(0xf830, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData bar_chart_vertical_filter = IconData(0xf77e, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData bar_chart_vertical_filter_solid = IconData(0xf77f, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData baseball = IconData(0xeb20, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData beer_mug = IconData(0xf49e, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData bidi_ltr = IconData(0xe9aa, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData bidi_rtl = IconData(0xe9ab, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData bill = IconData(0xe5fa, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData bing_logo = IconData(0xeb6b, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData birthday_cake = IconData(0xef8d, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData blob_storage = IconData(0xe436, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData block_contact = IconData(0xe8f8, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData blocked = IconData(0xe733, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData blocked12 = IconData(0xf62e, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData blocked2 = IconData(0xece4, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData blocked2_solid = IconData(0xf737, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData blocked_site = IconData(0xe72f, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData blocked_site_solid12 = IconData(0xf70a, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData blocked_solid = IconData(0xf531, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData blog = IconData(0xf22b, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData blowing_snow = IconData(0xe9c9, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData blur = IconData(0xf28e, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData boards = IconData(0xef68, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData bold = IconData(0xe8dd, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData bold_bulgarian = IconData(0xe5c5, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData bold_f = IconData(0xe5b5, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData bold_g = IconData(0xe5b3, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData bold_k = IconData(0xe5c6, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData bold_kazakh = IconData(0xe5c9, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData bold_korean = IconData(0xe5bd, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData bold_n = IconData(0xe5b7, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData bold_p = IconData(0xe5c7, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData bold_russion = IconData(0xe5b9, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData bold_serbian = IconData(0xe5ca, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData bold_t = IconData(0xe5c8, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData book_answers = IconData(0xf8a4, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData bookings_logo = IconData(0xedc7, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData bookmark_report = IconData(0xf76b, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData bookmarks = IconData(0xe8a4, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData bookmarks_mirrored = IconData(0xea41, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData boolean_data = IconData(0xe678, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData border_all = IconData(0xe5f4, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData border_dash = IconData(0xf50a, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData border_dot = IconData(0xf50b, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData border_inside = IconData(0xe5f3, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData border_inside_horizontal = IconData(0xe5f2, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData border_inside_vertical = IconData(0xe5f1, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData border_none = IconData(0xe5f0, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData box_addition_solid = IconData(0xf2d4, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData box_checkmark_solid = IconData(0xf2d7, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData box_multiply_solid = IconData(0xf2d5, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData box_play_solid = IconData(0xf2d6, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData box_subtract_solid = IconData(0xf2d3, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData branch_commit = IconData(0xf293, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData branch_compare = IconData(0xf294, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData branch_fork = IconData(0xf173, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData branch_fork2 = IconData(0xf291, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData branch_locked = IconData(0xf292, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData branch_merge = IconData(0xf295, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData branch_pull_request = IconData(0xf296, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData branch_search = IconData(0xf297, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData branch_shelveset = IconData(0xf298, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData breadcrumb = IconData(0xef8c, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData breakfast = IconData(0xf49c, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData brightness = IconData(0xe706, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData broom = IconData(0xea99, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData browser_screen_shot = IconData(0xebed, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData browser_tab = IconData(0xf5d7, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData browser_tab_screenshot = IconData(0xf5d8, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData brunch = IconData(0xf49d, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData brush = IconData(0xecff, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData bucket_color = IconData(0xf1b6, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData bucket_color_fill = IconData(0xf1b7, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData buffer_time_after = IconData(0xf0d0, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData buffer_time_before = IconData(0xf0cf, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData buffer_time_both = IconData(0xf0d1, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData bug = IconData(0xebe8, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData bug_action = IconData(0xe358, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData bug_block = IconData(0xe400, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData bug_solid = IconData(0xf335, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData bug_sync = IconData(0xe3ff, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData bug_warning = IconData(0xe357, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData build = IconData(0xf28f, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData build_definition = IconData(0xf6e9, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData build_issue = IconData(0xf319, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData build_queue = IconData(0xf24f, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData build_queue_new = IconData(0xf250, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData bulk_page_block = IconData(0xe553, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData bulk_upload = IconData(0xf548, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData bulleted_list = IconData(0xe8fd, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData bulleted_list2 = IconData(0xf2c7, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData bulleted_list2_mirrored = IconData(0xf2c8, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData bulleted_list_bullet = IconData(0xf793, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData bulleted_list_bullet_mirrored = IconData(0xf795, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData bulleted_list_mirrored = IconData(0xea42, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData bulleted_list_text = IconData(0xf792, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData bulleted_list_text_mirrored = IconData(0xf794, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData bulleted_tree_list = IconData(0xf84c, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData bullseye = IconData(0xf272, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData bullseye_target = IconData(0xf5f0, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData bullseye_target_add = IconData(0xe664, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData bullseye_target_delete = IconData(0xf6c1, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData bullseye_target_edit = IconData(0xe319, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData bus = IconData(0xe806, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData bus_solid = IconData(0xeb47, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData business_card = IconData(0xe5fb, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData business_center_logo = IconData(0xf4b2, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData business_hours_sign = IconData(0xf310, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData business_rule = IconData(0xe562, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData button_control = IconData(0xf6c0, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData c_c_solid = IconData(0xe4f4, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData c_plus_plus = IconData(0xf2f4, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData c_plus_plus_language = IconData(0xf2f3, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData c_r_m_lead = IconData(0xefd6, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData c_r_m_processes = IconData(0xefb1, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData c_r_m_report = IconData(0xeffe, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData c_r_m_resource_optimization_app32 = IconData(0xf6ef, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData c_r_m_services = IconData(0xefd2, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData c_sharp = IconData(0xf2f0, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData c_sharp_language = IconData(0xf2ef, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData cafe = IconData(0xec32, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData cake = IconData(0xeca4, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData calculated_table = IconData(0xe4be, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData calculator = IconData(0xe8ef, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData calculator_addition = IconData(0xe948, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData calculator_delta = IconData(0xe406, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData calculator_equal_to = IconData(0xe94e, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData calculator_group = IconData(0xe462, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData calculator_multiply = IconData(0xe947, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData calculator_not_equal_to = IconData(0xf2d2, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData calculator_percentage = IconData(0xe94c, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData calculator_subtract = IconData(0xe949, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData calendar = IconData(0xe787, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData calendar_agenda = IconData(0xee9a, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData calendar_day = IconData(0xe8bf, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData calendar_mirrored = IconData(0xed28, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData calendar_reply = IconData(0xe8f5, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData calendar_settings = IconData(0xf558, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData calendar_settings_mirrored = IconData(0xf559, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData calendar_week = IconData(0xe8c0, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData calendar_work_week = IconData(0xef51, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData calendar_year = IconData(0xe371, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData calories = IconData(0xecad, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData calories_add = IconData(0xf172, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData camera = IconData(0xe722, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData campaign_template = IconData(0xf811, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData cancel = IconData(0xe711, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData canned_chat = IconData(0xf0f2, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData canvas_app_template32 = IconData(0xe5fe, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData car = IconData(0xe804, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData care_activity = IconData(0xe549, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData care_plan = IconData(0xe54a, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData care_plan_template = IconData(0xe61e, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData caret_bottom_left_center8 = IconData(0xf365, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData caret_bottom_left_solid8 = IconData(0xf121, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData caret_bottom_right_center8 = IconData(0xf364, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData caret_bottom_right_solid8 = IconData(0xf122, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData caret_down8 = IconData(0xedd8, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData caret_down_solid8 = IconData(0xeddc, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData caret_hollow = IconData(0xe817, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData caret_hollow_mirrored = IconData(0xea45, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData caret_left8 = IconData(0xedd5, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData caret_left_solid8 = IconData(0xedd9, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData caret_right = IconData(0xf06b, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData caret_right8 = IconData(0xedd6, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData caret_right_solid8 = IconData(0xedda, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData caret_solid = IconData(0xe818, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData caret_solid16 = IconData(0xee62, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData caret_solid_alt = IconData(0xe483, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData caret_solid_down = IconData(0xf08e, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData caret_solid_left = IconData(0xf08d, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData caret_solid_mirrored = IconData(0xea46, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData caret_solid_right = IconData(0xf08f, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData caret_solid_up = IconData(0xf090, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData caret_top_left_center8 = IconData(0xf367, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData caret_top_left_solid8 = IconData(0xef54, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData caret_top_right_center8 = IconData(0xf366, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData caret_top_right_solid8 = IconData(0xef55, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData caret_up8 = IconData(0xedd7, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData caret_up_solid8 = IconData(0xeddb, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData cat = IconData(0xed7f, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData category_classification = IconData(0xe48c, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData cc = IconData(0xe7f0, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData cell_phone = IconData(0xe8ea, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData cell_split_vertical = IconData(0xe66c, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData certificate = IconData(0xeb95, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData certified_database = IconData(0xf5bb, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData change_entitlements = IconData(0xe310, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData chart = IconData(0xe999, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData chart_series = IconData(0xf513, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData chart_template = IconData(0xf812, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData chart_x_angle = IconData(0xf514, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData chart_y_angle = IconData(0xf515, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData charticulator_arrange_polar = IconData(0xe632, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData charticulator_arrange_polar_angles = IconData(0xe633, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData charticulator_band = IconData(0xe634, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData charticulator_guide_coordinator = IconData(0xe635, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData charticulator_guide_x = IconData(0xe636, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData charticulator_guide_y = IconData(0xe637, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData charticulator_legend = IconData(0xe638, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData charticulator_line = IconData(0xe639, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData charticulator_line_style_dashed = IconData(0xe63a, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData charticulator_line_style_dotted = IconData(0xe63b, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData charticulator_linking_data = IconData(0xe63c, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData charticulator_linking_sequence = IconData(0xe63d, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData charticulator_order_column = IconData(0xe63e, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData charticulator_order_row = IconData(0xe63f, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData charticulator_plot_cartesian = IconData(0xe640, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData charticulator_plot_curve = IconData(0xe641, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData charticulator_polar_coordinates = IconData(0xe642, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData charticulator_spiral = IconData(0xe643, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData charticulator_stack_radial = IconData(0xe644, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData charticulator_stack_y = IconData(0xe645, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData chat = IconData(0xe901, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData chat_bot = IconData(0xf08b, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData chat_invite_friend = IconData(0xecfe, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData chat_settings = IconData(0xe600, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData chat_solid = IconData(0xf344, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData check_list = IconData(0xe9d5, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData check_list_check = IconData(0xf7a9, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData check_list_check_mirrored = IconData(0xf7ab, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData check_list_text = IconData(0xf7a8, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData check_list_text_mirrored = IconData(0xf7aa, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData check_mark = IconData(0xe73e, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData checkbox = IconData(0xe739, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData checkbox_composite = IconData(0xe73a, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData checkbox_composite_reversed = IconData(0xe73d, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData checkbox_fill = IconData(0xe73b, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData checkbox_indeterminate = IconData(0xe73c, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData checkbox_indeterminate_combo = IconData(0xf16e, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData checked_out_by_other12 = IconData(0xf630, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData checked_out_by_you12 = IconData(0xf631, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData chevron_down = IconData(0xe70d, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData chevron_down_end = IconData(0xf5e4, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData chevron_down_end6 = IconData(0xf36f, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData chevron_down_med = IconData(0xe972, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData chevron_down_small = IconData(0xe96e, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData chevron_fold10 = IconData(0xf36a, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData chevron_left = IconData(0xe76b, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData chevron_left_end6 = IconData(0xf371, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData chevron_left_med = IconData(0xe973, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData chevron_left_small = IconData(0xe96f, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData chevron_right = IconData(0xe76c, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData chevron_right_end6 = IconData(0xf372, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData chevron_right_med = IconData(0xe974, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData chevron_right_small = IconData(0xe970, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData chevron_unfold10 = IconData(0xf369, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData chevron_up = IconData(0xe70e, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData chevron_up_end = IconData(0xe55b, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData chevron_up_end6 = IconData(0xf370, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData chevron_up_med = IconData(0xe971, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData chevron_up_small = IconData(0xe96d, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData childof = IconData(0xf82d, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData choice_column = IconData(0xe4ae, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData chopsticks = IconData(0xf4a2, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData chrome_back = IconData(0xe830, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData chrome_back_mirrored = IconData(0xea47, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData chrome_close = IconData(0xe8bb, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData chrome_full_screen = IconData(0xe92d, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData chrome_minimize = IconData(0xe921, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData chrome_restore = IconData(0xe923, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData circle_addition = IconData(0xf2e3, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData circle_addition_solid = IconData(0xf2e4, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData circle_dollar = IconData(0xeaed, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData circle_fill = IconData(0xea3b, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData circle_half_full = IconData(0xed9e, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData circle_pause = IconData(0xf2d9, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData circle_pause_solid = IconData(0xf2d8, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData circle_plus = IconData(0xeaee, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData circle_ring = IconData(0xea3a, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData circle_shape = IconData(0xf1a5, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData circle_shape_solid = IconData(0xf63c, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData circle_stop = IconData(0xf2dc, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData circle_stop_solid = IconData(0xf2db, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData city_next = IconData(0xec06, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData city_next2 = IconData(0xec07, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData class_notebook_logo16 = IconData(0xf488, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData class_notebook_logo32 = IconData(0xf486, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData class_notebook_logo_fill16 = IconData(0xf489, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData class_notebook_logo_fill32 = IconData(0xf487, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData class_notebook_logo_inverse = IconData(0xedc8, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData class_notebook_logo_inverse16 = IconData(0xf48b, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData class_notebook_logo_inverse32 = IconData(0xf48a, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData classroom_logo = IconData(0xef75, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData clear = IconData(0xe894, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData clear_filter = IconData(0xef8f, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData clear_formatting = IconData(0xeddd, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData clear_formatting_a = IconData(0xf79d, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData clear_formatting_eraser = IconData(0xf79e, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData clear_night = IconData(0xe9c2, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData clear_selection = IconData(0xe8e6, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData clear_selection_mirrored = IconData(0xea48, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData clicked = IconData(0xf268, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData clinical_impression = IconData(0xe54b, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData clipboard_list = IconData(0xf0e3, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData clipboard_list_add = IconData(0xe4ef, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData clipboard_list_mirrored = IconData(0xf0e4, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData clipboard_list_question = IconData(0xe4f0, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData clipboard_list_reply = IconData(0xe4f1, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData clipboard_solid = IconData(0xf5dc, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData clock = IconData(0xe917, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData clone_to_desktop = IconData(0xf28c, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData close_pane = IconData(0xe89f, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData close_pane_mirrored = IconData(0xea49, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData closed_caption = IconData(0xef84, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData cloud = IconData(0xe753, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData cloud_add = IconData(0xeca9, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData cloud_download = IconData(0xebd3, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData cloud_edit = IconData(0xe4c8, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData cloud_flow = IconData(0xe5ea, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData cloud_import_export = IconData(0xee55, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData cloud_link = IconData(0xe4c9, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData cloud_not_synced = IconData(0xec9c, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData cloud_printer = IconData(0xeda6, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData cloud_search = IconData(0xede4, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData cloud_secure = IconData(0xe4d5, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData cloud_upload = IconData(0xec8e, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData cloud_weather = IconData(0xe9be, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData cloudy = IconData(0xe9bf, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData cocktails = IconData(0xea9d, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData code = IconData(0xe943, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData code_edit = IconData(0xf544, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData coffee = IconData(0xeaef, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData coffee_script = IconData(0xf2fa, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData collapse_all = IconData(0xf85a, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData collapse_content = IconData(0xf165, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData collapse_content_single = IconData(0xf166, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData collapse_menu = IconData(0xef66, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData college_football = IconData(0xeb26, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData college_hoops = IconData(0xeb25, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData color = IconData(0xe790, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData color_solid = IconData(0xf354, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData column = IconData(0xe438, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData column_function = IconData(0xe4c2, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData column_left_two_thirds = IconData(0xf1d6, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData column_left_two_thirds_edit = IconData(0xf324, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData column_options = IconData(0xf317, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData column_question = IconData(0xe4c0, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData column_question_mirrored = IconData(0xe4c1, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData column_right_two_thirds = IconData(0xf1d7, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData column_right_two_thirds_edit = IconData(0xf325, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData column_sigma = IconData(0xe4bf, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData column_vertical_section = IconData(0xf81e, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData column_vertical_section_edit = IconData(0xf806, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData combine = IconData(0xedbb, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData combobox = IconData(0xf516, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData command_prompt = IconData(0xe756, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData comment = IconData(0xe90a, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData comment_active = IconData(0xf804, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData comment_add = IconData(0xf2b3, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData comment_next = IconData(0xf2b4, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData comment_previous = IconData(0xf2b5, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData comment_solid = IconData(0xe30e, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData comment_urgent = IconData(0xf307, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData commitments = IconData(0xec4d, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData common_data_service_c_d_s = IconData(0xe377, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData communication_details = IconData(0xe4cf, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData communication_details_mirrored = IconData(0xe4d0, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData communications = IconData(0xe95a, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData company_directory = IconData(0xef0d, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData company_directory_mirrored = IconData(0xef2b, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData compare = IconData(0xf057, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData compare_uneven = IconData(0xe42e, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData compass_n_w = IconData(0xe942, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData completed = IconData(0xe930, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData completed12 = IconData(0xe559, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData completed_solid = IconData(0xec61, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData compliance_audit = IconData(0xe369, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData configuration_solid = IconData(0xf334, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData confirm_event = IconData(0xe680, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData connect_contacts = IconData(0xefd4, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData connect_virtual_machine = IconData(0xee9d, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData construction_cone = IconData(0xe98f, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData construction_cone_solid = IconData(0xf339, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData contact = IconData(0xe77b, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData contact_card = IconData(0xeebd, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData contact_card_settings = IconData(0xf556, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData contact_card_settings_mirrored = IconData(0xf557, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData contact_heart = IconData(0xf862, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData contact_info = IconData(0xe779, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData contact_info_mirrored = IconData(0xea4a, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData contact_link = IconData(0xf25f, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData contact_list = IconData(0xf7e5, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData contact_lock = IconData(0xf400, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData content_feed = IconData(0xe428, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData content_settings = IconData(0xf647, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData content_understanding_app = IconData(0xe4fb, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData context_menu = IconData(0xf37c, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData contrast = IconData(0xe7a1, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData copy = IconData(0xe8c8, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData copy_edit = IconData(0xe464, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData cortana_logo_beckon_inner = IconData(0xf4c6, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData cortana_logo_beckon_outer = IconData(0xf4c7, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData cortana_logo_inner = IconData(0xe832, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData cortana_logo_outer = IconData(0xe831, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData cortana_logo_ready_inner = IconData(0xf4c8, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData cortana_logo_ready_outer = IconData(0xf4c9, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData cost_contral_ledger_admin = IconData(0xf208, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData cost_control = IconData(0xf207, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData cotton = IconData(0xeaf3, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData count = IconData(0xe9ee, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData coupon = IconData(0xf7bc, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData create_mail_rule = IconData(0xf67a, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData credit_card_bill = IconData(0xecd6, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData cricket = IconData(0xeb1e, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData critical_error_solid = IconData(0xf5c9, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData crop = IconData(0xe7a8, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData crown = IconData(0xed01, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData crown_solid = IconData(0xf336, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData css = IconData(0xebef, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData ctrl_button = IconData(0xe4b8, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData cube_shape = IconData(0xf1aa, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData cube_shape_solid = IconData(0xe421, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData currency = IconData(0xeaf5, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData custom_activity = IconData(0xeff0, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData custom_entity = IconData(0xeff7, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData custom_list = IconData(0xeebe, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData custom_list_mirrored = IconData(0xeebf, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData customer_assets = IconData(0xf426, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData customize_toolbar = IconData(0xf828, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData cut = IconData(0xe8c6, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData cycling = IconData(0xeac7, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData d365_business_central = IconData(0xf833, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData d365_core_h_r = IconData(0xf6bd, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData d365_customer_insights = IconData(0xf3c8, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData d365_customer_voice_app = IconData(0xe4f7, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData d365_project_operations = IconData(0xe432, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData d365_talent_insight = IconData(0xf6bc, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData d365_talent_learn = IconData(0xf6bb, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData dashboard_add = IconData(0xf52d, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData data_connection_library = IconData(0xeeb7, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData data_enrichment = IconData(0xe4f5, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData data_flow = IconData(0xe577, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData data_management_settings = IconData(0xefc8, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData database = IconData(0xefc7, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData database_activity = IconData(0xe670, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData database_block = IconData(0xe617, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData database_refresh = IconData(0xe67f, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData database_source = IconData(0xe30a, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData database_swap = IconData(0xe671, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData database_sync = IconData(0xf842, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData database_view = IconData(0xe437, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData dataflows = IconData(0xf7dd, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData dataflows_link = IconData(0xe366, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData dataverse = IconData(0xe659, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData date_time = IconData(0xec92, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData date_time12 = IconData(0xf38f, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData date_time2 = IconData(0xea17, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData date_time_mirrored = IconData(0xee93, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData deactivate_orders = IconData(0xefe1, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData decimals = IconData(0xf218, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData decision_solid = IconData(0xf350, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData decline_call = IconData(0xf405, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData decrease_indent = IconData(0xe39b, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData decrease_indent_arrow = IconData(0xf7a3, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData decrease_indent_arrow_mirrored = IconData(0xf7a7, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData decrease_indent_mirrored = IconData(0xe39c, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData decrease_indent_text = IconData(0xf7a2, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData decrease_indent_text_mirrored = IconData(0xf7a6, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData default_ratio = IconData(0xf529, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData default_settings = IconData(0xf648, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData defect_solid = IconData(0xf449, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData defender_app = IconData(0xe83d, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData defender_badge12 = IconData(0xf0fb, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData defender_t_v_m = IconData(0xf6b3, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData delete = IconData(0xe74d, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData delete_columns = IconData(0xf64e, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData delete_rows = IconData(0xf64f, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData delete_rows_mirrored = IconData(0xf650, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData delete_table = IconData(0xf651, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData delivery_truck = IconData(0xebf4, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData delve_analytics = IconData(0xeeee, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData delve_analytics_logo = IconData(0xedca, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData delve_logo = IconData(0xf280, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData delve_logo_fill = IconData(0xf281, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData delve_logo_inverse = IconData(0xed76, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData density_comfy = IconData(0xe4ba, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData density_default = IconData(0xe4b9, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData dependency_add = IconData(0xe344, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData dependency_remove = IconData(0xe345, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData deploy = IconData(0xf29d, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData descending = IconData(0xedc1, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData design = IconData(0xeb3c, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData desktop_flow = IconData(0xe4f3, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData desktop_screenshot = IconData(0xf5d9, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData developer_tools = IconData(0xec7a, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData device_bug = IconData(0xe424, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData device_off = IconData(0xe402, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData device_run = IconData(0xe401, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData devices2 = IconData(0xe975, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData devices3 = IconData(0xea6c, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData devices4 = IconData(0xeb66, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData diagnostic = IconData(0xe9d9, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData diagnostic_data_bar_tooltip = IconData(0xf7df, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData diagnostic_data_viewer_app = IconData(0xf568, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData dialpad = IconData(0xe75f, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData diamond = IconData(0xed02, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData diamond_solid = IconData(0xf34c, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData diamond_user = IconData(0xe4f9, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData dictionary = IconData(0xe82d, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData dictionary_remove = IconData(0xf69a, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData diet_plan_notebook = IconData(0xeac8, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData diff_inline = IconData(0xf309, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData diff_side_by_side = IconData(0xf30a, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData diploma = IconData(0xf320, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData disable_updates = IconData(0xe8d8, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData disconnect_virtual_machine = IconData(0xf873, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData dislike = IconData(0xe8e0, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData dislike_solid = IconData(0xf3c0, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData distribute_down = IconData(0xf76a, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData doc_library = IconData(0xeeb8, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData dock_left = IconData(0xe90c, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData dock_left_mirrored = IconData(0xea4c, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData dock_right = IconData(0xe90d, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData docs_logo_inverse = IconData(0xedcb, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData document = IconData(0xe8a5, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData document_approval = IconData(0xf28b, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData document_management = IconData(0xeffc, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData document_reply = IconData(0xef57, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData document_search = IconData(0xef6c, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData document_set = IconData(0xeed6, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData documentation = IconData(0xec17, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData dom = IconData(0xec8d, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData donut_chart = IconData(0xf368, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData door = IconData(0xeb75, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData double_bookmark = IconData(0xeb8f, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData double_chevron_down = IconData(0xee04, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData double_chevron_down12 = IconData(0xee97, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData double_chevron_down8 = IconData(0xf36b, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData double_chevron_left = IconData(0xedbe, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData double_chevron_left12 = IconData(0xee98, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData double_chevron_left8 = IconData(0xf36d, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData double_chevron_left_med = IconData(0xe991, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData double_chevron_left_med_mirrored = IconData(0xea4d, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData double_chevron_right = IconData(0xedbf, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData double_chevron_right12 = IconData(0xee99, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData double_chevron_right8 = IconData(0xf36e, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData double_chevron_up = IconData(0xedbd, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData double_chevron_up12 = IconData(0xee96, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData double_chevron_up8 = IconData(0xf36c, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData double_column = IconData(0xf1d4, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData double_column_edit = IconData(0xf322, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData double_down_arrow = IconData(0xf769, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData down = IconData(0xe74b, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData download = IconData(0xe896, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData download_document = IconData(0xf549, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData drag_object = IconData(0xf553, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData drill_down = IconData(0xf532, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData drill_down_solid = IconData(0xf533, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData drill_expand = IconData(0xf534, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData drill_show = IconData(0xf535, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData drill_through = IconData(0xf5b9, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData driver_off = IconData(0xe3fb, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData drm = IconData(0xeca8, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData drop = IconData(0xeb42, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData drop_shape = IconData(0xf1a8, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData drop_shape_solid = IconData(0xf63f, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData dropdown = IconData(0xedc5, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData duplicate_row = IconData(0xf82a, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData duststorm = IconData(0xe9cd, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData dynamic_list = IconData(0xe491, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData dynamic_s_m_b_logo = IconData(0xedcd, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData dynamics365_logo = IconData(0xedcc, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData e_discovery = IconData(0xe370, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData ease_of_access = IconData(0xe776, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData eat_drink = IconData(0xe807, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData edge_logo = IconData(0xe3ab, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData edge_logo16 = IconData(0xe3aa, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData edge_old_logo = IconData(0xec60, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData edit = IconData(0xe70f, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData edit_contact = IconData(0xefd3, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData edit_create = IconData(0xf3c9, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData edit_event = IconData(0xf05b, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData edit_list_pencil = IconData(0xe61b, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData edit_mail = IconData(0xef61, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData edit_mirrored = IconData(0xeb7e, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData edit_note = IconData(0xed9d, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData edit_photo = IconData(0xef77, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData edit_solid12 = IconData(0xf4b5, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData edit_solid_mirrored12 = IconData(0xf4b6, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData edit_style = IconData(0xef60, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData edit_table = IconData(0xe4c4, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData education = IconData(0xe7be, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData ellipse = IconData(0xf4fb, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData embed = IconData(0xecce, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData emi = IconData(0xe731, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData emoji = IconData(0xe899, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData emoji2 = IconData(0xe76e, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData emoji_disappointed = IconData(0xea88, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData emoji_neutral = IconData(0xea87, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData emoji_tab_symbols = IconData(0xed58, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData employee_self_service = IconData(0xee24, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData empty_recycle_bin = IconData(0xef88, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData encounter = IconData(0xe54c, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData encryption = IconData(0xf69d, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData end_point_solid = IconData(0xeb4b, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData engineering_group = IconData(0xf362, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData entitlement_policy = IconData(0xe346, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData entitlement_redemption = IconData(0xe347, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData entity_extraction = IconData(0xe467, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData entry_decline = IconData(0xf555, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData entry_view = IconData(0xf554, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData equalizer = IconData(0xe9e9, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData erase_tool = IconData(0xe75c, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData error = IconData(0xe783, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData error_badge = IconData(0xea39, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData error_badge12 = IconData(0xe558, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData event = IconData(0xeca3, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData event12 = IconData(0xf763, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData event_accepted = IconData(0xf422, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData event_date = IconData(0xf059, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData event_date_missed12 = IconData(0xf764, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData event_declined = IconData(0xf425, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData event_info = IconData(0xed8b, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData event_tentative = IconData(0xf423, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData event_tentative_mirrored = IconData(0xf424, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData event_to_do_logo = IconData(0xf869, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData excel_document = IconData(0xef73, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData excel_logo = IconData(0xf1e5, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData excel_logo16 = IconData(0xf397, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData excel_logo_inverse = IconData(0xec28, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData excel_logo_inverse16 = IconData(0xf396, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData exchange_logo = IconData(0xf284, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData exchange_logo_inverse = IconData(0xed78, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData exercise_tracker = IconData(0xeacc, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData expand_all = IconData(0xf859, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData expand_menu = IconData(0xef67, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData explore_content = IconData(0xeccd, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData explore_content_single = IconData(0xf164, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData explore_data = IconData(0xf5b6, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData export = IconData(0xede1, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData export_mirrored = IconData(0xede2, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData express_route_circuits = IconData(0xe557, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData external_build = IconData(0xf445, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData external_t_f_v_c = IconData(0xf446, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData external_user = IconData(0xe4ca, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData external_x_a_m_l = IconData(0xf447, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData eye_shadow = IconData(0xf7eb, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData eyedropper = IconData(0xef3c, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData f12_dev_tools = IconData(0xebee, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData f_sharp = IconData(0xf2f6, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData f_sharp_language = IconData(0xf2f5, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData fabric_asset_library = IconData(0xf09c, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData fabric_channel_folder = IconData(0xe4fa, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData fabric_data_connection_library = IconData(0xf09d, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData fabric_doc_library = IconData(0xf09e, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData fabric_folder = IconData(0xf0a9, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData fabric_folder_confirm = IconData(0xf7ff, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData fabric_folder_fill = IconData(0xf0aa, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData fabric_folder_link = IconData(0xe45c, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData fabric_folder_search = IconData(0xf0a4, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData fabric_folder_upload = IconData(0xe3ac, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData fabric_form_library = IconData(0xf09f, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData fabric_form_library_mirrored = IconData(0xf0a0, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData fabric_moveto_folder = IconData(0xf0a5, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData fabric_network_folder = IconData(0xf5e6, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData fabric_new_folder = IconData(0xf0ab, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData fabric_open_folder_horizontal = IconData(0xf0a8, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData fabric_picture_library = IconData(0xf0ac, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData fabric_public_folder = IconData(0xf0a3, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData fabric_report_library = IconData(0xf0a1, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData fabric_report_library_mirrored = IconData(0xf0a2, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData fabric_sync_folder = IconData(0xf0a7, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData fabric_text_highlight = IconData(0xf79c, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData fabric_text_highlight_composite = IconData(0xf7da, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData fabric_unsync_folder = IconData(0xf0a6, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData fabric_user_folder = IconData(0xf5e5, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData factory = IconData(0xe60e, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData family = IconData(0xebda, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData fang_body = IconData(0xeceb, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData fast_forward = IconData(0xeb9d, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData fast_forward_eight_x = IconData(0xe443, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData fast_forward_four_x = IconData(0xe442, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData fast_forward_one_five_x = IconData(0xe440, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData fast_forward_one_x = IconData(0xe43f, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData fast_forward_point_five_x = IconData(0xe43e, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData fast_forward_two_x = IconData(0xe441, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData fast_mode = IconData(0xf19a, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData favicon = IconData(0xe737, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData favorite_block = IconData(0xe67e, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData favorite_list = IconData(0xe728, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData favorite_star = IconData(0xe734, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData favorite_star_fill = IconData(0xe735, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData fax = IconData(0xef5c, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData feedback = IconData(0xed15, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData feedback_request_mirrored_solid = IconData(0xf35a, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData feedback_request_solid = IconData(0xf359, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData feedback_response_solid = IconData(0xf35b, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData ferry = IconData(0xe7e3, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData ferry_solid = IconData(0xeb48, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData field_changed = IconData(0xf2c3, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData field_empty = IconData(0xf2c1, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData field_filled = IconData(0xf2c2, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData field_not_changed = IconData(0xf2c4, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData field_read_only = IconData(0xf442, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData field_required = IconData(0xf443, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData file_a_s_p_x = IconData(0xf2e9, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData file_bug = IconData(0xf30d, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData file_c_s_s = IconData(0xf2ea, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData file_code = IconData(0xf30e, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData file_comment = IconData(0xf30f, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData file_h_t_m_l = IconData(0xf2ed, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData file_image = IconData(0xf311, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData file_j_a_v_a = IconData(0xf2e8, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData file_less = IconData(0xf2ec, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData file_off = IconData(0xe3fc, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData file_p_d_b = IconData(0xf2e5, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData file_request = IconData(0xf789, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData file_s_q_l = IconData(0xf2e7, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData file_sass = IconData(0xf2eb, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData file_symlink = IconData(0xf312, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData file_system = IconData(0xe433, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData file_template = IconData(0xf2e6, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData file_type_solution = IconData(0xf387, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData file_y_m_l = IconData(0xf5da, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData filter = IconData(0xe71c, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData filter_ascending = IconData(0xf21a, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData filter_descending = IconData(0xf21b, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData filter_settings = IconData(0xf76c, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData filter_solid = IconData(0xf412, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData filters = IconData(0xe795, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData filters_solid = IconData(0xf353, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData financial = IconData(0xe7bb, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData financial_mirrored_solid = IconData(0xf347, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData financial_solid = IconData(0xf346, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData fingerprint = IconData(0xe928, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData fit_page = IconData(0xe9a6, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData fit_width = IconData(0xe9a7, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData five_tile_grid = IconData(0xf274, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData fixed_asset_management = IconData(0xef93, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData fixed_column_width = IconData(0xe3ea, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData flag = IconData(0xe7c1, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData flame_solid = IconData(0xf1f3, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData flash_auto = IconData(0xe95c, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData flash_off = IconData(0xea6e, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData flashlight = IconData(0xe754, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData flick_down = IconData(0xe935, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData flick_left = IconData(0xe937, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData flick_right = IconData(0xe938, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData flick_up = IconData(0xe936, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData flow = IconData(0xef90, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData flow_chart = IconData(0xe9d4, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData flow_template = IconData(0xe49c, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData flow_trigger = IconData(0xe60c, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData flower = IconData(0xf54e, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData fluid_logo = IconData(0xe48a, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData focal_point = IconData(0xf277, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData focus = IconData(0xea6f, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData focus_view = IconData(0xf1a3, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData fog = IconData(0xe9cb, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData folder = IconData(0xe8b7, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData folder_fill = IconData(0xe8d5, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData folder_horizontal = IconData(0xf12b, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData folder_list = IconData(0xf2ce, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData folder_list_mirrored = IconData(0xf2cf, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData folder_open = IconData(0xe838, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData folder_query = IconData(0xf2cd, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData folder_search = IconData(0xef65, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData follow_user = IconData(0xee05, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData font = IconData(0xe8d2, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData font_color = IconData(0xe8d3, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData font_color_a = IconData(0xf4ec, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData font_color_korean = IconData(0xe5be, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData font_color_swatch = IconData(0xf4ed, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData font_decrease = IconData(0xe8e7, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData font_increase = IconData(0xe8e8, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData font_size = IconData(0xe8e9, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData font_size2 = IconData(0xe3c0, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData font_style_korean = IconData(0xe5ba, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData footer = IconData(0xf82e, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData form_library = IconData(0xeeb9, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData form_library_mirrored = IconData(0xeeba, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData form_processing = IconData(0xe48b, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData format_painter = IconData(0xe3dc, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData forum = IconData(0xe378, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData forward = IconData(0xe72a, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData forward_event = IconData(0xed8c, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData freezing = IconData(0xe9ef, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData freezing_rain = IconData(0xe475, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData frigid = IconData(0xe9ca, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData front_camera = IconData(0xe96b, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData full_circle_mask = IconData(0xe91f, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData full_history = IconData(0xf31c, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData full_screen = IconData(0xe740, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData full_view = IconData(0xf1a2, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData full_width = IconData(0xf2fe, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData full_width_edit = IconData(0xf2ff, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData functional_manager_dashboard = IconData(0xf542, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData funnel_chart = IconData(0xe9f1, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData gallatin_logo = IconData(0xf496, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData game = IconData(0xe7fc, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData gather = IconData(0xe460, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData generate = IconData(0xe9da, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData generic_scan = IconData(0xee6f, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData generic_scan_filled = IconData(0xf7e3, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData gif = IconData(0xf4a9, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData gift_box_solid = IconData(0xf341, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData gift_card = IconData(0xeb8e, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData giftbox = IconData(0xec1f, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData giftbox_open = IconData(0xf133, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData git_graph = IconData(0xf2ca, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData glasses = IconData(0xea16, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData glimmer = IconData(0xecf4, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData global_nav_button = IconData(0xe700, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData global_nav_button_active = IconData(0xf89f, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData globe = IconData(0xe774, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData globe2 = IconData(0xf49a, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData globe_favorite = IconData(0xef53, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData go = IconData(0xe8ad, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData go_mirrored = IconData(0xea4f, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData go_to_dashboard = IconData(0xeeed, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData golf = IconData(0xeb1f, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData goto_today = IconData(0xe8d1, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData graph_symbol = IconData(0xe35d, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData greeting_card = IconData(0xf54b, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData grid_view_large = IconData(0xf234, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData grid_view_medium = IconData(0xf233, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData grid_view_small = IconData(0xf232, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData gripper_bar_horizontal = IconData(0xe76f, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData gripper_bar_vertical = IconData(0xe784, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData gripper_dots_vertical = IconData(0xf772, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData gripper_tool = IconData(0xe75e, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData group = IconData(0xe902, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData group_list = IconData(0xf168, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData group_object = IconData(0xf4f1, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData group_remove = IconData(0xe495, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData grouped_ascending = IconData(0xee67, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData grouped_descending = IconData(0xee66, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData grouped_list = IconData(0xef74, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData guid = IconData(0xf52b, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData guitar = IconData(0xf49b, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData hail_day = IconData(0xea00, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData hail_night = IconData(0xea13, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData half_alpha = IconData(0xe97e, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData half_circle = IconData(0xf501, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData hands_free = IconData(0xead0, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData handwriting = IconData(0xe929, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData hard_drive = IconData(0xeda2, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData hard_drive_group = IconData(0xf18f, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData hard_drive_lock = IconData(0xf55a, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData hard_drive_unlock = IconData(0xf55b, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData hazy_day = IconData(0xe46b, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData hazy_night = IconData(0xe479, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData header = IconData(0xf82f, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData header1 = IconData(0xea19, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData header2 = IconData(0xef36, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData header3 = IconData(0xef37, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData header4 = IconData(0xef38, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData headset = IconData(0xe95b, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData headset_solid = IconData(0xf348, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData health = IconData(0xe95e, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData health_refresh = IconData(0xe3bd, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData health_solid = IconData(0xf33f, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData heart = IconData(0xeb51, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData heart_broken = IconData(0xea92, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData heart_fill = IconData(0xeb52, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData help = IconData(0xe897, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData help_mirrored = IconData(0xea51, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData hexadite_investigation = IconData(0xe3f8, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData hexadite_investigation_cancel = IconData(0xe3f9, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData hexadite_investigation_semi_auto = IconData(0xe3fa, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData hexagon = IconData(0xf4fe, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData hide = IconData(0xed1a, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData hide2 = IconData(0xef89, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData hide3 = IconData(0xf6ac, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData hide_visual_filter = IconData(0xf403, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData highlight = IconData(0xe7e6, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData highlight_mapped_shapes = IconData(0xf2a1, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData hint_text = IconData(0xf50f, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData historical_weather = IconData(0xeb43, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData history = IconData(0xe81c, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData home = IconData(0xe80f, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData home_dropdown = IconData(0xe427, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData home_group = IconData(0xec26, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData home_solid = IconData(0xea8a, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData home_verify = IconData(0xf00e, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData horizontal_distribute_center = IconData(0xf4f9, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData horizontal_tab_key = IconData(0xe7fd, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData hospital = IconData(0xe91d, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData hot = IconData(0xece2, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData hotel = IconData(0xe824, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData hour_glass = IconData(0xea03, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData i_d_badge = IconData(0xf427, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData i_r_m_forward = IconData(0xf41f, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData i_r_m_forward_mirrored = IconData(0xf420, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData i_r_m_reply = IconData(0xf41d, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData i_r_m_reply_mirrored = IconData(0xf41e, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData ice = IconData(0xe473, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData icon_sets_flag = IconData(0xf2a4, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData ignore_conversation = IconData(0xe372, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData image_crosshair = IconData(0xf2c9, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData image_diff = IconData(0xf30b, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData image_in_a_r = IconData(0xe420, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData image_pixel = IconData(0xf30c, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData image_search = IconData(0xf4e8, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData import = IconData(0xe8b5, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData import_all_mirrored = IconData(0xea53, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData import_mirrored = IconData(0xea52, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData important = IconData(0xe8c9, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData inbox = IconData(0xf41c, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData inbox_active = IconData(0xe497, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData inbox_check = IconData(0xef64, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData incident_triangle = IconData(0xe814, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData incoming_call = IconData(0xe77e, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData increase_indent = IconData(0xe399, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData increase_indent_arrow = IconData(0xf7a1, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData increase_indent_arrow_mirrored = IconData(0xf7a5, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData increase_indent_hanging = IconData(0xe39d, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData increase_indent_hanging_mirrored = IconData(0xe39e, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData increase_indent_mirrored = IconData(0xe39a, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData increase_indent_text = IconData(0xf7a0, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData increase_indent_text_mirrored = IconData(0xf7a4, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData indent_first_line = IconData(0xe3dd, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData info = IconData(0xe946, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData info12 = IconData(0xe55a, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData info2 = IconData(0xea1f, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData info_solid = IconData(0xf167, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData information_barriers = IconData(0xf803, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData inking_tool = IconData(0xe76d, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData input_address = IconData(0xe41e, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData insert = IconData(0xf278, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData insert_columns_left = IconData(0xf64a, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData insert_columns_right = IconData(0xf64b, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData insert_rows_above = IconData(0xf64c, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData insert_rows_below = IconData(0xf64d, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData insert_signature_line = IconData(0xf677, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData insert_text_box = IconData(0xec7d, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData insert_text_box_korean = IconData(0xe5d3, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData insights = IconData(0xe3af, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData install_to_drive = IconData(0xf28d, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData installation = IconData(0xe311, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData intermittent_clouds_day = IconData(0xe46a, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData intermittent_clouds_night = IconData(0xe478, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData internal_investigation = IconData(0xf854, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData internet_sharing = IconData(0xe704, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData intersect_shape = IconData(0xf8fd, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData invoice = IconData(0xe9dc, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData io_t_secure = IconData(0xe4d6, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData iot = IconData(0xf22c, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData issue_solid = IconData(0xf448, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData issue_tracking = IconData(0xeec0, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData issue_tracking_mirrored = IconData(0xeec1, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData italic = IconData(0xe8db, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData italic_c = IconData(0xe5b2, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData italic_d = IconData(0xe5ce, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData italic_k = IconData(0xe5b6, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData italic_kazakh = IconData(0xe5d2, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData italic_korean = IconData(0xe5bc, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData italic_l = IconData(0xe5d1, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData italic_s = IconData(0xe5cf, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData italic_t = IconData(0xe5d0, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData java_script_language = IconData(0xf2ee, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData join_online_meeting = IconData(0xed8f, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData js = IconData(0xebf0, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData kaizala_logo = IconData(0xf492, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData key_phrase_extraction = IconData(0xe395, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData keyboard_classic = IconData(0xe765, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData knowledge_article = IconData(0xf000, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData knowledge_management_app = IconData(0xe4fc, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData label = IconData(0xe932, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData ladybug_solid = IconData(0xf44a, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData lamp = IconData(0xeb19, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData landscape_orientation = IconData(0xef6b, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData laptop_secure = IconData(0xf552, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData laptop_selected = IconData(0xec76, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData large_grid = IconData(0xeecb, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData learning_app = IconData(0xe5d8, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData learning_tools = IconData(0xf7db, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData leave = IconData(0xf627, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData leave_user = IconData(0xe3a8, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData library = IconData(0xe8f1, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData library_add_to = IconData(0xe60d, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData lifesaver = IconData(0xef62, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData lifesaver_lock = IconData(0xef63, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData light = IconData(0xe793, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData light_snow = IconData(0xea02, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData light_weight = IconData(0xf4ee, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData lightbulb = IconData(0xea80, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData lightbulb_solid = IconData(0xe681, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData lightning_bolt = IconData(0xe945, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData lightning_bolt_solid = IconData(0xe45f, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData lightning_secure = IconData(0xe4d3, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData like = IconData(0xe8e1, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData like_solid = IconData(0xf3bf, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData line = IconData(0xf4fc, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData line_chart = IconData(0xe9e6, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData line_spacing = IconData(0xf517, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData line_style = IconData(0xf50c, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData line_thickness = IconData(0xf50d, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData link = IconData(0xe71b, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData link12 = IconData(0xf6e3, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData linked_database = IconData(0xf779, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData linked_in_logo = IconData(0xf20a, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData list = IconData(0xea37, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData list_mirrored = IconData(0xea55, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData live_site = IconData(0xf6a6, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData local_admin = IconData(0xf1fb, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData locale_language = IconData(0xf2b7, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData location = IconData(0xe81d, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData location_circle = IconData(0xe80e, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData location_dot = IconData(0xe827, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData location_fill = IconData(0xe920, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData location_outline = IconData(0xf2d0, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData lock = IconData(0xe72e, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData lock12 = IconData(0xf6e6, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData lock_share = IconData(0xe455, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData lock_solid = IconData(0xe9a2, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData log_remove = IconData(0xf316, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData lookup_entities = IconData(0xf5b5, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData lower_brightness = IconData(0xec8a, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData lower_case = IconData(0xe5ee, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData lync_logo = IconData(0xed79, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData m365_invoicing_logo = IconData(0xf7c1, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData m_s_lists_connected = IconData(0xe601, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData m_s_n_logo = IconData(0xeb6c, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData m_s_n_videos = IconData(0xeb1c, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData m_s_n_videos_solid = IconData(0xf2da, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData m_s_n_volume = IconData(0xeb15, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData machine_learning = IconData(0xe3b8, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData mail = IconData(0xe715, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData mail_alert = IconData(0xed80, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData mail_attached = IconData(0xf774, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData mail_check = IconData(0xed81, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData mail_fill = IconData(0xe8a8, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData mail_forward = IconData(0xe89c, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData mail_forward_mirrored = IconData(0xea56, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData mail_link = IconData(0xefac, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData mail_low_importance = IconData(0xed82, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData mail_options = IconData(0xf82c, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData mail_pause = IconData(0xed83, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData mail_reminder = IconData(0xf418, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData mail_repeat = IconData(0xed84, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData mail_reply = IconData(0xe8ca, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData mail_reply_all = IconData(0xe8c2, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData mail_reply_all_mirrored = IconData(0xea58, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData mail_reply_mirrored = IconData(0xea57, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData mail_schedule = IconData(0xf72e, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData mail_secure = IconData(0xe4d4, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData mail_solid = IconData(0xf343, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData mail_tentative = IconData(0xf416, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData mail_tentative_mirrored = IconData(0xf417, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData mail_undelivered = IconData(0xf415, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData manager_self_service = IconData(0xee23, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData manufacturing = IconData(0xe99c, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData map_directions = IconData(0xe816, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData map_layers = IconData(0xe81e, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData map_pin = IconData(0xe707, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData map_pin12 = IconData(0xe3ae, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData map_pin_solid = IconData(0xf52e, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData mark_as_protected = IconData(0xf6ae, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData mark_down_language = IconData(0xf2fb, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData market = IconData(0xeafc, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData market_down = IconData(0xef42, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData master_database = IconData(0xf5ba, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData maximum_value = IconData(0xf5bc, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData medal = IconData(0xee38, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData medal_solid = IconData(0xf6b9, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData media = IconData(0xea69, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData media_add = IconData(0xf510, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData medical = IconData(0xead4, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData medical_care = IconData(0xe54d, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData medication_admin = IconData(0xe54e, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData medication_request = IconData(0xe54f, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData megaphone = IconData(0xe789, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData megaphone_solid = IconData(0xf332, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData memo = IconData(0xe77c, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData merge = IconData(0xe7d5, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData merge_case = IconData(0xefc9, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData merge_duplicate = IconData(0xf29a, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData message = IconData(0xe8bd, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData message_fill = IconData(0xec70, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData message_friend_request = IconData(0xf055, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData metrics_failure = IconData(0xe4ce, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData metrics_install = IconData(0xe4cd, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData metrics_usage = IconData(0xe4cc, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData mic_off = IconData(0xec54, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData mic_off2 = IconData(0xf781, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData microphone = IconData(0xe720, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData microsoft_staffhub_logo = IconData(0xf130, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData microsoft_translator_logo = IconData(0xf782, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData microsoft_translator_logo_blue = IconData(0xf853, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData microsoft_translator_logo_green = IconData(0xf852, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData mini_contract = IconData(0xe93b, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData mini_contract_mirrored = IconData(0xea59, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData mini_expand = IconData(0xe93a, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData mini_expand_mirrored = IconData(0xea5a, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData mini_link = IconData(0xe732, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData minimum_value = IconData(0xf5bd, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData mobile_angled = IconData(0xe463, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData mobile_report = IconData(0xf18a, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData mobile_selected = IconData(0xec75, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData model_app_template32 = IconData(0xe5fd, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData modeling_view = IconData(0xf871, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData money = IconData(0xeafd, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData more = IconData(0xe712, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData more_sports = IconData(0xeb22, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData more_vertical = IconData(0xf2bc, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData mosty_clear_night = IconData(0xe476, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData mosty_cloudy_flurries_day = IconData(0xe471, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData mosty_cloudy_flurries_night = IconData(0xe47d, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData mosty_cloudy_showers_day = IconData(0xe46d, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData mosty_cloudy_t_storms_day = IconData(0xe46f, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData mosty_cloudy_t_storms_night = IconData(0xe47b, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData mosty_sunny_day = IconData(0xe468, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData mountain_climbing = IconData(0xf6db, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData move = IconData(0xe7c2, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData move_to_folder = IconData(0xe8de, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData movers = IconData(0xebcd, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData multi_select = IconData(0xe762, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData multi_select_mirrored = IconData(0xea98, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData music_in_collection = IconData(0xe940, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData music_in_collection_fill = IconData(0xea36, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData music_note = IconData(0xec4f, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData mute_chat = IconData(0xf17a, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData my_movies_t_v = IconData(0xee6c, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData my_network = IconData(0xec27, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData n_u_i_face = IconData(0xeb68, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData nav2_d_map_view = IconData(0xe800, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData navigate_back = IconData(0xf2dd, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData navigate_back_mirrored = IconData(0xf2de, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData navigate_external_inline = IconData(0xf35f, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData navigate_forward = IconData(0xf2df, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData navigate_forward_mirrored = IconData(0xf2e0, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData navigation_flipper = IconData(0xf51d, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData network_device_scanning = IconData(0xe4f6, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData network_tower = IconData(0xec05, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData new_analytics_query = IconData(0xf1e0, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData new_folder = IconData(0xe8f4, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData new_mail = IconData(0xf7ea, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData new_team_project = IconData(0xf2b2, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData news = IconData(0xe900, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData news_search = IconData(0xf4e9, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData next = IconData(0xe893, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData normal_weight = IconData(0xf4ef, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData not_executed = IconData(0xf440, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData not_impacted_solid = IconData(0xf441, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData note_forward = IconData(0xed99, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData note_pinned = IconData(0xed9a, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData note_reply = IconData(0xed98, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData nuget_logo = IconData(0xf44c, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData number = IconData(0xf691, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData number_field = IconData(0xedc4, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData number_sequence = IconData(0xf52a, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData number_symbol = IconData(0xf7ac, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData numbered_list = IconData(0xea1c, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData numbered_list_mirrored = IconData(0xe398, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData numbered_list_number = IconData(0xf797, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData numbered_list_number_mirrored = IconData(0xf799, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData numbered_list_text = IconData(0xf796, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData numbered_list_text_mirrored = IconData(0xf798, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData o_d_link = IconData(0xe4bb, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData o_d_link12 = IconData(0xe4bc, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData o_d_shared_channel = IconData(0xe649, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData o_d_shared_channel12 = IconData(0xe64a, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData oauth = IconData(0xe5c3, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData object_recognition = IconData(0xe4ee, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData octagon = IconData(0xf4fd, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData oem = IconData(0xe74c, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData office_addins_logo = IconData(0xeec7, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData office_assistant_logo = IconData(0xedce, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData office_catch_up = IconData(0xe490, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData office_chat = IconData(0xf70f, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData office_chat_solid = IconData(0xf710, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData office_forms_logo = IconData(0xf434, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData office_forms_logo16 = IconData(0xf436, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData office_forms_logo24 = IconData(0xf43b, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData office_forms_logo_inverse = IconData(0xef86, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData office_forms_logo_inverse16 = IconData(0xf433, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData office_forms_logo_inverse24 = IconData(0xf43a, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData office_logo = IconData(0xeb6e, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData office_store_logo = IconData(0xedcf, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData office_video_logo = IconData(0xf282, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData office_video_logo_fill = IconData(0xf283, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData office_video_logo_inverse = IconData(0xed7a, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData offline_one_drive_parachute = IconData(0xeec8, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData offline_one_drive_parachute_disabled = IconData(0xeec9, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData offline_storage = IconData(0xec8c, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData offline_storage_solid = IconData(0xf34e, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData onboarding = IconData(0xf3ba, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData one_drive_add = IconData(0xef32, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData one_drive_folder16 = IconData(0xf53b, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData one_drive_logo = IconData(0xe941, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData one_note_doc_type = IconData(0xf04f, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData one_note_edu_logo_inverse = IconData(0xedd0, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData one_note_logo = IconData(0xf1e7, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData one_note_logo16 = IconData(0xf39a, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData one_note_logo_inverse = IconData(0xec0d, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData one_note_logo_inverse16 = IconData(0xf399, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData open_enrollment = IconData(0xef1c, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData open_file = IconData(0xe8e5, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData open_folder_horizontal = IconData(0xed25, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData open_in_new_tab = IconData(0xf6ab, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData open_in_new_window = IconData(0xe8a7, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData open_pane = IconData(0xe8a0, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData open_pane_mirrored = IconData(0xea5b, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData open_source = IconData(0xebc2, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData open_with = IconData(0xe7ac, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData open_with_mirrored = IconData(0xea5c, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData opportunities = IconData(0xf05f, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData order_lock = IconData(0xe4cb, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData org = IconData(0xeca6, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData orientation = IconData(0xe8b4, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData orientation2 = IconData(0xf7e1, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData out_of_office = IconData(0xed34, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData outlook_logo = IconData(0xf1e9, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData outlook_logo16 = IconData(0xf39d, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData outlook_logo_inverse = IconData(0xeb6d, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData outlook_logo_inverse16 = IconData(0xf39c, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData outlook_spaces_bucket = IconData(0xe481, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData p_a_action = IconData(0xe60b, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData p_b_i_anomalies_marker = IconData(0xe554, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData p_b_i_anomaly = IconData(0xe548, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData p_b_i_column = IconData(0xe67a, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData p_b_i_connect_points = IconData(0xe67b, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData p_b_i_direct_query = IconData(0xe4e9, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData p_b_i_dual = IconData(0xe4ea, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData p_b_i_gap = IconData(0xe67c, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData p_b_i_goal_entry = IconData(0xe615, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData p_b_i_goal_entry_add = IconData(0xe616, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData p_b_i_home_layout_default = IconData(0xe65b, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData p_b_i_home_layout_expanded = IconData(0xe65c, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData p_b_i_import = IconData(0xe4eb, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData p_b_i_live_connect = IconData(0xe4ec, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData p_b_i_perspective = IconData(0xe658, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData p_b_i_report_template = IconData(0xe5ec, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData p_b_i_zero = IconData(0xe67d, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData p_o_i_solid = IconData(0xf2d1, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData package = IconData(0xe7b8, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData packages = IconData(0xf318, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData padding = IconData(0xf518, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData padding_bottom = IconData(0xf51a, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData padding_left = IconData(0xf51b, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData padding_right = IconData(0xf51c, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData padding_top = IconData(0xf519, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData page = IconData(0xe7c3, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData page_add = IconData(0xea1a, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData page_arrow_right = IconData(0xefb8, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData page_block = IconData(0xefb5, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData page_checked_out = IconData(0xf02c, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData page_checkedin = IconData(0xf104, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData page_data = IconData(0xe31c, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData page_edit = IconData(0xefb6, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData page_header = IconData(0xecee, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData page_header_edit = IconData(0xe31d, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData page_left = IconData(0xe760, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData page_link = IconData(0xe302, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData page_list = IconData(0xf106, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData page_list_filter = IconData(0xf813, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData page_list_mirrored_solid = IconData(0xf33b, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData page_list_solid = IconData(0xf33a, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData page_lock = IconData(0xf43f, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData page_permission = IconData(0xe618, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData page_remove = IconData(0xefba, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData page_right = IconData(0xe761, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData page_shared = IconData(0xf02d, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData page_solid = IconData(0xe729, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData pano_indicator = IconData(0xe7b0, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData parachute = IconData(0xf351, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData parachute_solid = IconData(0xf352, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData parameter = IconData(0xf306, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData parking_location = IconData(0xe811, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData parking_location_mirrored = IconData(0xea5e, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData parking_mirrored_solid = IconData(0xf34b, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData parking_solid = IconData(0xf34a, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData partly_clear_night = IconData(0xe477, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData partly_cloudy_day = IconData(0xe9c0, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData partly_cloudy_night = IconData(0xe9c1, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData partly_sunny_day = IconData(0xe469, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData partly_sunny_flurries_day = IconData(0xe472, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData partly_sunny_showers_day = IconData(0xe46e, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData partly_sunny_showers_night = IconData(0xe47a, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData partly_sunny_t_storms_day = IconData(0xe470, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData partly_sunny_t_storms_night = IconData(0xe47c, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData party_leader = IconData(0xeca7, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData passive_authentication = IconData(0xf32a, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData password_field = IconData(0xf6aa, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData paste = IconData(0xe77f, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData paste_as_code = IconData(0xf5d6, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData paste_as_text = IconData(0xf5d5, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData pause = IconData(0xe769, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData payment_card = IconData(0xe8c7, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData pc1 = IconData(0xe977, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData pdf = IconData(0xea90, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData pen_workspace = IconData(0xedc6, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData pencil_reply = IconData(0xef7b, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData pentagon = IconData(0xf4ff, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData people = IconData(0xe716, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData people_add = IconData(0xea15, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData people_alert = IconData(0xed93, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData people_block = IconData(0xed91, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData people_external_share = IconData(0xe5ef, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData people_pause = IconData(0xed94, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData people_repeat = IconData(0xed92, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData permissions = IconData(0xe8d7, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData permissions_solid = IconData(0xf349, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData personalize = IconData(0xe771, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData phishing = IconData(0xf679, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData phishing_campaign = IconData(0xe48d, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData phishing_hook = IconData(0xe48e, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData phone = IconData(0xe717, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData photo = IconData(0xe91b, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData photo2 = IconData(0xeb9f, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData photo2_add = IconData(0xecab, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData photo2_fill = IconData(0xf79f, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData photo2_remove = IconData(0xecac, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData photo_block = IconData(0xe4c3, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData photo_collection = IconData(0xe7aa, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData photo_error = IconData(0xe3f7, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData photo_video_media = IconData(0xf0b1, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData picture = IconData(0xe8b9, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData picture_center = IconData(0xf522, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData picture_fill = IconData(0xf523, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData picture_library = IconData(0xeec2, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData picture_position = IconData(0xf524, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData picture_stretch = IconData(0xf525, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData picture_tile = IconData(0xf526, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData pie_double = IconData(0xeb04, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData pie_single = IconData(0xeb05, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData pie_single_solid = IconData(0xf530, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData pill = IconData(0xeacb, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData pin = IconData(0xe718, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData pin_solid12 = IconData(0xe352, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData pin_solid_off12 = IconData(0xe353, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData pin_to_tab = IconData(0xe5e5, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData pinned = IconData(0xe840, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData pinned_fill = IconData(0xe842, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData pinned_solid = IconData(0xf676, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData pivot_chart = IconData(0xf24c, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData plain_text = IconData(0xf834, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData plan_view = IconData(0xf360, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData planner_logo = IconData(0xedd1, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData play = IconData(0xe768, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData play_resume = IconData(0xf2c6, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData play_reverse = IconData(0xf3e5, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData play_reverse_resume = IconData(0xf3e4, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData play_solid = IconData(0xf5b0, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData playback_rate1x = IconData(0xec57, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData player_settings = IconData(0xef58, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData playlist_music = IconData(0xe93f, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData plug = IconData(0xf300, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData plug_connected = IconData(0xf302, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData plug_disconnected = IconData(0xf303, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData plug_solid = IconData(0xf301, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData poi = IconData(0xecaf, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData poll_results = IconData(0xf8a0, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData pop_expand = IconData(0xe49a, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData portal_app_template32 = IconData(0xe5fc, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData post_update = IconData(0xe8f3, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData power_apps = IconData(0xedd2, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData power_apps2_logo = IconData(0xf092, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData power_apps_logo = IconData(0xf091, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData power_apps_template = IconData(0xe4ac, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData power_automate_logo = IconData(0xf4b1, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData power_b_i_logo = IconData(0xea1e, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData power_b_i_logo16 = IconData(0xf790, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData power_b_i_logo_backplate16 = IconData(0xf791, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData power_button = IconData(0xe7e8, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData power_point_document = IconData(0xef72, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData power_point_logo = IconData(0xf1eb, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData power_point_logo16 = IconData(0xf394, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData power_point_logo_inverse = IconData(0xec2a, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData power_point_logo_inverse16 = IconData(0xf393, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData power_shell = IconData(0xf1fd, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData power_shell2 = IconData(0xf730, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData power_standby = IconData(0xe55c, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData power_virtual_agents_logo = IconData(0xe484, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData precipitation = IconData(0xe9cf, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData presence_chicklet_video = IconData(0xe979, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData presentation = IconData(0xf6e4, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData presentation12 = IconData(0xf6e5, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData preview = IconData(0xe8ff, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData preview_below = IconData(0xe5d5, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData preview_link = IconData(0xe8a1, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData preview_side_by_side = IconData(0xe5d6, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData previous = IconData(0xe892, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData primary_calendar = IconData(0xf4ae, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData print = IconData(0xe749, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData printfax_printer_file = IconData(0xe956, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData priority = IconData(0xe8d0, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData pro_football = IconData(0xeb27, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData pro_hockey = IconData(0xeb28, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData process = IconData(0xe9f3, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData process_advisor = IconData(0xe5e4, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData process_map = IconData(0xe9f6, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData process_meta_task = IconData(0xf290, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData processing = IconData(0xe9f5, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData processing_cancel = IconData(0xe403, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData processing_pause = IconData(0xe405, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData processing_run = IconData(0xe404, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData product = IconData(0xecdc, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData product_catalog = IconData(0xefe8, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData product_list = IconData(0xe31e, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData product_release = IconData(0xee2e, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData product_variant = IconData(0xee30, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData product_warning = IconData(0xe5c0, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData production_floor_management = IconData(0xee29, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData profile_search = IconData(0xef35, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData progress_loop_inner = IconData(0xecde, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData progress_loop_outer = IconData(0xecdf, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData progress_ring5 = IconData(0xedf6, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData progress_ring_dots = IconData(0xf16a, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData project_collection = IconData(0xf363, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData project_document = IconData(0xf759, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData project_logo16 = IconData(0xf480, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData project_logo32 = IconData(0xf47e, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData project_logo_inverse = IconData(0xedd4, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData project_management = IconData(0xe9de, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData promoted_database = IconData(0xf77d, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData pronouns = IconData(0xe556, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData protect_restrict = IconData(0xf22a, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData protected_document = IconData(0xe8a6, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData protection_center_logo32 = IconData(0xf494, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData provisioning_package = IconData(0xe835, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData public_calendar = IconData(0xef6d, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData public_contact_card = IconData(0xef6e, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData public_contact_card_mirrored = IconData(0xf230, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData public_email = IconData(0xef6f, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData public_folder = IconData(0xef70, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData publish_content = IconData(0xf0d4, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData publish_course = IconData(0xf699, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData publisher_logo = IconData(0xf1ed, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData publisher_logo16 = IconData(0xf3a0, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData publisher_logo_inverse16 = IconData(0xf39f, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData puzzle = IconData(0xea86, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData py = IconData(0xf2f9, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData python_language = IconData(0xf2f8, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData q_r_code = IconData(0xed14, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData qand_a = IconData(0xf8a2, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData qand_a_mirror = IconData(0xf8a3, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData quad_column = IconData(0xf66f, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData quantity = IconData(0xe9f8, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData quarter_circle = IconData(0xf502, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData query_list = IconData(0xf2b8, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData questionnaire = IconData(0xee19, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData questionnaire_mirrored = IconData(0xee4b, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData queue_advanced = IconData(0xe62e, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData quick_note = IconData(0xe70b, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData quick_note_solid = IconData(0xf338, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData quotes = IconData(0xf067, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData r = IconData(0xf4eb, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData radio_btn_off = IconData(0xecca, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData radio_btn_on = IconData(0xeccb, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData radio_bullet = IconData(0xe915, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData rain = IconData(0xe9c4, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData rain_showers_day = IconData(0xe9c3, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData rain_showers_night = IconData(0xea0f, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData rain_snow = IconData(0xe9c7, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData rate = IconData(0xeb07, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData raw_source = IconData(0xf299, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData read = IconData(0xe8c3, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData read_out_loud = IconData(0xf112, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData reading_mode = IconData(0xe736, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData reading_mode_solid = IconData(0xf33d, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData real_estate = IconData(0xe758, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData receipt_check = IconData(0xef5b, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData receipt_forward = IconData(0xef59, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData receipt_processing = IconData(0xe496, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData receipt_reply = IconData(0xef5a, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData receipt_tentative = IconData(0xf41a, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData receipt_tentative_mirrored = IconData(0xf41b, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData receipt_undelivered = IconData(0xf419, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData recent = IconData(0xe823, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData record2 = IconData(0xea3f, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData record_routing = IconData(0xe62d, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData recruitment_management = IconData(0xee12, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData rectangle_shape = IconData(0xf1a9, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData rectangle_shape_solid = IconData(0xf640, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData rectangular_clipping = IconData(0xf407, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData recurring_event = IconData(0xef5d, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData recurring_task = IconData(0xedb2, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData recycle_bin = IconData(0xef87, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData red_eye = IconData(0xe7b3, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData red_eye12 = IconData(0xe3ad, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData redeploy = IconData(0xf29e, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData redo = IconData(0xe7a6, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData refresh = IconData(0xe72c, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData registry_editor = IconData(0xf1ff, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData relationship = IconData(0xf003, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData release_definition = IconData(0xf6ea, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData release_gate = IconData(0xf7be, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData release_gate_check = IconData(0xf7bf, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData release_gate_error = IconData(0xf7c0, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData reminder_group = IconData(0xebf8, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData reminder_person = IconData(0xebf7, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData reminder_time = IconData(0xebf9, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData remote = IconData(0xe8af, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData remote_application = IconData(0xf621, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData remove = IconData(0xe738, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData remove_content = IconData(0xecc7, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData remove_event = IconData(0xed8a, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData remove_filter = IconData(0xeb08, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData remove_from_shopping_list = IconData(0xf7d5, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData remove_from_trash = IconData(0xf82b, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData remove_link = IconData(0xed90, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData remove_link_chain = IconData(0xf79a, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData remove_link_x = IconData(0xf79b, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData remove_occurrence = IconData(0xed9b, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData rename = IconData(0xe8ac, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData renewal_current = IconData(0xf545, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData renewal_future = IconData(0xf546, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData reopen_pages = IconData(0xed50, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData repair = IconData(0xe90f, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData repeat_all = IconData(0xe8ee, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData repeat_header_rows = IconData(0xe3eb, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData repeat_one = IconData(0xe8ed, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData reply = IconData(0xe97a, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData reply_all = IconData(0xee0a, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData reply_all_alt = IconData(0xef5f, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData reply_all_mirrored = IconData(0xee36, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData reply_alt = IconData(0xef5e, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData reply_mirrored = IconData(0xee35, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData repo = IconData(0xf2cb, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData repo_solid = IconData(0xf2cc, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData report_add = IconData(0xf52c, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData report_alert = IconData(0xf721, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData report_alert_mirrored = IconData(0xf722, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData report_document = IconData(0xe9f9, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData report_hacked = IconData(0xe730, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData report_library = IconData(0xeebb, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData report_library_mirrored = IconData(0xeebc, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData report_lock = IconData(0xf875, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData report_trophy = IconData(0xe614, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData report_warning = IconData(0xf569, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData rerun = IconData(0xf8a1, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData reservation_orders = IconData(0xf845, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData reset = IconData(0xe423, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData reset_device = IconData(0xed10, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData responses_menu = IconData(0xf768, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData return_key = IconData(0xe751, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData return_to_session = IconData(0xed24, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData rev_toggle_key = IconData(0xe845, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData revenue_management = IconData(0xf85e, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData review_request_mirrored_solid = IconData(0xf357, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData review_request_solid = IconData(0xf356, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData review_response_solid = IconData(0xf358, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData review_solid = IconData(0xf355, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData rewards_logo = IconData(0xed4e, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData rewards_logo_art64 = IconData(0xeef2, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData rewards_logo_solid = IconData(0xed4f, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData rewind = IconData(0xeb9e, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData rewind_eight_x = IconData(0xe449, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData rewind_four_x = IconData(0xe448, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData rewind_one_five_x = IconData(0xe446, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData rewind_one_x = IconData(0xe445, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData rewind_point_five_x = IconData(0xe444, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData rewind_two_x = IconData(0xe447, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData ribbon = IconData(0xe9d1, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData ribbon2 = IconData(0xf19b, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData ribbon_solid = IconData(0xf345, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData right_double_quote = IconData(0xe9b1, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData right_triangle = IconData(0xf500, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData ringer = IconData(0xea8f, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData ringer_active = IconData(0xe498, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData ringer_off = IconData(0xf2c5, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData ringer_remove = IconData(0xf279, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData ringer_solid = IconData(0xef3a, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData robot = IconData(0xe99a, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData rocket = IconData(0xf3b3, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData room = IconData(0xed9f, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData rotate = IconData(0xe7ad, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData rotate90_clockwise = IconData(0xf80d, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData rotate90_counter_clockwise = IconData(0xf80e, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData rows_child = IconData(0xf29c, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData rows_group = IconData(0xf29b, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData rugby = IconData(0xeb2d, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData running = IconData(0xeada, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData s_d_card = IconData(0xe7f1, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData s_i_p_move = IconData(0xe759, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData s_q_l_analytics_pool = IconData(0xe434, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData s_q_l_server_logo = IconData(0xe61a, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData sad = IconData(0xe757, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData sad_solid = IconData(0xf33e, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData samsung_gallery = IconData(0xe4e2, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData save = IconData(0xe74e, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData save_all = IconData(0xf203, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData save_and_close = IconData(0xf038, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData save_as = IconData(0xe792, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData save_template = IconData(0xf6ec, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData save_to_mobile = IconData(0xf7e0, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData saved_offline = IconData(0xe546, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData savings = IconData(0xeb0b, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData scale_up = IconData(0xed09, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData scale_volume = IconData(0xf18c, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData scatter_chart = IconData(0xefeb, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData schedule_event_action = IconData(0xf1ef, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData school_data_sync_logo = IconData(0xe34c, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData scope_template = IconData(0xf2b0, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData screen = IconData(0xef39, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData screen_cast = IconData(0xf7e2, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData screen_preview_on = IconData(0xf11e, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData screen_time = IconData(0xf182, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData script = IconData(0xf03a, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData scroll_up_down = IconData(0xec8f, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData search = IconData(0xe721, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData search_and_apps = IconData(0xe773, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData search_art64 = IconData(0xeef5, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData search_bookmark = IconData(0xf5b8, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData search_calendar = IconData(0xf4af, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData search_data = IconData(0xf3f1, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData search_issue = IconData(0xf09a, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData search_issue_mirrored = IconData(0xf09b, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData search_nearby = IconData(0xe820, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData secondary_nav = IconData(0xf814, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData section = IconData(0xec0c, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData sections = IconData(0xef76, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData security_camera = IconData(0xeb35, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData security_group = IconData(0xed85, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData security_test = IconData(0xe48f, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData see_do = IconData(0xe808, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData select_all = IconData(0xe8b3, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData sell = IconData(0xeb0c, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData semibold_weight = IconData(0xf4f0, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData send = IconData(0xe724, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData send_mirrored = IconData(0xea63, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData sentiment_analysis = IconData(0xe393, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData separator = IconData(0xf35e, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData server = IconData(0xf201, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData server_enviroment = IconData(0xf29f, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData server_processes = IconData(0xf1fe, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData service_activity = IconData(0xeff1, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData service_off = IconData(0xe3fd, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData set_action = IconData(0xf071, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData settings = IconData(0xe713, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData settings_add = IconData(0xe35a, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData settings_secure = IconData(0xe4d2, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData settings_sync = IconData(0xe359, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData shake_device = IconData(0xf80a, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData shape_solid = IconData(0xe422, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData shapes = IconData(0xec7c, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData share = IconData(0xe72d, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData shared_database = IconData(0xe3d9, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData shared_notes = IconData(0xf481, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData sharei_o_s = IconData(0xef79, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData sharepoint2013_logo_inverse = IconData(0xe480, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData sharepoint_app_icon16 = IconData(0xe365, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData sharepoint_logo = IconData(0xf27e, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData sharepoint_logo_inverse = IconData(0xed18, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData shield = IconData(0xea18, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData shield_alert = IconData(0xf7d7, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData shield_solid = IconData(0xf340, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData shirt = IconData(0xed00, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData shop = IconData(0xe719, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData shop_server = IconData(0xf2b6, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData shopping_cart = IconData(0xe7bf, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData shopping_cart_solid = IconData(0xf342, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData show_grid = IconData(0xf7de, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData show_results = IconData(0xe8bc, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData show_results_mirrored = IconData(0xea65, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData show_time_as = IconData(0xf787, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData show_visual_filter = IconData(0xf4de, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData showers = IconData(0xe46c, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData side_panel = IconData(0xef52, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData side_panel_mirrored = IconData(0xf221, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData sign_out = IconData(0xf3b1, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData signin = IconData(0xf286, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData simplified_view = IconData(0xe5c1, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData single_bookmark = IconData(0xedff, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData single_bookmark_solid = IconData(0xee00, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData single_column = IconData(0xf1d3, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData single_column_edit = IconData(0xf321, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData site_scan = IconData(0xebec, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData six_point_star = IconData(0xf504, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData size_legacy = IconData(0xe2b2, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData ski_resorts = IconData(0xeb45, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData skip_back10 = IconData(0xed3c, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData skip_forward30 = IconData(0xed3d, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData skype_arrow = IconData(0xf748, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData skype_check = IconData(0xef80, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData skype_circle_arrow = IconData(0xf747, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData skype_circle_check = IconData(0xef7d, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData skype_circle_clock = IconData(0xef7e, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData skype_circle_minus = IconData(0xef7f, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData skype_circle_slash = IconData(0xf825, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData skype_clock = IconData(0xef81, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData skype_for_business_logo = IconData(0xf0fc, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData skype_for_business_logo16 = IconData(0xf40f, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData skype_for_business_logo_fill = IconData(0xf27d, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData skype_for_business_logo_fill16 = IconData(0xf410, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData skype_logo = IconData(0xeb6f, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData skype_logo16 = IconData(0xf40e, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData skype_message = IconData(0xef83, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData skype_minus = IconData(0xef82, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData skype_slash = IconData(0xf826, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData sleet = IconData(0xe474, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData slider = IconData(0xf527, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData slider_handle_size = IconData(0xf528, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData slider_thumb = IconData(0xec13, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData slideshow = IconData(0xe786, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData smart_glass_remote = IconData(0xf80b, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData snap_to_grid = IconData(0xf7e4, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData snooze = IconData(0xf4bd, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData snow = IconData(0xe9c8, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData snow_shower_day = IconData(0xe9fd, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData snow_shower_night = IconData(0xea11, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData snowflake = IconData(0xeb46, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData soccer = IconData(0xeb21, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData social_listening_logo = IconData(0xed7c, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData sort = IconData(0xe8cb, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData sort_down = IconData(0xee69, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData sort_lines = IconData(0xe9d0, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData sort_lines_ascending = IconData(0xe43a, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData sort_up = IconData(0xee68, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData source = IconData(0xeb1b, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData spacer = IconData(0xf40d, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData speakers = IconData(0xe7f5, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData special_event = IconData(0xf536, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData speech = IconData(0xefa9, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData speech_off = IconData(0xf8ba, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData speed_high = IconData(0xec4a, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData spelling = IconData(0xf87b, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData split = IconData(0xedbc, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData split_object = IconData(0xf547, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData sprint = IconData(0xf3b0, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData squalls = IconData(0xe9cc, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData square_shape = IconData(0xf1a6, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData square_shape_solid = IconData(0xf63d, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData stack = IconData(0xf26f, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData stack_column_chart = IconData(0xe9fc, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData stack_indicator = IconData(0xe7ff, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData stacked_bar_chart = IconData(0xf24d, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData stacked_bar_chart_full = IconData(0xf668, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData stacked_column_chart2 = IconData(0xf666, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData stacked_column_chart2_fill = IconData(0xf831, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData stacked_line_chart = IconData(0xf24e, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData staff_notebook_logo16 = IconData(0xf48e, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData staff_notebook_logo32 = IconData(0xf48c, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData staff_notebook_logo_fill16 = IconData(0xf48f, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData staff_notebook_logo_fill32 = IconData(0xf48d, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData staff_notebook_logo_inverted16 = IconData(0xf491, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData staff_notebook_logo_inverted32 = IconData(0xf490, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData starburst = IconData(0xef78, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData starburst_solid = IconData(0xf33c, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData status_circle_block = IconData(0xf140, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData status_circle_block2 = IconData(0xf141, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData status_circle_checkmark = IconData(0xf13e, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData status_circle_error_x = IconData(0xf13d, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData status_circle_exclamation = IconData(0xf13c, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData status_circle_info = IconData(0xf13f, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData status_circle_inner = IconData(0xf137, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData status_circle_outer = IconData(0xf136, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData status_circle_question_mark = IconData(0xf142, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData status_circle_ring = IconData(0xf138, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData status_circle_sync = IconData(0xf143, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData status_error_full = IconData(0xeb90, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData status_triangle = IconData(0xea82, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData status_triangle_exclamation = IconData(0xf13b, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData status_triangle_inner = IconData(0xf13a, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData status_triangle_outer = IconData(0xf139, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData step = IconData(0xf241, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData step_insert = IconData(0xf242, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData step_shared = IconData(0xf243, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData step_shared_add = IconData(0xf244, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData step_shared_insert = IconData(0xf245, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData sticky_notes_outline_app_icon = IconData(0xe36a, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData sticky_notes_solid_app_icon = IconData(0xe36b, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData stock_down = IconData(0xeb0f, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData stock_up = IconData(0xeb11, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData stop = IconData(0xe71a, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData stop_solid = IconData(0xee95, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData stopwatch = IconData(0xe916, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData storage_acount = IconData(0xe435, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData storage_optical = IconData(0xe958, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData store_logo16 = IconData(0xea96, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData store_logo_med20 = IconData(0xea04, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData storyboard = IconData(0xf308, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData stream_discover = IconData(0xf7d9, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData stream_logo = IconData(0xf329, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData stream_playlist = IconData(0xe669, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData streaming = IconData(0xe93e, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData streaming_dataflow = IconData(0xe668, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData streaming_dataset = IconData(0xe667, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData streaming_off = IconData(0xf2bb, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData street = IconData(0xe913, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData streetside_split_minimize = IconData(0xe802, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData strikethrough = IconData(0xede0, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData strikethrough_korean = IconData(0xe5d4, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData subscribe = IconData(0xeda1, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData subscript = IconData(0xeddf, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData substitutions_in = IconData(0xeb31, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData subtract_shape = IconData(0xf8fc, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData suitcase = IconData(0xedd3, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData summary_chart = IconData(0xe9fe, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData sun_add = IconData(0xef69, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData sun_question_mark = IconData(0xef6a, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData sunny = IconData(0xe9bd, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData superscript = IconData(0xedde, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData survey_question_response = IconData(0xe4f2, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData survey_questions = IconData(0xf01b, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData sway_logo16 = IconData(0xf484, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData sway_logo32 = IconData(0xf482, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData sway_logo_fill16 = IconData(0xf485, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData sway_logo_fill32 = IconData(0xf483, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData sway_logo_inverse = IconData(0xed29, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData switch_user = IconData(0xe748, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData switch_widget = IconData(0xe8ab, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData switcher_start_end = IconData(0xe810, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData sync = IconData(0xe895, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData sync_error = IconData(0xea6a, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData sync_folder = IconData(0xe8f7, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData sync_occurence = IconData(0xf4a3, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData sync_occurence_cancel = IconData(0xf7e7, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData sync_status = IconData(0xf751, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData sync_status_solid = IconData(0xf752, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData sync_to_p_c = IconData(0xee6e, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData system = IconData(0xe770, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData t_f_v_c_logo = IconData(0xf44d, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData t_v_monitor = IconData(0xe7f4, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData t_v_monitor_selected = IconData(0xec77, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData tab = IconData(0xe7e9, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData tab_center = IconData(0xf100, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData tab_one_column = IconData(0xf849, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData tab_three_column = IconData(0xf84b, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData tab_two_column = IconData(0xf84a, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData table = IconData(0xed86, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData table_branded_column = IconData(0xe3f1, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData table_branded_row = IconData(0xe3ee, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData table_column = IconData(0xe4bd, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData table_computed = IconData(0xf8f5, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData table_first_column = IconData(0xe3ef, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData table_group = IconData(0xf6d9, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData table_header_row = IconData(0xe3ec, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData table_last_column = IconData(0xe3f0, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData table_link = IconData(0xf77a, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData table_permission = IconData(0xe619, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData table_total_row = IconData(0xe3ed, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData tablet = IconData(0xe70a, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData tablet_mode = IconData(0xebfc, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData tablet_selected = IconData(0xec74, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData tag = IconData(0xe8ec, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData tag_group = IconData(0xe3f6, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData tag_solid = IconData(0xf70e, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData tag_unknown = IconData(0xf6df, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData tag_unknown12 = IconData(0xf6e1, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData tag_unknown12_mirror = IconData(0xf6e2, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData tag_unknown_mirror = IconData(0xf6e0, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData task_add = IconData(0xe4fd, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData task_group = IconData(0xf2ae, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData task_group_mirrored = IconData(0xf2af, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData task_list = IconData(0xe3b6, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData task_logo = IconData(0xf493, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData task_manager = IconData(0xedb7, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData task_manager_mirrored = IconData(0xedb8, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData task_solid = IconData(0xf333, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData taskboard = IconData(0xf1c2, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData taxi = IconData(0xf4a1, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData team_favorite = IconData(0xf2ad, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData teams_logo = IconData(0xf27b, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData teams_logo16 = IconData(0xf40a, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData teams_logo_inverse = IconData(0xf27a, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData teamwork = IconData(0xea12, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData teeth = IconData(0xf4a0, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData telemarketer = IconData(0xe7b9, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData temporary_access_pass = IconData(0xe4ad, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData temporary_user = IconData(0xee58, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData tennis = IconData(0xeb33, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData test_add = IconData(0xe4dc, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData test_auto_solid = IconData(0xf3a8, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData test_beaker = IconData(0xf3a5, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData test_beaker_solid = IconData(0xf3a6, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData test_case = IconData(0xf3af, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData test_explore_solid = IconData(0xf3a7, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData test_impact_solid = IconData(0xf3aa, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData test_parameter = IconData(0xf3ad, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData test_plan = IconData(0xf3ab, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData test_remove = IconData(0xe4e1, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData test_step = IconData(0xf3ac, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData test_suite = IconData(0xf3ae, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData test_user_solid = IconData(0xf3a9, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData text_align_bottom = IconData(0xe3e2, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData text_align_middle = IconData(0xe3e1, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData text_align_top = IconData(0xe3e0, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData text_box = IconData(0xedc2, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData text_callout = IconData(0xf2a2, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData text_document = IconData(0xf029, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData text_document_edit = IconData(0xe43b, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData text_document_settings = IconData(0xe4aa, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData text_document_shared = IconData(0xf02b, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData text_field = IconData(0xedc3, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData text_overflow = IconData(0xf51f, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData text_paragraph_option = IconData(0xe3e3, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData text_recognition = IconData(0xe394, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData text_rotate270_degrees = IconData(0xe3e7, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData text_rotate90_degrees = IconData(0xe3e6, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData text_rotate_horizontal = IconData(0xe3e5, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData text_rotation = IconData(0xe3e4, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData this_p_c = IconData(0xec4e, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData three_quarter_circle = IconData(0xf503, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData thumbnail_view = IconData(0xe7b6, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData thumbnail_view_mirrored = IconData(0xea67, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData thunderstorms = IconData(0xe9c6, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData ticket = IconData(0xeb54, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData tiles = IconData(0xeca5, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData tiles2 = IconData(0xef7c, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData time_entry = IconData(0xef95, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData time_picker = IconData(0xe367, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData time_sheet = IconData(0xea05, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData timeline = IconData(0xed9c, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData timeline_delivery = IconData(0xf2ab, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData timeline_matrix_view = IconData(0xf361, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData timeline_progress = IconData(0xf2aa, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData timer = IconData(0xe91e, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData title = IconData(0xf23b, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData title_mirrored = IconData(0xf23c, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData to_do_logo_bottom = IconData(0xf4b3, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData to_do_logo_inverse = IconData(0xf4bc, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData to_do_logo_outline = IconData(0xf75b, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData to_do_logo_top = IconData(0xf4b4, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData toggle_border = IconData(0xec12, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData toggle_filled = IconData(0xec11, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData toggle_left = IconData(0xf19e, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData toggle_right = IconData(0xf19f, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData toggle_thumb = IconData(0xec14, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData toll = IconData(0xf160, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData toolbox = IconData(0xeced, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData total = IconData(0xe9df, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData touch = IconData(0xe815, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData touch_pointer = IconData(0xe7c9, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData trackers = IconData(0xeadf, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData trackers_mirrored = IconData(0xee92, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData train = IconData(0xe7c0, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData train_solid = IconData(0xeb4d, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData transfer_call = IconData(0xed95, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData transition = IconData(0xf3bc, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData transition_effect = IconData(0xf5b4, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData transition_pop = IconData(0xf5b2, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData transition_push = IconData(0xf5b3, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData translate = IconData(0xe7b2, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData transportation = IconData(0xebf1, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData trending12 = IconData(0xf62d, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData triangle_down12 = IconData(0xeed1, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData triangle_left12 = IconData(0xeed2, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData triangle_right12 = IconData(0xeed3, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData triangle_shape = IconData(0xf1a7, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData triangle_shape_solid = IconData(0xf63e, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData triangle_solid = IconData(0xea08, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData triangle_solid_down12 = IconData(0xeecd, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData triangle_solid_left12 = IconData(0xeece, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData triangle_solid_right12 = IconData(0xeecf, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData triangle_solid_up12 = IconData(0xeecc, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData triangle_up12 = IconData(0xeed0, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData trigger_approval = IconData(0xf3b2, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData trigger_auto = IconData(0xf24a, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData trigger_phrase = IconData(0xe5ff, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData trigger_user = IconData(0xf24b, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData trim = IconData(0xe78a, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData trim_end = IconData(0xf8bc, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData trim_start = IconData(0xf8bb, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData triple_column = IconData(0xf1d5, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData triple_column_edit = IconData(0xf323, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData triple_column_wide = IconData(0xf66e, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData trophy = IconData(0xed3f, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData trophy2 = IconData(0xf1ae, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData trophy2_solid = IconData(0xf337, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData turn_right = IconData(0xe7db, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData twelve_point_star = IconData(0xf505, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData type_script_language = IconData(0xf2f7, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData u_r_l_block = IconData(0xe3fe, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData umbrella = IconData(0xec04, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData un_set_color = IconData(0xf3f9, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData unavailable_offline = IconData(0xe545, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData underline = IconData(0xe8dc, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData underline_a = IconData(0xe5cc, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData underline_korean = IconData(0xe5bb, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData underline_p = IconData(0xe5cd, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData underline_russian = IconData(0xe5b8, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData underline_s = IconData(0xe5b4, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData underline_serbian = IconData(0xe5cb, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData undo = IconData(0xe7a7, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData uneditable = IconData(0xed1d, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData uneditable2 = IconData(0xf876, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData uneditable2_mirrored = IconData(0xf877, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData uneditable_mirrored = IconData(0xf4b9, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData uneditable_solid12 = IconData(0xf4b7, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData uneditable_solid_mirrored12 = IconData(0xf4b8, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData unfavorite = IconData(0xe8d9, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData ungroup_object = IconData(0xf4f2, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData unite_shape = IconData(0xf8fb, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData unknown = IconData(0xe9ce, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData unknown_call = IconData(0xed97, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData unknown_mirrored = IconData(0xf22e, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData unknown_mirrored_solid = IconData(0xf2e2, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData unknown_solid = IconData(0xf2e1, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData unlock = IconData(0xe785, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData unlock_solid = IconData(0xf304, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData unpin = IconData(0xe77a, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData unpublish_content = IconData(0xe31f, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData unstack_selected = IconData(0xe7fe, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData unsubscribe = IconData(0xeda0, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData unsync_folder = IconData(0xe8f6, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData unsync_occurence = IconData(0xf4a4, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData untag = IconData(0xf60b, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData up = IconData(0xe74a, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData update_restore = IconData(0xe777, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData upgrade_analysis = IconData(0xea0b, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData upload = IconData(0xe898, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData upper_case = IconData(0xe5ed, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData usb = IconData(0xe88e, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData user_clapper = IconData(0xe666, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData user_event = IconData(0xf69c, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData user_followed = IconData(0xf25c, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData user_gauge = IconData(0xf6ed, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData user_optional = IconData(0xf767, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData user_pause = IconData(0xf2ba, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData user_remove = IconData(0xf69b, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData user_sync = IconData(0xf2b9, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData user_warning = IconData(0xe368, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData user_window = IconData(0xe4ed, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData v_s_t_s_alt_logo1 = IconData(0xf382, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData v_s_t_s_alt_logo2 = IconData(0xf383, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData v_s_t_s_logo = IconData(0xf381, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData vacation = IconData(0xf49f, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData vaccination = IconData(0xeae0, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData vaccination_recent = IconData(0xe550, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData variable = IconData(0xf305, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData variable2 = IconData(0xf86d, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData variable3 = IconData(0xe4d1, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData variable_group = IconData(0xf31b, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData vb = IconData(0xf2f2, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData venn_diagram = IconData(0xf273, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData verified_brand = IconData(0xf7bd, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData verified_brand_solid = IconData(0xf6ad, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData version_control_push = IconData(0xf664, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData vertical_distribute_center = IconData(0xf4fa, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData video = IconData(0xe714, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData video360_generic = IconData(0xf609, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData video_add = IconData(0xe430, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData video_light_off = IconData(0xea74, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData video_off = IconData(0xf4b0, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData video_off2 = IconData(0xe43c, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData video_search = IconData(0xf4ea, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData video_solid = IconData(0xea0c, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData view = IconData(0xe890, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData view_all = IconData(0xe8a9, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData view_all2 = IconData(0xef56, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData view_dashboard = IconData(0xf246, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData view_in_a_r = IconData(0xe41f, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData view_list = IconData(0xf247, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData view_list_group = IconData(0xf248, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData view_list_tree = IconData(0xf249, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData view_original = IconData(0xe7b4, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData virtual_network = IconData(0xf815, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData visio_diagram = IconData(0xf2a0, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData visio_diagram_sync = IconData(0xf762, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData visio_document = IconData(0xf2a9, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData visio_logo = IconData(0xf2a7, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData visio_logo16 = IconData(0xf3a3, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData visio_logo_inverse = IconData(0xed7d, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData visio_logo_inverse16 = IconData(0xf3a2, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData visual_basic_language = IconData(0xf2f1, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData visual_studio_for_windows = IconData(0xf5d0, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData visual_studio_for_windows_alt = IconData(0xec22, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData visually_impaired = IconData(0xf866, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData visuals_folder = IconData(0xf520, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData visuals_store = IconData(0xf521, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData voicemail_forward = IconData(0xed87, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData voicemail_i_r_m = IconData(0xf421, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData voicemail_reply = IconData(0xed88, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData volume0 = IconData(0xe992, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData volume1 = IconData(0xe993, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData volume2 = IconData(0xe994, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData volume3 = IconData(0xe995, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData volume_disabled = IconData(0xea85, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData waffle = IconData(0xed89, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData waffle_office365 = IconData(0xf4e0, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData waitlist_confirm = IconData(0xf550, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData waitlist_confirm_mirrored = IconData(0xf551, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const IconData warning = IconData(0xe7ba, fontFamily: 'FluentIcons', fontPackage: 'fluent_ui');
-  static const Map<String,IconData> allIcons = {
+  static const IconData a_a_d_logo = IconData(
+    0xed68,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData a_t_p_logo = IconData(
+    0xef85,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData accept = IconData(
+    0xe8fb,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData accept_medium = IconData(
+    0xf78c,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData access_logo = IconData(
+    0xed69,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData accessibilty_checker = IconData(
+    0xf835,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData account_activity = IconData(
+    0xeff4,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData account_browser = IconData(
+    0xf652,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData account_management = IconData(
+    0xf55c,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData accounts = IconData(
+    0xe910,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData action_center = IconData(
+    0xe91c,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData activate_orders = IconData(
+    0xefe0,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData activity_feed = IconData(
+    0xf056,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData add = IconData(
+    0xe710,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData add_bookmark = IconData(
+    0xf5b7,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData add_connection = IconData(
+    0xf4e1,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData add_event = IconData(
+    0xeeb5,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData add_favorite = IconData(
+    0xf0c8,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData add_favorite_fill = IconData(
+    0xf0c9,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData add_field = IconData(
+    0xe4c7,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData add_friend = IconData(
+    0xe8fa,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData add_group = IconData(
+    0xee3d,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData add_home = IconData(
+    0xf17b,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData add_in = IconData(
+    0xf775,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData add_link = IconData(
+    0xe35e,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData add_medium = IconData(
+    0xeca1,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData add_multiple = IconData(
+    0xe9c5,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData add_notes = IconData(
+    0xeae3,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData add_online_meeting = IconData(
+    0xed8e,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData add_phone = IconData(
+    0xed96,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData add_reaction = IconData(
+    0xf85d,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData add_space_after = IconData(
+    0xe3df,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData add_space_before = IconData(
+    0xe3de,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData add_table = IconData(
+    0xe4c6,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData add_to = IconData(
+    0xecc8,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData add_to_shopping_list = IconData(
+    0xea9a,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData add_work = IconData(
+    0xf17c,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData admin = IconData(
+    0xe7ef,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData admin_a_logo32 = IconData(
+    0xf4ba,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData admin_a_logo_fill32 = IconData(
+    0xf4bb,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData admin_a_logo_inverse32 = IconData(
+    0xed6a,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData admin_c_logo_inverse32 = IconData(
+    0xed6b,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData admin_d_logo_inverse32 = IconData(
+    0xed6c,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData admin_e_logo_inverse32 = IconData(
+    0xed6d,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData admin_l_logo_inverse32 = IconData(
+    0xed6e,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData admin_m_logo_inverse32 = IconData(
+    0xed6f,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData admin_o_logo_inverse32 = IconData(
+    0xed70,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData admin_p_logo_inverse32 = IconData(
+    0xed71,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData admin_s_logo_inverse32 = IconData(
+    0xed72,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData admin_y_logo_inverse32 = IconData(
+    0xed73,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData air_tickets = IconData(
+    0xef7a,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData airplane = IconData(
+    0xe709,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData airplane_solid = IconData(
+    0xeb4c,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData alarm_clock = IconData(
+    0xe919,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData album = IconData(
+    0xe7ab,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData album_remove = IconData(
+    0xec62,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData alert_settings = IconData(
+    0xf8b6,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData alert_solid = IconData(
+    0xf331,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData align_center = IconData(
+    0xe8e3,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData align_horizontal_center = IconData(
+    0xf4f4,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData align_horizontal_left = IconData(
+    0xf4f3,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData align_horizontal_right = IconData(
+    0xf4f5,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData align_justify = IconData(
+    0xf51e,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData align_left = IconData(
+    0xe8e4,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData align_right = IconData(
+    0xe8e2,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData align_vertical_bottom = IconData(
+    0xf4f8,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData align_vertical_center = IconData(
+    0xf4f7,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData align_vertical_top = IconData(
+    0xf4f6,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData all_apps = IconData(
+    0xe71d,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData all_apps_mirrored = IconData(
+    0xea40,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData all_currency = IconData(
+    0xeae4,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData alt_text = IconData(
+    0xe397,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData analytics_logo = IconData(
+    0xf1de,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData analytics_query = IconData(
+    0xf1df,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData analytics_report = IconData(
+    0xf1e1,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData analytics_view = IconData(
+    0xf5f1,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData anchor_lock = IconData(
+    0xf511,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData annotation = IconData(
+    0xe924,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData app_icon_default = IconData(
+    0xecaa,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData app_icon_default_add = IconData(
+    0xefda,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData app_icon_default_edit = IconData(
+    0xefdc,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData app_icon_default_list = IconData(
+    0xefde,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData app_icon_secure = IconData(
+    0xe657,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData apps_content = IconData(
+    0xee54,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData archive = IconData(
+    0xf03f,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData archive_undo = IconData(
+    0xe3a1,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData area_chart = IconData(
+    0xe9d2,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData arrange_bring_forward = IconData(
+    0xf509,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData arrange_bring_to_front = IconData(
+    0xf506,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData arrange_by_from = IconData(
+    0xf678,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData arrange_send_backward = IconData(
+    0xf508,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData arrange_send_to_back = IconData(
+    0xf507,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData arrivals = IconData(
+    0xeb34,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData arrow_down_right8 = IconData(
+    0xeed5,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData arrow_down_right_mirrored8 = IconData(
+    0xeef0,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData arrow_tall_down_left = IconData(
+    0xf2bf,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData arrow_tall_down_right = IconData(
+    0xf2c0,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData arrow_tall_up_left = IconData(
+    0xf2bd,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData arrow_tall_up_right = IconData(
+    0xf2be,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData arrow_up_right = IconData(
+    0xf069,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData arrow_up_right8 = IconData(
+    0xeed4,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData arrow_up_right_mirrored8 = IconData(
+    0xeeef,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData articles = IconData(
+    0xeac1,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData ascending = IconData(
+    0xedc0,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData aspect_ratio = IconData(
+    0xe799,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData assessment_group = IconData(
+    0xf31a,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData assessment_group_template = IconData(
+    0xf2b1,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData asset_library = IconData(
+    0xeeb6,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData assign = IconData(
+    0xe9d3,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData assign_policy = IconData(
+    0xe461,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData asterisk = IconData(
+    0xea38,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData asterisk_solid = IconData(
+    0xf34d,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData attach = IconData(
+    0xe723,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData australian_rules = IconData(
+    0xee70,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData authenticator_app = IconData(
+    0xf6b1,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData auto_deploy_settings = IconData(
+    0xf3fa,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData auto_enhance_off = IconData(
+    0xe78e,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData auto_enhance_on = IconData(
+    0xe78d,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData auto_fill_template = IconData(
+    0xf313,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData auto_fit_contents = IconData(
+    0xe3e8,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData auto_fit_window = IconData(
+    0xe3e9,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData auto_height = IconData(
+    0xf512,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData auto_racing = IconData(
+    0xeb24,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData automate_flow = IconData(
+    0xe3f5,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData away_status = IconData(
+    0xee6a,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData azure_a_p_i_management = IconData(
+    0xf37f,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData azure_data_explorer = IconData(
+    0xe439,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData azure_icon = IconData(
+    0xeb6a,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData azure_key_vault = IconData(
+    0xf3b4,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData azure_service_endpoint = IconData(
+    0xf380,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData b_i_dashboard = IconData(
+    0xf543,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData back = IconData(
+    0xe72b,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData back_to_window = IconData(
+    0xe73f,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData background_color = IconData(
+    0xf42b,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData backlog = IconData(
+    0xf2ac,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData backlog_board = IconData(
+    0xf444,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData backlog_list = IconData(
+    0xf6bf,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData badge = IconData(
+    0xec1b,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData balloons = IconData(
+    0xed7e,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData bank = IconData(
+    0xe825,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData bank_solid = IconData(
+    0xf34f,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData bar_chart4 = IconData(
+    0xeae7,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData bar_chart_horizontal = IconData(
+    0xe9eb,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData bar_chart_vertical = IconData(
+    0xe9ec,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData bar_chart_vertical_edit = IconData(
+    0xf89d,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData bar_chart_vertical_fill = IconData(
+    0xf830,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData bar_chart_vertical_filter = IconData(
+    0xf77e,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData bar_chart_vertical_filter_solid = IconData(
+    0xf77f,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData baseball = IconData(
+    0xeb20,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData beer_mug = IconData(
+    0xf49e,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData bidi_ltr = IconData(
+    0xe9aa,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData bidi_rtl = IconData(
+    0xe9ab,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData bill = IconData(
+    0xe5fa,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData bing_logo = IconData(
+    0xeb6b,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData birthday_cake = IconData(
+    0xef8d,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData blob_storage = IconData(
+    0xe436,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData block_contact = IconData(
+    0xe8f8,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData blocked = IconData(
+    0xe733,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData blocked12 = IconData(
+    0xf62e,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData blocked2 = IconData(
+    0xece4,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData blocked2_solid = IconData(
+    0xf737,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData blocked_site = IconData(
+    0xe72f,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData blocked_site_solid12 = IconData(
+    0xf70a,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData blocked_solid = IconData(
+    0xf531,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData blog = IconData(
+    0xf22b,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData blowing_snow = IconData(
+    0xe9c9,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData blur = IconData(
+    0xf28e,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData boards = IconData(
+    0xef68,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData bold = IconData(
+    0xe8dd,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData bold_bulgarian = IconData(
+    0xe5c5,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData bold_f = IconData(
+    0xe5b5,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData bold_g = IconData(
+    0xe5b3,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData bold_k = IconData(
+    0xe5c6,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData bold_kazakh = IconData(
+    0xe5c9,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData bold_korean = IconData(
+    0xe5bd,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData bold_n = IconData(
+    0xe5b7,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData bold_p = IconData(
+    0xe5c7,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData bold_russion = IconData(
+    0xe5b9,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData bold_serbian = IconData(
+    0xe5ca,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData bold_t = IconData(
+    0xe5c8,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData book_answers = IconData(
+    0xf8a4,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData bookings_logo = IconData(
+    0xedc7,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData bookmark_report = IconData(
+    0xf76b,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData bookmarks = IconData(
+    0xe8a4,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData bookmarks_mirrored = IconData(
+    0xea41,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData boolean_data = IconData(
+    0xe678,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData border_all = IconData(
+    0xe5f4,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData border_dash = IconData(
+    0xf50a,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData border_dot = IconData(
+    0xf50b,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData border_inside = IconData(
+    0xe5f3,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData border_inside_horizontal = IconData(
+    0xe5f2,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData border_inside_vertical = IconData(
+    0xe5f1,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData border_none = IconData(
+    0xe5f0,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData box_addition_solid = IconData(
+    0xf2d4,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData box_checkmark_solid = IconData(
+    0xf2d7,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData box_multiply_solid = IconData(
+    0xf2d5,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData box_play_solid = IconData(
+    0xf2d6,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData box_subtract_solid = IconData(
+    0xf2d3,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData branch_commit = IconData(
+    0xf293,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData branch_compare = IconData(
+    0xf294,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData branch_fork = IconData(
+    0xf173,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData branch_fork2 = IconData(
+    0xf291,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData branch_locked = IconData(
+    0xf292,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData branch_merge = IconData(
+    0xf295,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData branch_pull_request = IconData(
+    0xf296,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData branch_search = IconData(
+    0xf297,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData branch_shelveset = IconData(
+    0xf298,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData breadcrumb = IconData(
+    0xef8c,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData breakfast = IconData(
+    0xf49c,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData brightness = IconData(
+    0xe706,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData broom = IconData(
+    0xea99,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData browser_screen_shot = IconData(
+    0xebed,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData browser_tab = IconData(
+    0xf5d7,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData browser_tab_screenshot = IconData(
+    0xf5d8,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData brunch = IconData(
+    0xf49d,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData brush = IconData(
+    0xecff,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData bucket_color = IconData(
+    0xf1b6,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData bucket_color_fill = IconData(
+    0xf1b7,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData buffer_time_after = IconData(
+    0xf0d0,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData buffer_time_before = IconData(
+    0xf0cf,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData buffer_time_both = IconData(
+    0xf0d1,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData bug = IconData(
+    0xebe8,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData bug_action = IconData(
+    0xe358,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData bug_block = IconData(
+    0xe400,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData bug_solid = IconData(
+    0xf335,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData bug_sync = IconData(
+    0xe3ff,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData bug_warning = IconData(
+    0xe357,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData build = IconData(
+    0xf28f,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData build_definition = IconData(
+    0xf6e9,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData build_issue = IconData(
+    0xf319,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData build_queue = IconData(
+    0xf24f,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData build_queue_new = IconData(
+    0xf250,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData bulk_page_block = IconData(
+    0xe553,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData bulk_upload = IconData(
+    0xf548,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData bulleted_list = IconData(
+    0xe8fd,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData bulleted_list2 = IconData(
+    0xf2c7,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData bulleted_list2_mirrored = IconData(
+    0xf2c8,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData bulleted_list_bullet = IconData(
+    0xf793,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData bulleted_list_bullet_mirrored = IconData(
+    0xf795,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData bulleted_list_mirrored = IconData(
+    0xea42,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData bulleted_list_text = IconData(
+    0xf792,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData bulleted_list_text_mirrored = IconData(
+    0xf794,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData bulleted_tree_list = IconData(
+    0xf84c,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData bullseye = IconData(
+    0xf272,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData bullseye_target = IconData(
+    0xf5f0,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData bullseye_target_add = IconData(
+    0xe664,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData bullseye_target_delete = IconData(
+    0xf6c1,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData bullseye_target_edit = IconData(
+    0xe319,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData bus = IconData(
+    0xe806,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData bus_solid = IconData(
+    0xeb47,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData business_card = IconData(
+    0xe5fb,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData business_center_logo = IconData(
+    0xf4b2,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData business_hours_sign = IconData(
+    0xf310,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData business_rule = IconData(
+    0xe562,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData button_control = IconData(
+    0xf6c0,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData c_c_solid = IconData(
+    0xe4f4,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData c_plus_plus = IconData(
+    0xf2f4,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData c_plus_plus_language = IconData(
+    0xf2f3,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData c_r_m_lead = IconData(
+    0xefd6,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData c_r_m_processes = IconData(
+    0xefb1,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData c_r_m_report = IconData(
+    0xeffe,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData c_r_m_resource_optimization_app32 = IconData(
+    0xf6ef,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData c_r_m_services = IconData(
+    0xefd2,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData c_sharp = IconData(
+    0xf2f0,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData c_sharp_language = IconData(
+    0xf2ef,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData cafe = IconData(
+    0xec32,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData cake = IconData(
+    0xeca4,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData calculated_table = IconData(
+    0xe4be,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData calculator = IconData(
+    0xe8ef,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData calculator_addition = IconData(
+    0xe948,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData calculator_delta = IconData(
+    0xe406,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData calculator_equal_to = IconData(
+    0xe94e,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData calculator_group = IconData(
+    0xe462,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData calculator_multiply = IconData(
+    0xe947,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData calculator_not_equal_to = IconData(
+    0xf2d2,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData calculator_percentage = IconData(
+    0xe94c,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData calculator_subtract = IconData(
+    0xe949,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData calendar = IconData(
+    0xe787,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData calendar_agenda = IconData(
+    0xee9a,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData calendar_day = IconData(
+    0xe8bf,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData calendar_mirrored = IconData(
+    0xed28,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData calendar_reply = IconData(
+    0xe8f5,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData calendar_settings = IconData(
+    0xf558,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData calendar_settings_mirrored = IconData(
+    0xf559,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData calendar_week = IconData(
+    0xe8c0,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData calendar_work_week = IconData(
+    0xef51,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData calendar_year = IconData(
+    0xe371,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData calories = IconData(
+    0xecad,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData calories_add = IconData(
+    0xf172,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData camera = IconData(
+    0xe722,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData campaign_template = IconData(
+    0xf811,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData cancel = IconData(
+    0xe711,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData canned_chat = IconData(
+    0xf0f2,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData canvas_app_template32 = IconData(
+    0xe5fe,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData car = IconData(
+    0xe804,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData care_activity = IconData(
+    0xe549,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData care_plan = IconData(
+    0xe54a,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData care_plan_template = IconData(
+    0xe61e,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData caret_bottom_left_center8 = IconData(
+    0xf365,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData caret_bottom_left_solid8 = IconData(
+    0xf121,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData caret_bottom_right_center8 = IconData(
+    0xf364,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData caret_bottom_right_solid8 = IconData(
+    0xf122,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData caret_down8 = IconData(
+    0xedd8,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData caret_down_solid8 = IconData(
+    0xeddc,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData caret_hollow = IconData(
+    0xe817,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData caret_hollow_mirrored = IconData(
+    0xea45,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData caret_left8 = IconData(
+    0xedd5,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData caret_left_solid8 = IconData(
+    0xedd9,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData caret_right = IconData(
+    0xf06b,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData caret_right8 = IconData(
+    0xedd6,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData caret_right_solid8 = IconData(
+    0xedda,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData caret_solid = IconData(
+    0xe818,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData caret_solid16 = IconData(
+    0xee62,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData caret_solid_alt = IconData(
+    0xe483,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData caret_solid_down = IconData(
+    0xf08e,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData caret_solid_left = IconData(
+    0xf08d,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData caret_solid_mirrored = IconData(
+    0xea46,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData caret_solid_right = IconData(
+    0xf08f,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData caret_solid_up = IconData(
+    0xf090,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData caret_top_left_center8 = IconData(
+    0xf367,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData caret_top_left_solid8 = IconData(
+    0xef54,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData caret_top_right_center8 = IconData(
+    0xf366,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData caret_top_right_solid8 = IconData(
+    0xef55,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData caret_up8 = IconData(
+    0xedd7,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData caret_up_solid8 = IconData(
+    0xeddb,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData cat = IconData(
+    0xed7f,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData category_classification = IconData(
+    0xe48c,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData cc = IconData(
+    0xe7f0,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData cell_phone = IconData(
+    0xe8ea,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData cell_split_vertical = IconData(
+    0xe66c,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData certificate = IconData(
+    0xeb95,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData certified_database = IconData(
+    0xf5bb,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData change_entitlements = IconData(
+    0xe310,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData chart = IconData(
+    0xe999,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData chart_series = IconData(
+    0xf513,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData chart_template = IconData(
+    0xf812,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData chart_x_angle = IconData(
+    0xf514,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData chart_y_angle = IconData(
+    0xf515,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData charticulator_arrange_polar = IconData(
+    0xe632,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData charticulator_arrange_polar_angles = IconData(
+    0xe633,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData charticulator_band = IconData(
+    0xe634,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData charticulator_guide_coordinator = IconData(
+    0xe635,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData charticulator_guide_x = IconData(
+    0xe636,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData charticulator_guide_y = IconData(
+    0xe637,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData charticulator_legend = IconData(
+    0xe638,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData charticulator_line = IconData(
+    0xe639,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData charticulator_line_style_dashed = IconData(
+    0xe63a,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData charticulator_line_style_dotted = IconData(
+    0xe63b,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData charticulator_linking_data = IconData(
+    0xe63c,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData charticulator_linking_sequence = IconData(
+    0xe63d,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData charticulator_order_column = IconData(
+    0xe63e,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData charticulator_order_row = IconData(
+    0xe63f,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData charticulator_plot_cartesian = IconData(
+    0xe640,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData charticulator_plot_curve = IconData(
+    0xe641,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData charticulator_polar_coordinates = IconData(
+    0xe642,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData charticulator_spiral = IconData(
+    0xe643,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData charticulator_stack_radial = IconData(
+    0xe644,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData charticulator_stack_y = IconData(
+    0xe645,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData chat = IconData(
+    0xe901,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData chat_bot = IconData(
+    0xf08b,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData chat_invite_friend = IconData(
+    0xecfe,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData chat_settings = IconData(
+    0xe600,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData chat_solid = IconData(
+    0xf344,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData check_list = IconData(
+    0xe9d5,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData check_list_check = IconData(
+    0xf7a9,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData check_list_check_mirrored = IconData(
+    0xf7ab,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData check_list_text = IconData(
+    0xf7a8,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData check_list_text_mirrored = IconData(
+    0xf7aa,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData check_mark = IconData(
+    0xe73e,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData checkbox = IconData(
+    0xe739,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData checkbox_composite = IconData(
+    0xe73a,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData checkbox_composite_reversed = IconData(
+    0xe73d,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData checkbox_fill = IconData(
+    0xe73b,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData checkbox_indeterminate = IconData(
+    0xe73c,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData checkbox_indeterminate_combo = IconData(
+    0xf16e,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData checked_out_by_other12 = IconData(
+    0xf630,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData checked_out_by_you12 = IconData(
+    0xf631,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData chevron_down = IconData(
+    0xe70d,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData chevron_down_end = IconData(
+    0xf5e4,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData chevron_down_end6 = IconData(
+    0xf36f,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData chevron_down_med = IconData(
+    0xe972,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData chevron_down_small = IconData(
+    0xe96e,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData chevron_fold10 = IconData(
+    0xf36a,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData chevron_left = IconData(
+    0xe76b,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData chevron_left_end6 = IconData(
+    0xf371,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData chevron_left_med = IconData(
+    0xe973,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData chevron_left_small = IconData(
+    0xe96f,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData chevron_right = IconData(
+    0xe76c,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData chevron_right_end6 = IconData(
+    0xf372,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData chevron_right_med = IconData(
+    0xe974,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData chevron_right_small = IconData(
+    0xe970,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData chevron_unfold10 = IconData(
+    0xf369,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData chevron_up = IconData(
+    0xe70e,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData chevron_up_end = IconData(
+    0xe55b,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData chevron_up_end6 = IconData(
+    0xf370,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData chevron_up_med = IconData(
+    0xe971,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData chevron_up_small = IconData(
+    0xe96d,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData childof = IconData(
+    0xf82d,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData choice_column = IconData(
+    0xe4ae,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData chopsticks = IconData(
+    0xf4a2,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData chrome_back = IconData(
+    0xe830,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData chrome_back_mirrored = IconData(
+    0xea47,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData chrome_close = IconData(
+    0xe8bb,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData chrome_full_screen = IconData(
+    0xe92d,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData chrome_minimize = IconData(
+    0xe921,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData chrome_restore = IconData(
+    0xe923,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData circle_addition = IconData(
+    0xf2e3,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData circle_addition_solid = IconData(
+    0xf2e4,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData circle_dollar = IconData(
+    0xeaed,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData circle_fill = IconData(
+    0xea3b,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData circle_half_full = IconData(
+    0xed9e,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData circle_pause = IconData(
+    0xf2d9,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData circle_pause_solid = IconData(
+    0xf2d8,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData circle_plus = IconData(
+    0xeaee,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData circle_ring = IconData(
+    0xea3a,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData circle_shape = IconData(
+    0xf1a5,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData circle_shape_solid = IconData(
+    0xf63c,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData circle_stop = IconData(
+    0xf2dc,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData circle_stop_solid = IconData(
+    0xf2db,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData city_next = IconData(
+    0xec06,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData city_next2 = IconData(
+    0xec07,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData class_notebook_logo16 = IconData(
+    0xf488,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData class_notebook_logo32 = IconData(
+    0xf486,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData class_notebook_logo_fill16 = IconData(
+    0xf489,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData class_notebook_logo_fill32 = IconData(
+    0xf487,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData class_notebook_logo_inverse = IconData(
+    0xedc8,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData class_notebook_logo_inverse16 = IconData(
+    0xf48b,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData class_notebook_logo_inverse32 = IconData(
+    0xf48a,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData classroom_logo = IconData(
+    0xef75,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData clear = IconData(
+    0xe894,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData clear_filter = IconData(
+    0xef8f,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData clear_formatting = IconData(
+    0xeddd,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData clear_formatting_a = IconData(
+    0xf79d,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData clear_formatting_eraser = IconData(
+    0xf79e,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData clear_night = IconData(
+    0xe9c2,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData clear_selection = IconData(
+    0xe8e6,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData clear_selection_mirrored = IconData(
+    0xea48,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData clicked = IconData(
+    0xf268,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData clinical_impression = IconData(
+    0xe54b,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData clipboard_list = IconData(
+    0xf0e3,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData clipboard_list_add = IconData(
+    0xe4ef,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData clipboard_list_mirrored = IconData(
+    0xf0e4,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData clipboard_list_question = IconData(
+    0xe4f0,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData clipboard_list_reply = IconData(
+    0xe4f1,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData clipboard_solid = IconData(
+    0xf5dc,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData clock = IconData(
+    0xe917,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData clone_to_desktop = IconData(
+    0xf28c,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData close_pane = IconData(
+    0xe89f,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData close_pane_mirrored = IconData(
+    0xea49,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData closed_caption = IconData(
+    0xef84,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData cloud = IconData(
+    0xe753,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData cloud_add = IconData(
+    0xeca9,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData cloud_download = IconData(
+    0xebd3,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData cloud_edit = IconData(
+    0xe4c8,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData cloud_flow = IconData(
+    0xe5ea,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData cloud_import_export = IconData(
+    0xee55,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData cloud_link = IconData(
+    0xe4c9,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData cloud_not_synced = IconData(
+    0xec9c,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData cloud_printer = IconData(
+    0xeda6,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData cloud_search = IconData(
+    0xede4,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData cloud_secure = IconData(
+    0xe4d5,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData cloud_upload = IconData(
+    0xec8e,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData cloud_weather = IconData(
+    0xe9be,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData cloudy = IconData(
+    0xe9bf,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData cocktails = IconData(
+    0xea9d,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData code = IconData(
+    0xe943,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData code_edit = IconData(
+    0xf544,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData coffee = IconData(
+    0xeaef,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData coffee_script = IconData(
+    0xf2fa,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData collapse_all = IconData(
+    0xf85a,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData collapse_content = IconData(
+    0xf165,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData collapse_content_single = IconData(
+    0xf166,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData collapse_menu = IconData(
+    0xef66,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData college_football = IconData(
+    0xeb26,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData college_hoops = IconData(
+    0xeb25,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData color = IconData(
+    0xe790,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData color_solid = IconData(
+    0xf354,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData column = IconData(
+    0xe438,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData column_function = IconData(
+    0xe4c2,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData column_left_two_thirds = IconData(
+    0xf1d6,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData column_left_two_thirds_edit = IconData(
+    0xf324,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData column_options = IconData(
+    0xf317,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData column_question = IconData(
+    0xe4c0,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData column_question_mirrored = IconData(
+    0xe4c1,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData column_right_two_thirds = IconData(
+    0xf1d7,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData column_right_two_thirds_edit = IconData(
+    0xf325,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData column_sigma = IconData(
+    0xe4bf,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData column_vertical_section = IconData(
+    0xf81e,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData column_vertical_section_edit = IconData(
+    0xf806,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData combine = IconData(
+    0xedbb,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData combobox = IconData(
+    0xf516,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData command_prompt = IconData(
+    0xe756,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData comment = IconData(
+    0xe90a,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData comment_active = IconData(
+    0xf804,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData comment_add = IconData(
+    0xf2b3,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData comment_next = IconData(
+    0xf2b4,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData comment_previous = IconData(
+    0xf2b5,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData comment_solid = IconData(
+    0xe30e,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData comment_urgent = IconData(
+    0xf307,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData commitments = IconData(
+    0xec4d,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData common_data_service_c_d_s = IconData(
+    0xe377,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData communication_details = IconData(
+    0xe4cf,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData communication_details_mirrored = IconData(
+    0xe4d0,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData communications = IconData(
+    0xe95a,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData company_directory = IconData(
+    0xef0d,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData company_directory_mirrored = IconData(
+    0xef2b,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData compare = IconData(
+    0xf057,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData compare_uneven = IconData(
+    0xe42e,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData compass_n_w = IconData(
+    0xe942,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData completed = IconData(
+    0xe930,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData completed12 = IconData(
+    0xe559,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData completed_solid = IconData(
+    0xec61,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData compliance_audit = IconData(
+    0xe369,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData configuration_solid = IconData(
+    0xf334,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData confirm_event = IconData(
+    0xe680,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData connect_contacts = IconData(
+    0xefd4,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData connect_virtual_machine = IconData(
+    0xee9d,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData construction_cone = IconData(
+    0xe98f,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData construction_cone_solid = IconData(
+    0xf339,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData contact = IconData(
+    0xe77b,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData contact_card = IconData(
+    0xeebd,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData contact_card_settings = IconData(
+    0xf556,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData contact_card_settings_mirrored = IconData(
+    0xf557,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData contact_heart = IconData(
+    0xf862,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData contact_info = IconData(
+    0xe779,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData contact_info_mirrored = IconData(
+    0xea4a,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData contact_link = IconData(
+    0xf25f,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData contact_list = IconData(
+    0xf7e5,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData contact_lock = IconData(
+    0xf400,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData content_feed = IconData(
+    0xe428,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData content_settings = IconData(
+    0xf647,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData content_understanding_app = IconData(
+    0xe4fb,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData context_menu = IconData(
+    0xf37c,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData contrast = IconData(
+    0xe7a1,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData copy = IconData(
+    0xe8c8,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData copy_edit = IconData(
+    0xe464,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData cortana_logo_beckon_inner = IconData(
+    0xf4c6,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData cortana_logo_beckon_outer = IconData(
+    0xf4c7,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData cortana_logo_inner = IconData(
+    0xe832,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData cortana_logo_outer = IconData(
+    0xe831,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData cortana_logo_ready_inner = IconData(
+    0xf4c8,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData cortana_logo_ready_outer = IconData(
+    0xf4c9,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData cost_contral_ledger_admin = IconData(
+    0xf208,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData cost_control = IconData(
+    0xf207,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData cotton = IconData(
+    0xeaf3,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData count = IconData(
+    0xe9ee,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData coupon = IconData(
+    0xf7bc,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData create_mail_rule = IconData(
+    0xf67a,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData credit_card_bill = IconData(
+    0xecd6,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData cricket = IconData(
+    0xeb1e,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData critical_error_solid = IconData(
+    0xf5c9,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData crop = IconData(
+    0xe7a8,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData crown = IconData(
+    0xed01,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData crown_solid = IconData(
+    0xf336,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData css = IconData(
+    0xebef,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData ctrl_button = IconData(
+    0xe4b8,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData cube_shape = IconData(
+    0xf1aa,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData cube_shape_solid = IconData(
+    0xe421,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData currency = IconData(
+    0xeaf5,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData custom_activity = IconData(
+    0xeff0,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData custom_entity = IconData(
+    0xeff7,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData custom_list = IconData(
+    0xeebe,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData custom_list_mirrored = IconData(
+    0xeebf,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData customer_assets = IconData(
+    0xf426,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData customize_toolbar = IconData(
+    0xf828,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData cut = IconData(
+    0xe8c6,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData cycling = IconData(
+    0xeac7,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData d365_business_central = IconData(
+    0xf833,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData d365_core_h_r = IconData(
+    0xf6bd,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData d365_customer_insights = IconData(
+    0xf3c8,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData d365_customer_voice_app = IconData(
+    0xe4f7,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData d365_project_operations = IconData(
+    0xe432,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData d365_talent_insight = IconData(
+    0xf6bc,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData d365_talent_learn = IconData(
+    0xf6bb,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData dashboard_add = IconData(
+    0xf52d,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData data_connection_library = IconData(
+    0xeeb7,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData data_enrichment = IconData(
+    0xe4f5,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData data_flow = IconData(
+    0xe577,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData data_management_settings = IconData(
+    0xefc8,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData database = IconData(
+    0xefc7,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData database_activity = IconData(
+    0xe670,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData database_block = IconData(
+    0xe617,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData database_refresh = IconData(
+    0xe67f,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData database_source = IconData(
+    0xe30a,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData database_swap = IconData(
+    0xe671,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData database_sync = IconData(
+    0xf842,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData database_view = IconData(
+    0xe437,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData dataflows = IconData(
+    0xf7dd,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData dataflows_link = IconData(
+    0xe366,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData dataverse = IconData(
+    0xe659,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData date_time = IconData(
+    0xec92,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData date_time12 = IconData(
+    0xf38f,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData date_time2 = IconData(
+    0xea17,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData date_time_mirrored = IconData(
+    0xee93,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData deactivate_orders = IconData(
+    0xefe1,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData decimals = IconData(
+    0xf218,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData decision_solid = IconData(
+    0xf350,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData decline_call = IconData(
+    0xf405,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData decrease_indent = IconData(
+    0xe39b,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData decrease_indent_arrow = IconData(
+    0xf7a3,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData decrease_indent_arrow_mirrored = IconData(
+    0xf7a7,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData decrease_indent_mirrored = IconData(
+    0xe39c,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData decrease_indent_text = IconData(
+    0xf7a2,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData decrease_indent_text_mirrored = IconData(
+    0xf7a6,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData default_ratio = IconData(
+    0xf529,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData default_settings = IconData(
+    0xf648,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData defect_solid = IconData(
+    0xf449,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData defender_app = IconData(
+    0xe83d,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData defender_badge12 = IconData(
+    0xf0fb,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData defender_t_v_m = IconData(
+    0xf6b3,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData delete = IconData(
+    0xe74d,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData delete_columns = IconData(
+    0xf64e,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData delete_rows = IconData(
+    0xf64f,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData delete_rows_mirrored = IconData(
+    0xf650,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData delete_table = IconData(
+    0xf651,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData delivery_truck = IconData(
+    0xebf4,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData delve_analytics = IconData(
+    0xeeee,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData delve_analytics_logo = IconData(
+    0xedca,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData delve_logo = IconData(
+    0xf280,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData delve_logo_fill = IconData(
+    0xf281,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData delve_logo_inverse = IconData(
+    0xed76,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData density_comfy = IconData(
+    0xe4ba,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData density_default = IconData(
+    0xe4b9,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData dependency_add = IconData(
+    0xe344,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData dependency_remove = IconData(
+    0xe345,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData deploy = IconData(
+    0xf29d,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData descending = IconData(
+    0xedc1,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData design = IconData(
+    0xeb3c,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData desktop_flow = IconData(
+    0xe4f3,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData desktop_screenshot = IconData(
+    0xf5d9,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData developer_tools = IconData(
+    0xec7a,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData device_bug = IconData(
+    0xe424,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData device_off = IconData(
+    0xe402,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData device_run = IconData(
+    0xe401,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData devices2 = IconData(
+    0xe975,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData devices3 = IconData(
+    0xea6c,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData devices4 = IconData(
+    0xeb66,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData diagnostic = IconData(
+    0xe9d9,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData diagnostic_data_bar_tooltip = IconData(
+    0xf7df,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData diagnostic_data_viewer_app = IconData(
+    0xf568,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData dialpad = IconData(
+    0xe75f,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData diamond = IconData(
+    0xed02,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData diamond_solid = IconData(
+    0xf34c,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData diamond_user = IconData(
+    0xe4f9,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData dictionary = IconData(
+    0xe82d,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData dictionary_remove = IconData(
+    0xf69a,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData diet_plan_notebook = IconData(
+    0xeac8,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData diff_inline = IconData(
+    0xf309,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData diff_side_by_side = IconData(
+    0xf30a,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData diploma = IconData(
+    0xf320,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData disable_updates = IconData(
+    0xe8d8,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData disconnect_virtual_machine = IconData(
+    0xf873,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData dislike = IconData(
+    0xe8e0,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData dislike_solid = IconData(
+    0xf3c0,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData distribute_down = IconData(
+    0xf76a,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData doc_library = IconData(
+    0xeeb8,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData dock_left = IconData(
+    0xe90c,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData dock_left_mirrored = IconData(
+    0xea4c,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData dock_right = IconData(
+    0xe90d,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData docs_logo_inverse = IconData(
+    0xedcb,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData document = IconData(
+    0xe8a5,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData document_approval = IconData(
+    0xf28b,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData document_management = IconData(
+    0xeffc,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData document_reply = IconData(
+    0xef57,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData document_search = IconData(
+    0xef6c,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData document_set = IconData(
+    0xeed6,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData documentation = IconData(
+    0xec17,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData dom = IconData(
+    0xec8d,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData donut_chart = IconData(
+    0xf368,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData door = IconData(
+    0xeb75,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData double_bookmark = IconData(
+    0xeb8f,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData double_chevron_down = IconData(
+    0xee04,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData double_chevron_down12 = IconData(
+    0xee97,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData double_chevron_down8 = IconData(
+    0xf36b,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData double_chevron_left = IconData(
+    0xedbe,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData double_chevron_left12 = IconData(
+    0xee98,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData double_chevron_left8 = IconData(
+    0xf36d,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData double_chevron_left_med = IconData(
+    0xe991,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData double_chevron_left_med_mirrored = IconData(
+    0xea4d,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData double_chevron_right = IconData(
+    0xedbf,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData double_chevron_right12 = IconData(
+    0xee99,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData double_chevron_right8 = IconData(
+    0xf36e,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData double_chevron_up = IconData(
+    0xedbd,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData double_chevron_up12 = IconData(
+    0xee96,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData double_chevron_up8 = IconData(
+    0xf36c,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData double_column = IconData(
+    0xf1d4,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData double_column_edit = IconData(
+    0xf322,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData double_down_arrow = IconData(
+    0xf769,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData down = IconData(
+    0xe74b,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData download = IconData(
+    0xe896,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData download_document = IconData(
+    0xf549,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData drag_object = IconData(
+    0xf553,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData drill_down = IconData(
+    0xf532,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData drill_down_solid = IconData(
+    0xf533,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData drill_expand = IconData(
+    0xf534,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData drill_show = IconData(
+    0xf535,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData drill_through = IconData(
+    0xf5b9,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData driver_off = IconData(
+    0xe3fb,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData drm = IconData(
+    0xeca8,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData drop = IconData(
+    0xeb42,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData drop_shape = IconData(
+    0xf1a8,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData drop_shape_solid = IconData(
+    0xf63f,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData dropdown = IconData(
+    0xedc5,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData duplicate_row = IconData(
+    0xf82a,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData duststorm = IconData(
+    0xe9cd,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData dynamic_list = IconData(
+    0xe491,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData dynamic_s_m_b_logo = IconData(
+    0xedcd,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData dynamics365_logo = IconData(
+    0xedcc,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData e_discovery = IconData(
+    0xe370,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData ease_of_access = IconData(
+    0xe776,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData eat_drink = IconData(
+    0xe807,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData edge_logo = IconData(
+    0xe3ab,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData edge_logo16 = IconData(
+    0xe3aa,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData edge_old_logo = IconData(
+    0xec60,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData edit = IconData(
+    0xe70f,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData edit_contact = IconData(
+    0xefd3,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData edit_create = IconData(
+    0xf3c9,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData edit_event = IconData(
+    0xf05b,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData edit_list_pencil = IconData(
+    0xe61b,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData edit_mail = IconData(
+    0xef61,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData edit_mirrored = IconData(
+    0xeb7e,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData edit_note = IconData(
+    0xed9d,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData edit_photo = IconData(
+    0xef77,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData edit_solid12 = IconData(
+    0xf4b5,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData edit_solid_mirrored12 = IconData(
+    0xf4b6,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData edit_style = IconData(
+    0xef60,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData edit_table = IconData(
+    0xe4c4,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData education = IconData(
+    0xe7be,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData ellipse = IconData(
+    0xf4fb,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData embed = IconData(
+    0xecce,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData emi = IconData(
+    0xe731,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData emoji = IconData(
+    0xe899,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData emoji2 = IconData(
+    0xe76e,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData emoji_disappointed = IconData(
+    0xea88,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData emoji_neutral = IconData(
+    0xea87,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData emoji_tab_symbols = IconData(
+    0xed58,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData employee_self_service = IconData(
+    0xee24,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData empty_recycle_bin = IconData(
+    0xef88,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData encounter = IconData(
+    0xe54c,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData encryption = IconData(
+    0xf69d,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData end_point_solid = IconData(
+    0xeb4b,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData engineering_group = IconData(
+    0xf362,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData entitlement_policy = IconData(
+    0xe346,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData entitlement_redemption = IconData(
+    0xe347,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData entity_extraction = IconData(
+    0xe467,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData entry_decline = IconData(
+    0xf555,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData entry_view = IconData(
+    0xf554,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData equalizer = IconData(
+    0xe9e9,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData erase_tool = IconData(
+    0xe75c,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData error = IconData(
+    0xe783,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData error_badge = IconData(
+    0xea39,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData error_badge12 = IconData(
+    0xe558,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData event = IconData(
+    0xeca3,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData event12 = IconData(
+    0xf763,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData event_accepted = IconData(
+    0xf422,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData event_date = IconData(
+    0xf059,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData event_date_missed12 = IconData(
+    0xf764,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData event_declined = IconData(
+    0xf425,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData event_info = IconData(
+    0xed8b,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData event_tentative = IconData(
+    0xf423,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData event_tentative_mirrored = IconData(
+    0xf424,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData event_to_do_logo = IconData(
+    0xf869,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData excel_document = IconData(
+    0xef73,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData excel_logo = IconData(
+    0xf1e5,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData excel_logo16 = IconData(
+    0xf397,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData excel_logo_inverse = IconData(
+    0xec28,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData excel_logo_inverse16 = IconData(
+    0xf396,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData exchange_logo = IconData(
+    0xf284,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData exchange_logo_inverse = IconData(
+    0xed78,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData exercise_tracker = IconData(
+    0xeacc,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData expand_all = IconData(
+    0xf859,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData expand_menu = IconData(
+    0xef67,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData explore_content = IconData(
+    0xeccd,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData explore_content_single = IconData(
+    0xf164,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData explore_data = IconData(
+    0xf5b6,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData export = IconData(
+    0xede1,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData export_mirrored = IconData(
+    0xede2,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData express_route_circuits = IconData(
+    0xe557,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData external_build = IconData(
+    0xf445,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData external_t_f_v_c = IconData(
+    0xf446,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData external_user = IconData(
+    0xe4ca,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData external_x_a_m_l = IconData(
+    0xf447,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData eye_shadow = IconData(
+    0xf7eb,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData eyedropper = IconData(
+    0xef3c,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData f12_dev_tools = IconData(
+    0xebee,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData f_sharp = IconData(
+    0xf2f6,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData f_sharp_language = IconData(
+    0xf2f5,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData fabric_asset_library = IconData(
+    0xf09c,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData fabric_channel_folder = IconData(
+    0xe4fa,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData fabric_data_connection_library = IconData(
+    0xf09d,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData fabric_doc_library = IconData(
+    0xf09e,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData fabric_folder = IconData(
+    0xf0a9,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData fabric_folder_confirm = IconData(
+    0xf7ff,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData fabric_folder_fill = IconData(
+    0xf0aa,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData fabric_folder_link = IconData(
+    0xe45c,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData fabric_folder_search = IconData(
+    0xf0a4,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData fabric_folder_upload = IconData(
+    0xe3ac,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData fabric_form_library = IconData(
+    0xf09f,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData fabric_form_library_mirrored = IconData(
+    0xf0a0,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData fabric_moveto_folder = IconData(
+    0xf0a5,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData fabric_network_folder = IconData(
+    0xf5e6,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData fabric_new_folder = IconData(
+    0xf0ab,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData fabric_open_folder_horizontal = IconData(
+    0xf0a8,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData fabric_picture_library = IconData(
+    0xf0ac,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData fabric_public_folder = IconData(
+    0xf0a3,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData fabric_report_library = IconData(
+    0xf0a1,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData fabric_report_library_mirrored = IconData(
+    0xf0a2,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData fabric_sync_folder = IconData(
+    0xf0a7,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData fabric_text_highlight = IconData(
+    0xf79c,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData fabric_text_highlight_composite = IconData(
+    0xf7da,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData fabric_unsync_folder = IconData(
+    0xf0a6,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData fabric_user_folder = IconData(
+    0xf5e5,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData factory = IconData(
+    0xe60e,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData family = IconData(
+    0xebda,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData fang_body = IconData(
+    0xeceb,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData fast_forward = IconData(
+    0xeb9d,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData fast_forward_eight_x = IconData(
+    0xe443,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData fast_forward_four_x = IconData(
+    0xe442,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData fast_forward_one_five_x = IconData(
+    0xe440,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData fast_forward_one_x = IconData(
+    0xe43f,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData fast_forward_point_five_x = IconData(
+    0xe43e,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData fast_forward_two_x = IconData(
+    0xe441,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData fast_mode = IconData(
+    0xf19a,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData favicon = IconData(
+    0xe737,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData favorite_block = IconData(
+    0xe67e,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData favorite_list = IconData(
+    0xe728,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData favorite_star = IconData(
+    0xe734,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData favorite_star_fill = IconData(
+    0xe735,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData fax = IconData(
+    0xef5c,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData feedback = IconData(
+    0xed15,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData feedback_request_mirrored_solid = IconData(
+    0xf35a,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData feedback_request_solid = IconData(
+    0xf359,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData feedback_response_solid = IconData(
+    0xf35b,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData ferry = IconData(
+    0xe7e3,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData ferry_solid = IconData(
+    0xeb48,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData field_changed = IconData(
+    0xf2c3,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData field_empty = IconData(
+    0xf2c1,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData field_filled = IconData(
+    0xf2c2,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData field_not_changed = IconData(
+    0xf2c4,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData field_read_only = IconData(
+    0xf442,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData field_required = IconData(
+    0xf443,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData file_a_s_p_x = IconData(
+    0xf2e9,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData file_bug = IconData(
+    0xf30d,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData file_c_s_s = IconData(
+    0xf2ea,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData file_code = IconData(
+    0xf30e,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData file_comment = IconData(
+    0xf30f,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData file_h_t_m_l = IconData(
+    0xf2ed,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData file_image = IconData(
+    0xf311,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData file_j_a_v_a = IconData(
+    0xf2e8,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData file_less = IconData(
+    0xf2ec,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData file_off = IconData(
+    0xe3fc,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData file_p_d_b = IconData(
+    0xf2e5,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData file_request = IconData(
+    0xf789,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData file_s_q_l = IconData(
+    0xf2e7,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData file_sass = IconData(
+    0xf2eb,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData file_symlink = IconData(
+    0xf312,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData file_system = IconData(
+    0xe433,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData file_template = IconData(
+    0xf2e6,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData file_type_solution = IconData(
+    0xf387,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData file_y_m_l = IconData(
+    0xf5da,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData filter = IconData(
+    0xe71c,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData filter_ascending = IconData(
+    0xf21a,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData filter_descending = IconData(
+    0xf21b,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData filter_settings = IconData(
+    0xf76c,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData filter_solid = IconData(
+    0xf412,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData filters = IconData(
+    0xe795,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData filters_solid = IconData(
+    0xf353,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData financial = IconData(
+    0xe7bb,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData financial_mirrored_solid = IconData(
+    0xf347,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData financial_solid = IconData(
+    0xf346,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData fingerprint = IconData(
+    0xe928,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData fit_page = IconData(
+    0xe9a6,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData fit_width = IconData(
+    0xe9a7,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData five_tile_grid = IconData(
+    0xf274,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData fixed_asset_management = IconData(
+    0xef93,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData fixed_column_width = IconData(
+    0xe3ea,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData flag = IconData(
+    0xe7c1,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData flame_solid = IconData(
+    0xf1f3,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData flash_auto = IconData(
+    0xe95c,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData flash_off = IconData(
+    0xea6e,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData flashlight = IconData(
+    0xe754,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData flick_down = IconData(
+    0xe935,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData flick_left = IconData(
+    0xe937,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData flick_right = IconData(
+    0xe938,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData flick_up = IconData(
+    0xe936,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData flow = IconData(
+    0xef90,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData flow_chart = IconData(
+    0xe9d4,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData flow_template = IconData(
+    0xe49c,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData flow_trigger = IconData(
+    0xe60c,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData flower = IconData(
+    0xf54e,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData fluid_logo = IconData(
+    0xe48a,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData focal_point = IconData(
+    0xf277,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData focus = IconData(
+    0xea6f,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData focus_view = IconData(
+    0xf1a3,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData fog = IconData(
+    0xe9cb,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData folder = IconData(
+    0xe8b7,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData folder_fill = IconData(
+    0xe8d5,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData folder_horizontal = IconData(
+    0xf12b,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData folder_list = IconData(
+    0xf2ce,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData folder_list_mirrored = IconData(
+    0xf2cf,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData folder_open = IconData(
+    0xe838,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData folder_query = IconData(
+    0xf2cd,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData folder_search = IconData(
+    0xef65,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData follow_user = IconData(
+    0xee05,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData font = IconData(
+    0xe8d2,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData font_color = IconData(
+    0xe8d3,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData font_color_a = IconData(
+    0xf4ec,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData font_color_korean = IconData(
+    0xe5be,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData font_color_swatch = IconData(
+    0xf4ed,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData font_decrease = IconData(
+    0xe8e7,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData font_increase = IconData(
+    0xe8e8,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData font_size = IconData(
+    0xe8e9,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData font_size2 = IconData(
+    0xe3c0,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData font_style_korean = IconData(
+    0xe5ba,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData footer = IconData(
+    0xf82e,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData form_library = IconData(
+    0xeeb9,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData form_library_mirrored = IconData(
+    0xeeba,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData form_processing = IconData(
+    0xe48b,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData format_painter = IconData(
+    0xe3dc,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData forum = IconData(
+    0xe378,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData forward = IconData(
+    0xe72a,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData forward_event = IconData(
+    0xed8c,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData freezing = IconData(
+    0xe9ef,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData freezing_rain = IconData(
+    0xe475,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData frigid = IconData(
+    0xe9ca,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData front_camera = IconData(
+    0xe96b,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData full_circle_mask = IconData(
+    0xe91f,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData full_history = IconData(
+    0xf31c,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData full_screen = IconData(
+    0xe740,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData full_view = IconData(
+    0xf1a2,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData full_width = IconData(
+    0xf2fe,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData full_width_edit = IconData(
+    0xf2ff,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData functional_manager_dashboard = IconData(
+    0xf542,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData funnel_chart = IconData(
+    0xe9f1,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData gallatin_logo = IconData(
+    0xf496,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData game = IconData(
+    0xe7fc,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData gather = IconData(
+    0xe460,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData generate = IconData(
+    0xe9da,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData generic_scan = IconData(
+    0xee6f,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData generic_scan_filled = IconData(
+    0xf7e3,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData gif = IconData(
+    0xf4a9,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData gift_box_solid = IconData(
+    0xf341,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData gift_card = IconData(
+    0xeb8e,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData giftbox = IconData(
+    0xec1f,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData giftbox_open = IconData(
+    0xf133,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData git_graph = IconData(
+    0xf2ca,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData glasses = IconData(
+    0xea16,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData glimmer = IconData(
+    0xecf4,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData global_nav_button = IconData(
+    0xe700,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData global_nav_button_active = IconData(
+    0xf89f,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData globe = IconData(
+    0xe774,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData globe2 = IconData(
+    0xf49a,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData globe_favorite = IconData(
+    0xef53,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData go = IconData(
+    0xe8ad,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData go_mirrored = IconData(
+    0xea4f,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData go_to_dashboard = IconData(
+    0xeeed,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData golf = IconData(
+    0xeb1f,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData goto_today = IconData(
+    0xe8d1,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData graph_symbol = IconData(
+    0xe35d,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData greeting_card = IconData(
+    0xf54b,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData grid_view_large = IconData(
+    0xf234,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData grid_view_medium = IconData(
+    0xf233,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData grid_view_small = IconData(
+    0xf232,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData gripper_bar_horizontal = IconData(
+    0xe76f,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData gripper_bar_vertical = IconData(
+    0xe784,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData gripper_dots_vertical = IconData(
+    0xf772,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData gripper_tool = IconData(
+    0xe75e,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData group = IconData(
+    0xe902,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData group_list = IconData(
+    0xf168,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData group_object = IconData(
+    0xf4f1,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData group_remove = IconData(
+    0xe495,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData grouped_ascending = IconData(
+    0xee67,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData grouped_descending = IconData(
+    0xee66,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData grouped_list = IconData(
+    0xef74,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData guid = IconData(
+    0xf52b,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData guitar = IconData(
+    0xf49b,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData hail_day = IconData(
+    0xea00,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData hail_night = IconData(
+    0xea13,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData half_alpha = IconData(
+    0xe97e,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData half_circle = IconData(
+    0xf501,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData hands_free = IconData(
+    0xead0,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData handwriting = IconData(
+    0xe929,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData hard_drive = IconData(
+    0xeda2,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData hard_drive_group = IconData(
+    0xf18f,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData hard_drive_lock = IconData(
+    0xf55a,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData hard_drive_unlock = IconData(
+    0xf55b,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData hazy_day = IconData(
+    0xe46b,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData hazy_night = IconData(
+    0xe479,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData header = IconData(
+    0xf82f,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData header1 = IconData(
+    0xea19,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData header2 = IconData(
+    0xef36,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData header3 = IconData(
+    0xef37,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData header4 = IconData(
+    0xef38,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData headset = IconData(
+    0xe95b,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData headset_solid = IconData(
+    0xf348,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData health = IconData(
+    0xe95e,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData health_refresh = IconData(
+    0xe3bd,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData health_solid = IconData(
+    0xf33f,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData heart = IconData(
+    0xeb51,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData heart_broken = IconData(
+    0xea92,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData heart_fill = IconData(
+    0xeb52,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData help = IconData(
+    0xe897,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData help_mirrored = IconData(
+    0xea51,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData hexadite_investigation = IconData(
+    0xe3f8,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData hexadite_investigation_cancel = IconData(
+    0xe3f9,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData hexadite_investigation_semi_auto = IconData(
+    0xe3fa,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData hexagon = IconData(
+    0xf4fe,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData hide = IconData(
+    0xed1a,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData hide2 = IconData(
+    0xef89,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData hide3 = IconData(
+    0xf6ac,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData hide_visual_filter = IconData(
+    0xf403,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData highlight = IconData(
+    0xe7e6,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData highlight_mapped_shapes = IconData(
+    0xf2a1,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData hint_text = IconData(
+    0xf50f,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData historical_weather = IconData(
+    0xeb43,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData history = IconData(
+    0xe81c,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData home = IconData(
+    0xe80f,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData home_dropdown = IconData(
+    0xe427,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData home_group = IconData(
+    0xec26,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData home_solid = IconData(
+    0xea8a,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData home_verify = IconData(
+    0xf00e,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData horizontal_distribute_center = IconData(
+    0xf4f9,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData horizontal_tab_key = IconData(
+    0xe7fd,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData hospital = IconData(
+    0xe91d,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData hot = IconData(
+    0xece2,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData hotel = IconData(
+    0xe824,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData hour_glass = IconData(
+    0xea03,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData i_d_badge = IconData(
+    0xf427,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData i_r_m_forward = IconData(
+    0xf41f,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData i_r_m_forward_mirrored = IconData(
+    0xf420,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData i_r_m_reply = IconData(
+    0xf41d,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData i_r_m_reply_mirrored = IconData(
+    0xf41e,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData ice = IconData(
+    0xe473,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData icon_sets_flag = IconData(
+    0xf2a4,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData ignore_conversation = IconData(
+    0xe372,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData image_crosshair = IconData(
+    0xf2c9,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData image_diff = IconData(
+    0xf30b,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData image_in_a_r = IconData(
+    0xe420,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData image_pixel = IconData(
+    0xf30c,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData image_search = IconData(
+    0xf4e8,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData import = IconData(
+    0xe8b5,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData import_all_mirrored = IconData(
+    0xea53,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData import_mirrored = IconData(
+    0xea52,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData important = IconData(
+    0xe8c9,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData inbox = IconData(
+    0xf41c,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData inbox_active = IconData(
+    0xe497,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData inbox_check = IconData(
+    0xef64,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData incident_triangle = IconData(
+    0xe814,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData incoming_call = IconData(
+    0xe77e,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData increase_indent = IconData(
+    0xe399,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData increase_indent_arrow = IconData(
+    0xf7a1,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData increase_indent_arrow_mirrored = IconData(
+    0xf7a5,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData increase_indent_hanging = IconData(
+    0xe39d,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData increase_indent_hanging_mirrored = IconData(
+    0xe39e,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData increase_indent_mirrored = IconData(
+    0xe39a,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData increase_indent_text = IconData(
+    0xf7a0,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData increase_indent_text_mirrored = IconData(
+    0xf7a4,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData indent_first_line = IconData(
+    0xe3dd,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData info = IconData(
+    0xe946,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData info12 = IconData(
+    0xe55a,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData info2 = IconData(
+    0xea1f,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData info_solid = IconData(
+    0xf167,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData information_barriers = IconData(
+    0xf803,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData inking_tool = IconData(
+    0xe76d,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData input_address = IconData(
+    0xe41e,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData insert = IconData(
+    0xf278,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData insert_columns_left = IconData(
+    0xf64a,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData insert_columns_right = IconData(
+    0xf64b,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData insert_rows_above = IconData(
+    0xf64c,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData insert_rows_below = IconData(
+    0xf64d,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData insert_signature_line = IconData(
+    0xf677,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData insert_text_box = IconData(
+    0xec7d,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData insert_text_box_korean = IconData(
+    0xe5d3,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData insights = IconData(
+    0xe3af,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData install_to_drive = IconData(
+    0xf28d,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData installation = IconData(
+    0xe311,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData intermittent_clouds_day = IconData(
+    0xe46a,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData intermittent_clouds_night = IconData(
+    0xe478,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData internal_investigation = IconData(
+    0xf854,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData internet_sharing = IconData(
+    0xe704,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData intersect_shape = IconData(
+    0xf8fd,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData invoice = IconData(
+    0xe9dc,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData io_t_secure = IconData(
+    0xe4d6,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData iot = IconData(
+    0xf22c,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData issue_solid = IconData(
+    0xf448,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData issue_tracking = IconData(
+    0xeec0,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData issue_tracking_mirrored = IconData(
+    0xeec1,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData italic = IconData(
+    0xe8db,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData italic_c = IconData(
+    0xe5b2,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData italic_d = IconData(
+    0xe5ce,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData italic_k = IconData(
+    0xe5b6,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData italic_kazakh = IconData(
+    0xe5d2,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData italic_korean = IconData(
+    0xe5bc,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData italic_l = IconData(
+    0xe5d1,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData italic_s = IconData(
+    0xe5cf,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData italic_t = IconData(
+    0xe5d0,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData java_script_language = IconData(
+    0xf2ee,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData join_online_meeting = IconData(
+    0xed8f,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData js = IconData(
+    0xebf0,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData kaizala_logo = IconData(
+    0xf492,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData key_phrase_extraction = IconData(
+    0xe395,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData keyboard_classic = IconData(
+    0xe765,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData knowledge_article = IconData(
+    0xf000,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData knowledge_management_app = IconData(
+    0xe4fc,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData label = IconData(
+    0xe932,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData ladybug_solid = IconData(
+    0xf44a,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData lamp = IconData(
+    0xeb19,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData landscape_orientation = IconData(
+    0xef6b,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData laptop_secure = IconData(
+    0xf552,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData laptop_selected = IconData(
+    0xec76,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData large_grid = IconData(
+    0xeecb,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData learning_app = IconData(
+    0xe5d8,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData learning_tools = IconData(
+    0xf7db,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData leave = IconData(
+    0xf627,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData leave_user = IconData(
+    0xe3a8,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData library = IconData(
+    0xe8f1,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData library_add_to = IconData(
+    0xe60d,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData lifesaver = IconData(
+    0xef62,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData lifesaver_lock = IconData(
+    0xef63,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData light = IconData(
+    0xe793,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData light_snow = IconData(
+    0xea02,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData light_weight = IconData(
+    0xf4ee,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData lightbulb = IconData(
+    0xea80,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData lightbulb_solid = IconData(
+    0xe681,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData lightning_bolt = IconData(
+    0xe945,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData lightning_bolt_solid = IconData(
+    0xe45f,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData lightning_secure = IconData(
+    0xe4d3,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData like = IconData(
+    0xe8e1,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData like_solid = IconData(
+    0xf3bf,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData line = IconData(
+    0xf4fc,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData line_chart = IconData(
+    0xe9e6,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData line_spacing = IconData(
+    0xf517,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData line_style = IconData(
+    0xf50c,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData line_thickness = IconData(
+    0xf50d,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData link = IconData(
+    0xe71b,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData link12 = IconData(
+    0xf6e3,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData linked_database = IconData(
+    0xf779,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData linked_in_logo = IconData(
+    0xf20a,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData list = IconData(
+    0xea37,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData list_mirrored = IconData(
+    0xea55,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData live_site = IconData(
+    0xf6a6,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData local_admin = IconData(
+    0xf1fb,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData locale_language = IconData(
+    0xf2b7,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData location = IconData(
+    0xe81d,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData location_circle = IconData(
+    0xe80e,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData location_dot = IconData(
+    0xe827,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData location_fill = IconData(
+    0xe920,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData location_outline = IconData(
+    0xf2d0,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData lock = IconData(
+    0xe72e,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData lock12 = IconData(
+    0xf6e6,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData lock_share = IconData(
+    0xe455,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData lock_solid = IconData(
+    0xe9a2,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData log_remove = IconData(
+    0xf316,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData lookup_entities = IconData(
+    0xf5b5,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData lower_brightness = IconData(
+    0xec8a,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData lower_case = IconData(
+    0xe5ee,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData lync_logo = IconData(
+    0xed79,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData m365_invoicing_logo = IconData(
+    0xf7c1,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData m_s_lists_connected = IconData(
+    0xe601,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData m_s_n_logo = IconData(
+    0xeb6c,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData m_s_n_videos = IconData(
+    0xeb1c,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData m_s_n_videos_solid = IconData(
+    0xf2da,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData m_s_n_volume = IconData(
+    0xeb15,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData machine_learning = IconData(
+    0xe3b8,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData mail = IconData(
+    0xe715,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData mail_alert = IconData(
+    0xed80,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData mail_attached = IconData(
+    0xf774,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData mail_check = IconData(
+    0xed81,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData mail_fill = IconData(
+    0xe8a8,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData mail_forward = IconData(
+    0xe89c,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData mail_forward_mirrored = IconData(
+    0xea56,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData mail_link = IconData(
+    0xefac,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData mail_low_importance = IconData(
+    0xed82,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData mail_options = IconData(
+    0xf82c,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData mail_pause = IconData(
+    0xed83,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData mail_reminder = IconData(
+    0xf418,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData mail_repeat = IconData(
+    0xed84,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData mail_reply = IconData(
+    0xe8ca,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData mail_reply_all = IconData(
+    0xe8c2,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData mail_reply_all_mirrored = IconData(
+    0xea58,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData mail_reply_mirrored = IconData(
+    0xea57,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData mail_schedule = IconData(
+    0xf72e,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData mail_secure = IconData(
+    0xe4d4,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData mail_solid = IconData(
+    0xf343,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData mail_tentative = IconData(
+    0xf416,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData mail_tentative_mirrored = IconData(
+    0xf417,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData mail_undelivered = IconData(
+    0xf415,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData manager_self_service = IconData(
+    0xee23,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData manufacturing = IconData(
+    0xe99c,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData map_directions = IconData(
+    0xe816,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData map_layers = IconData(
+    0xe81e,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData map_pin = IconData(
+    0xe707,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData map_pin12 = IconData(
+    0xe3ae,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData map_pin_solid = IconData(
+    0xf52e,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData mark_as_protected = IconData(
+    0xf6ae,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData mark_down_language = IconData(
+    0xf2fb,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData market = IconData(
+    0xeafc,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData market_down = IconData(
+    0xef42,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData master_database = IconData(
+    0xf5ba,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData maximum_value = IconData(
+    0xf5bc,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData medal = IconData(
+    0xee38,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData medal_solid = IconData(
+    0xf6b9,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData media = IconData(
+    0xea69,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData media_add = IconData(
+    0xf510,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData medical = IconData(
+    0xead4,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData medical_care = IconData(
+    0xe54d,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData medication_admin = IconData(
+    0xe54e,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData medication_request = IconData(
+    0xe54f,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData megaphone = IconData(
+    0xe789,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData megaphone_solid = IconData(
+    0xf332,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData memo = IconData(
+    0xe77c,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData merge = IconData(
+    0xe7d5,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData merge_case = IconData(
+    0xefc9,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData merge_duplicate = IconData(
+    0xf29a,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData message = IconData(
+    0xe8bd,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData message_fill = IconData(
+    0xec70,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData message_friend_request = IconData(
+    0xf055,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData metrics_failure = IconData(
+    0xe4ce,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData metrics_install = IconData(
+    0xe4cd,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData metrics_usage = IconData(
+    0xe4cc,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData mic_off = IconData(
+    0xec54,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData mic_off2 = IconData(
+    0xf781,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData microphone = IconData(
+    0xe720,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData microsoft_staffhub_logo = IconData(
+    0xf130,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData microsoft_translator_logo = IconData(
+    0xf782,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData microsoft_translator_logo_blue = IconData(
+    0xf853,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData microsoft_translator_logo_green = IconData(
+    0xf852,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData mini_contract = IconData(
+    0xe93b,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData mini_contract_mirrored = IconData(
+    0xea59,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData mini_expand = IconData(
+    0xe93a,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData mini_expand_mirrored = IconData(
+    0xea5a,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData mini_link = IconData(
+    0xe732,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData minimum_value = IconData(
+    0xf5bd,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData mobile_angled = IconData(
+    0xe463,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData mobile_report = IconData(
+    0xf18a,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData mobile_selected = IconData(
+    0xec75,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData model_app_template32 = IconData(
+    0xe5fd,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData modeling_view = IconData(
+    0xf871,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData money = IconData(
+    0xeafd,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData more = IconData(
+    0xe712,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData more_sports = IconData(
+    0xeb22,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData more_vertical = IconData(
+    0xf2bc,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData mosty_clear_night = IconData(
+    0xe476,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData mosty_cloudy_flurries_day = IconData(
+    0xe471,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData mosty_cloudy_flurries_night = IconData(
+    0xe47d,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData mosty_cloudy_showers_day = IconData(
+    0xe46d,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData mosty_cloudy_t_storms_day = IconData(
+    0xe46f,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData mosty_cloudy_t_storms_night = IconData(
+    0xe47b,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData mosty_sunny_day = IconData(
+    0xe468,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData mountain_climbing = IconData(
+    0xf6db,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData move = IconData(
+    0xe7c2,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData move_to_folder = IconData(
+    0xe8de,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData movers = IconData(
+    0xebcd,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData multi_select = IconData(
+    0xe762,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData multi_select_mirrored = IconData(
+    0xea98,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData music_in_collection = IconData(
+    0xe940,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData music_in_collection_fill = IconData(
+    0xea36,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData music_note = IconData(
+    0xec4f,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData mute_chat = IconData(
+    0xf17a,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData my_movies_t_v = IconData(
+    0xee6c,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData my_network = IconData(
+    0xec27,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData n_u_i_face = IconData(
+    0xeb68,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData nav2_d_map_view = IconData(
+    0xe800,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData navigate_back = IconData(
+    0xf2dd,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData navigate_back_mirrored = IconData(
+    0xf2de,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData navigate_external_inline = IconData(
+    0xf35f,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData navigate_forward = IconData(
+    0xf2df,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData navigate_forward_mirrored = IconData(
+    0xf2e0,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData navigation_flipper = IconData(
+    0xf51d,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData network_device_scanning = IconData(
+    0xe4f6,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData network_tower = IconData(
+    0xec05,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData new_analytics_query = IconData(
+    0xf1e0,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData new_folder = IconData(
+    0xe8f4,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData new_mail = IconData(
+    0xf7ea,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData new_team_project = IconData(
+    0xf2b2,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData news = IconData(
+    0xe900,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData news_search = IconData(
+    0xf4e9,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData next = IconData(
+    0xe893,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData normal_weight = IconData(
+    0xf4ef,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData not_executed = IconData(
+    0xf440,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData not_impacted_solid = IconData(
+    0xf441,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData note_forward = IconData(
+    0xed99,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData note_pinned = IconData(
+    0xed9a,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData note_reply = IconData(
+    0xed98,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData nuget_logo = IconData(
+    0xf44c,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData number = IconData(
+    0xf691,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData number_field = IconData(
+    0xedc4,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData number_sequence = IconData(
+    0xf52a,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData number_symbol = IconData(
+    0xf7ac,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData numbered_list = IconData(
+    0xea1c,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData numbered_list_mirrored = IconData(
+    0xe398,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData numbered_list_number = IconData(
+    0xf797,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData numbered_list_number_mirrored = IconData(
+    0xf799,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData numbered_list_text = IconData(
+    0xf796,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData numbered_list_text_mirrored = IconData(
+    0xf798,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData o_d_link = IconData(
+    0xe4bb,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData o_d_link12 = IconData(
+    0xe4bc,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData o_d_shared_channel = IconData(
+    0xe649,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData o_d_shared_channel12 = IconData(
+    0xe64a,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData oauth = IconData(
+    0xe5c3,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData object_recognition = IconData(
+    0xe4ee,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData octagon = IconData(
+    0xf4fd,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData oem = IconData(
+    0xe74c,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData office_addins_logo = IconData(
+    0xeec7,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData office_assistant_logo = IconData(
+    0xedce,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData office_catch_up = IconData(
+    0xe490,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData office_chat = IconData(
+    0xf70f,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData office_chat_solid = IconData(
+    0xf710,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData office_forms_logo = IconData(
+    0xf434,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData office_forms_logo16 = IconData(
+    0xf436,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData office_forms_logo24 = IconData(
+    0xf43b,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData office_forms_logo_inverse = IconData(
+    0xef86,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData office_forms_logo_inverse16 = IconData(
+    0xf433,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData office_forms_logo_inverse24 = IconData(
+    0xf43a,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData office_logo = IconData(
+    0xeb6e,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData office_store_logo = IconData(
+    0xedcf,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData office_video_logo = IconData(
+    0xf282,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData office_video_logo_fill = IconData(
+    0xf283,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData office_video_logo_inverse = IconData(
+    0xed7a,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData offline_one_drive_parachute = IconData(
+    0xeec8,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData offline_one_drive_parachute_disabled = IconData(
+    0xeec9,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData offline_storage = IconData(
+    0xec8c,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData offline_storage_solid = IconData(
+    0xf34e,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData onboarding = IconData(
+    0xf3ba,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData one_drive_add = IconData(
+    0xef32,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData one_drive_folder16 = IconData(
+    0xf53b,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData one_drive_logo = IconData(
+    0xe941,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData one_note_doc_type = IconData(
+    0xf04f,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData one_note_edu_logo_inverse = IconData(
+    0xedd0,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData one_note_logo = IconData(
+    0xf1e7,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData one_note_logo16 = IconData(
+    0xf39a,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData one_note_logo_inverse = IconData(
+    0xec0d,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData one_note_logo_inverse16 = IconData(
+    0xf399,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData open_enrollment = IconData(
+    0xef1c,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData open_file = IconData(
+    0xe8e5,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData open_folder_horizontal = IconData(
+    0xed25,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData open_in_new_tab = IconData(
+    0xf6ab,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData open_in_new_window = IconData(
+    0xe8a7,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData open_pane = IconData(
+    0xe8a0,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData open_pane_mirrored = IconData(
+    0xea5b,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData open_source = IconData(
+    0xebc2,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData open_with = IconData(
+    0xe7ac,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData open_with_mirrored = IconData(
+    0xea5c,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData opportunities = IconData(
+    0xf05f,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData order_lock = IconData(
+    0xe4cb,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData org = IconData(
+    0xeca6,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData orientation = IconData(
+    0xe8b4,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData orientation2 = IconData(
+    0xf7e1,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData out_of_office = IconData(
+    0xed34,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData outlook_logo = IconData(
+    0xf1e9,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData outlook_logo16 = IconData(
+    0xf39d,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData outlook_logo_inverse = IconData(
+    0xeb6d,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData outlook_logo_inverse16 = IconData(
+    0xf39c,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData outlook_spaces_bucket = IconData(
+    0xe481,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData p_a_action = IconData(
+    0xe60b,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData p_b_i_anomalies_marker = IconData(
+    0xe554,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData p_b_i_anomaly = IconData(
+    0xe548,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData p_b_i_column = IconData(
+    0xe67a,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData p_b_i_connect_points = IconData(
+    0xe67b,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData p_b_i_direct_query = IconData(
+    0xe4e9,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData p_b_i_dual = IconData(
+    0xe4ea,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData p_b_i_gap = IconData(
+    0xe67c,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData p_b_i_goal_entry = IconData(
+    0xe615,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData p_b_i_goal_entry_add = IconData(
+    0xe616,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData p_b_i_home_layout_default = IconData(
+    0xe65b,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData p_b_i_home_layout_expanded = IconData(
+    0xe65c,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData p_b_i_import = IconData(
+    0xe4eb,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData p_b_i_live_connect = IconData(
+    0xe4ec,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData p_b_i_perspective = IconData(
+    0xe658,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData p_b_i_report_template = IconData(
+    0xe5ec,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData p_b_i_zero = IconData(
+    0xe67d,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData p_o_i_solid = IconData(
+    0xf2d1,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData package = IconData(
+    0xe7b8,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData packages = IconData(
+    0xf318,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData padding = IconData(
+    0xf518,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData padding_bottom = IconData(
+    0xf51a,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData padding_left = IconData(
+    0xf51b,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData padding_right = IconData(
+    0xf51c,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData padding_top = IconData(
+    0xf519,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData page = IconData(
+    0xe7c3,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData page_add = IconData(
+    0xea1a,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData page_arrow_right = IconData(
+    0xefb8,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData page_block = IconData(
+    0xefb5,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData page_checked_out = IconData(
+    0xf02c,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData page_checkedin = IconData(
+    0xf104,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData page_data = IconData(
+    0xe31c,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData page_edit = IconData(
+    0xefb6,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData page_header = IconData(
+    0xecee,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData page_header_edit = IconData(
+    0xe31d,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData page_left = IconData(
+    0xe760,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData page_link = IconData(
+    0xe302,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData page_list = IconData(
+    0xf106,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData page_list_filter = IconData(
+    0xf813,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData page_list_mirrored_solid = IconData(
+    0xf33b,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData page_list_solid = IconData(
+    0xf33a,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData page_lock = IconData(
+    0xf43f,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData page_permission = IconData(
+    0xe618,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData page_remove = IconData(
+    0xefba,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData page_right = IconData(
+    0xe761,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData page_shared = IconData(
+    0xf02d,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData page_solid = IconData(
+    0xe729,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData pano_indicator = IconData(
+    0xe7b0,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData parachute = IconData(
+    0xf351,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData parachute_solid = IconData(
+    0xf352,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData parameter = IconData(
+    0xf306,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData parking_location = IconData(
+    0xe811,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData parking_location_mirrored = IconData(
+    0xea5e,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData parking_mirrored_solid = IconData(
+    0xf34b,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData parking_solid = IconData(
+    0xf34a,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData partly_clear_night = IconData(
+    0xe477,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData partly_cloudy_day = IconData(
+    0xe9c0,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData partly_cloudy_night = IconData(
+    0xe9c1,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData partly_sunny_day = IconData(
+    0xe469,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData partly_sunny_flurries_day = IconData(
+    0xe472,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData partly_sunny_showers_day = IconData(
+    0xe46e,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData partly_sunny_showers_night = IconData(
+    0xe47a,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData partly_sunny_t_storms_day = IconData(
+    0xe470,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData partly_sunny_t_storms_night = IconData(
+    0xe47c,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData party_leader = IconData(
+    0xeca7,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData passive_authentication = IconData(
+    0xf32a,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData password_field = IconData(
+    0xf6aa,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData paste = IconData(
+    0xe77f,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData paste_as_code = IconData(
+    0xf5d6,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData paste_as_text = IconData(
+    0xf5d5,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData pause = IconData(
+    0xe769,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData payment_card = IconData(
+    0xe8c7,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData pc1 = IconData(
+    0xe977,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData pdf = IconData(
+    0xea90,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData pen_workspace = IconData(
+    0xedc6,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData pencil_reply = IconData(
+    0xef7b,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData pentagon = IconData(
+    0xf4ff,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData people = IconData(
+    0xe716,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData people_add = IconData(
+    0xea15,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData people_alert = IconData(
+    0xed93,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData people_block = IconData(
+    0xed91,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData people_external_share = IconData(
+    0xe5ef,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData people_pause = IconData(
+    0xed94,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData people_repeat = IconData(
+    0xed92,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData permissions = IconData(
+    0xe8d7,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData permissions_solid = IconData(
+    0xf349,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData personalize = IconData(
+    0xe771,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData phishing = IconData(
+    0xf679,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData phishing_campaign = IconData(
+    0xe48d,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData phishing_hook = IconData(
+    0xe48e,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData phone = IconData(
+    0xe717,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData photo = IconData(
+    0xe91b,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData photo2 = IconData(
+    0xeb9f,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData photo2_add = IconData(
+    0xecab,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData photo2_fill = IconData(
+    0xf79f,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData photo2_remove = IconData(
+    0xecac,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData photo_block = IconData(
+    0xe4c3,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData photo_collection = IconData(
+    0xe7aa,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData photo_error = IconData(
+    0xe3f7,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData photo_video_media = IconData(
+    0xf0b1,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData picture = IconData(
+    0xe8b9,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData picture_center = IconData(
+    0xf522,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData picture_fill = IconData(
+    0xf523,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData picture_library = IconData(
+    0xeec2,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData picture_position = IconData(
+    0xf524,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData picture_stretch = IconData(
+    0xf525,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData picture_tile = IconData(
+    0xf526,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData pie_double = IconData(
+    0xeb04,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData pie_single = IconData(
+    0xeb05,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData pie_single_solid = IconData(
+    0xf530,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData pill = IconData(
+    0xeacb,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData pin = IconData(
+    0xe718,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData pin_solid12 = IconData(
+    0xe352,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData pin_solid_off12 = IconData(
+    0xe353,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData pin_to_tab = IconData(
+    0xe5e5,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData pinned = IconData(
+    0xe840,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData pinned_fill = IconData(
+    0xe842,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData pinned_solid = IconData(
+    0xf676,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData pivot_chart = IconData(
+    0xf24c,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData plain_text = IconData(
+    0xf834,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData plan_view = IconData(
+    0xf360,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData planner_logo = IconData(
+    0xedd1,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData play = IconData(
+    0xe768,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData play_resume = IconData(
+    0xf2c6,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData play_reverse = IconData(
+    0xf3e5,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData play_reverse_resume = IconData(
+    0xf3e4,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData play_solid = IconData(
+    0xf5b0,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData playback_rate1x = IconData(
+    0xec57,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData player_settings = IconData(
+    0xef58,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData playlist_music = IconData(
+    0xe93f,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData plug = IconData(
+    0xf300,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData plug_connected = IconData(
+    0xf302,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData plug_disconnected = IconData(
+    0xf303,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData plug_solid = IconData(
+    0xf301,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData poi = IconData(
+    0xecaf,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData poll_results = IconData(
+    0xf8a0,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData pop_expand = IconData(
+    0xe49a,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData portal_app_template32 = IconData(
+    0xe5fc,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData post_update = IconData(
+    0xe8f3,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData power_apps = IconData(
+    0xedd2,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData power_apps2_logo = IconData(
+    0xf092,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData power_apps_logo = IconData(
+    0xf091,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData power_apps_template = IconData(
+    0xe4ac,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData power_automate_logo = IconData(
+    0xf4b1,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData power_b_i_logo = IconData(
+    0xea1e,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData power_b_i_logo16 = IconData(
+    0xf790,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData power_b_i_logo_backplate16 = IconData(
+    0xf791,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData power_button = IconData(
+    0xe7e8,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData power_point_document = IconData(
+    0xef72,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData power_point_logo = IconData(
+    0xf1eb,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData power_point_logo16 = IconData(
+    0xf394,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData power_point_logo_inverse = IconData(
+    0xec2a,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData power_point_logo_inverse16 = IconData(
+    0xf393,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData power_shell = IconData(
+    0xf1fd,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData power_shell2 = IconData(
+    0xf730,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData power_standby = IconData(
+    0xe55c,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData power_virtual_agents_logo = IconData(
+    0xe484,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData precipitation = IconData(
+    0xe9cf,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData presence_chicklet_video = IconData(
+    0xe979,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData presentation = IconData(
+    0xf6e4,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData presentation12 = IconData(
+    0xf6e5,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData preview = IconData(
+    0xe8ff,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData preview_below = IconData(
+    0xe5d5,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData preview_link = IconData(
+    0xe8a1,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData preview_side_by_side = IconData(
+    0xe5d6,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData previous = IconData(
+    0xe892,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData primary_calendar = IconData(
+    0xf4ae,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData print = IconData(
+    0xe749,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData printfax_printer_file = IconData(
+    0xe956,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData priority = IconData(
+    0xe8d0,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData pro_football = IconData(
+    0xeb27,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData pro_hockey = IconData(
+    0xeb28,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData process = IconData(
+    0xe9f3,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData process_advisor = IconData(
+    0xe5e4,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData process_map = IconData(
+    0xe9f6,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData process_meta_task = IconData(
+    0xf290,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData processing = IconData(
+    0xe9f5,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData processing_cancel = IconData(
+    0xe403,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData processing_pause = IconData(
+    0xe405,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData processing_run = IconData(
+    0xe404,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData product = IconData(
+    0xecdc,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData product_catalog = IconData(
+    0xefe8,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData product_list = IconData(
+    0xe31e,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData product_release = IconData(
+    0xee2e,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData product_variant = IconData(
+    0xee30,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData product_warning = IconData(
+    0xe5c0,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData production_floor_management = IconData(
+    0xee29,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData profile_search = IconData(
+    0xef35,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData progress_loop_inner = IconData(
+    0xecde,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData progress_loop_outer = IconData(
+    0xecdf,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData progress_ring5 = IconData(
+    0xedf6,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData progress_ring_dots = IconData(
+    0xf16a,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData project_collection = IconData(
+    0xf363,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData project_document = IconData(
+    0xf759,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData project_logo16 = IconData(
+    0xf480,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData project_logo32 = IconData(
+    0xf47e,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData project_logo_inverse = IconData(
+    0xedd4,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData project_management = IconData(
+    0xe9de,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData promoted_database = IconData(
+    0xf77d,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData pronouns = IconData(
+    0xe556,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData protect_restrict = IconData(
+    0xf22a,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData protected_document = IconData(
+    0xe8a6,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData protection_center_logo32 = IconData(
+    0xf494,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData provisioning_package = IconData(
+    0xe835,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData public_calendar = IconData(
+    0xef6d,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData public_contact_card = IconData(
+    0xef6e,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData public_contact_card_mirrored = IconData(
+    0xf230,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData public_email = IconData(
+    0xef6f,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData public_folder = IconData(
+    0xef70,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData publish_content = IconData(
+    0xf0d4,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData publish_course = IconData(
+    0xf699,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData publisher_logo = IconData(
+    0xf1ed,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData publisher_logo16 = IconData(
+    0xf3a0,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData publisher_logo_inverse16 = IconData(
+    0xf39f,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData puzzle = IconData(
+    0xea86,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData py = IconData(
+    0xf2f9,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData python_language = IconData(
+    0xf2f8,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData q_r_code = IconData(
+    0xed14,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData qand_a = IconData(
+    0xf8a2,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData qand_a_mirror = IconData(
+    0xf8a3,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData quad_column = IconData(
+    0xf66f,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData quantity = IconData(
+    0xe9f8,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData quarter_circle = IconData(
+    0xf502,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData query_list = IconData(
+    0xf2b8,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData questionnaire = IconData(
+    0xee19,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData questionnaire_mirrored = IconData(
+    0xee4b,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData queue_advanced = IconData(
+    0xe62e,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData quick_note = IconData(
+    0xe70b,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData quick_note_solid = IconData(
+    0xf338,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData quotes = IconData(
+    0xf067,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData r = IconData(
+    0xf4eb,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData radio_btn_off = IconData(
+    0xecca,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData radio_btn_on = IconData(
+    0xeccb,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData radio_bullet = IconData(
+    0xe915,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData rain = IconData(
+    0xe9c4,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData rain_showers_day = IconData(
+    0xe9c3,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData rain_showers_night = IconData(
+    0xea0f,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData rain_snow = IconData(
+    0xe9c7,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData rate = IconData(
+    0xeb07,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData raw_source = IconData(
+    0xf299,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData read = IconData(
+    0xe8c3,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData read_out_loud = IconData(
+    0xf112,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData reading_mode = IconData(
+    0xe736,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData reading_mode_solid = IconData(
+    0xf33d,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData real_estate = IconData(
+    0xe758,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData receipt_check = IconData(
+    0xef5b,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData receipt_forward = IconData(
+    0xef59,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData receipt_processing = IconData(
+    0xe496,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData receipt_reply = IconData(
+    0xef5a,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData receipt_tentative = IconData(
+    0xf41a,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData receipt_tentative_mirrored = IconData(
+    0xf41b,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData receipt_undelivered = IconData(
+    0xf419,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData recent = IconData(
+    0xe823,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData record2 = IconData(
+    0xea3f,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData record_routing = IconData(
+    0xe62d,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData recruitment_management = IconData(
+    0xee12,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData rectangle_shape = IconData(
+    0xf1a9,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData rectangle_shape_solid = IconData(
+    0xf640,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData rectangular_clipping = IconData(
+    0xf407,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData recurring_event = IconData(
+    0xef5d,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData recurring_task = IconData(
+    0xedb2,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData recycle_bin = IconData(
+    0xef87,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData red_eye = IconData(
+    0xe7b3,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData red_eye12 = IconData(
+    0xe3ad,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData redeploy = IconData(
+    0xf29e,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData redo = IconData(
+    0xe7a6,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData refresh = IconData(
+    0xe72c,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData registry_editor = IconData(
+    0xf1ff,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData relationship = IconData(
+    0xf003,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData release_definition = IconData(
+    0xf6ea,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData release_gate = IconData(
+    0xf7be,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData release_gate_check = IconData(
+    0xf7bf,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData release_gate_error = IconData(
+    0xf7c0,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData reminder_group = IconData(
+    0xebf8,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData reminder_person = IconData(
+    0xebf7,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData reminder_time = IconData(
+    0xebf9,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData remote = IconData(
+    0xe8af,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData remote_application = IconData(
+    0xf621,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData remove = IconData(
+    0xe738,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData remove_content = IconData(
+    0xecc7,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData remove_event = IconData(
+    0xed8a,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData remove_filter = IconData(
+    0xeb08,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData remove_from_shopping_list = IconData(
+    0xf7d5,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData remove_from_trash = IconData(
+    0xf82b,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData remove_link = IconData(
+    0xed90,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData remove_link_chain = IconData(
+    0xf79a,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData remove_link_x = IconData(
+    0xf79b,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData remove_occurrence = IconData(
+    0xed9b,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData rename = IconData(
+    0xe8ac,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData renewal_current = IconData(
+    0xf545,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData renewal_future = IconData(
+    0xf546,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData reopen_pages = IconData(
+    0xed50,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData repair = IconData(
+    0xe90f,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData repeat_all = IconData(
+    0xe8ee,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData repeat_header_rows = IconData(
+    0xe3eb,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData repeat_one = IconData(
+    0xe8ed,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData reply = IconData(
+    0xe97a,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData reply_all = IconData(
+    0xee0a,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData reply_all_alt = IconData(
+    0xef5f,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData reply_all_mirrored = IconData(
+    0xee36,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData reply_alt = IconData(
+    0xef5e,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData reply_mirrored = IconData(
+    0xee35,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData repo = IconData(
+    0xf2cb,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData repo_solid = IconData(
+    0xf2cc,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData report_add = IconData(
+    0xf52c,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData report_alert = IconData(
+    0xf721,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData report_alert_mirrored = IconData(
+    0xf722,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData report_document = IconData(
+    0xe9f9,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData report_hacked = IconData(
+    0xe730,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData report_library = IconData(
+    0xeebb,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData report_library_mirrored = IconData(
+    0xeebc,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData report_lock = IconData(
+    0xf875,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData report_trophy = IconData(
+    0xe614,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData report_warning = IconData(
+    0xf569,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData rerun = IconData(
+    0xf8a1,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData reservation_orders = IconData(
+    0xf845,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData reset = IconData(
+    0xe423,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData reset_device = IconData(
+    0xed10,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData responses_menu = IconData(
+    0xf768,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData return_key = IconData(
+    0xe751,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData return_to_session = IconData(
+    0xed24,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData rev_toggle_key = IconData(
+    0xe845,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData revenue_management = IconData(
+    0xf85e,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData review_request_mirrored_solid = IconData(
+    0xf357,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData review_request_solid = IconData(
+    0xf356,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData review_response_solid = IconData(
+    0xf358,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData review_solid = IconData(
+    0xf355,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData rewards_logo = IconData(
+    0xed4e,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData rewards_logo_art64 = IconData(
+    0xeef2,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData rewards_logo_solid = IconData(
+    0xed4f,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData rewind = IconData(
+    0xeb9e,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData rewind_eight_x = IconData(
+    0xe449,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData rewind_four_x = IconData(
+    0xe448,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData rewind_one_five_x = IconData(
+    0xe446,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData rewind_one_x = IconData(
+    0xe445,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData rewind_point_five_x = IconData(
+    0xe444,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData rewind_two_x = IconData(
+    0xe447,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData ribbon = IconData(
+    0xe9d1,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData ribbon2 = IconData(
+    0xf19b,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData ribbon_solid = IconData(
+    0xf345,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData right_double_quote = IconData(
+    0xe9b1,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData right_triangle = IconData(
+    0xf500,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData ringer = IconData(
+    0xea8f,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData ringer_active = IconData(
+    0xe498,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData ringer_off = IconData(
+    0xf2c5,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData ringer_remove = IconData(
+    0xf279,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData ringer_solid = IconData(
+    0xef3a,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData robot = IconData(
+    0xe99a,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData rocket = IconData(
+    0xf3b3,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData room = IconData(
+    0xed9f,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData rotate = IconData(
+    0xe7ad,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData rotate90_clockwise = IconData(
+    0xf80d,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData rotate90_counter_clockwise = IconData(
+    0xf80e,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData rows_child = IconData(
+    0xf29c,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData rows_group = IconData(
+    0xf29b,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData rugby = IconData(
+    0xeb2d,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData running = IconData(
+    0xeada,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData s_d_card = IconData(
+    0xe7f1,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData s_i_p_move = IconData(
+    0xe759,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData s_q_l_analytics_pool = IconData(
+    0xe434,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData s_q_l_server_logo = IconData(
+    0xe61a,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData sad = IconData(
+    0xe757,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData sad_solid = IconData(
+    0xf33e,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData samsung_gallery = IconData(
+    0xe4e2,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData save = IconData(
+    0xe74e,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData save_all = IconData(
+    0xf203,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData save_and_close = IconData(
+    0xf038,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData save_as = IconData(
+    0xe792,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData save_template = IconData(
+    0xf6ec,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData save_to_mobile = IconData(
+    0xf7e0,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData saved_offline = IconData(
+    0xe546,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData savings = IconData(
+    0xeb0b,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData scale_up = IconData(
+    0xed09,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData scale_volume = IconData(
+    0xf18c,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData scatter_chart = IconData(
+    0xefeb,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData schedule_event_action = IconData(
+    0xf1ef,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData school_data_sync_logo = IconData(
+    0xe34c,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData scope_template = IconData(
+    0xf2b0,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData screen = IconData(
+    0xef39,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData screen_cast = IconData(
+    0xf7e2,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData screen_preview_on = IconData(
+    0xf11e,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData screen_time = IconData(
+    0xf182,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData script = IconData(
+    0xf03a,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData scroll_up_down = IconData(
+    0xec8f,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData search = IconData(
+    0xe721,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData search_and_apps = IconData(
+    0xe773,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData search_art64 = IconData(
+    0xeef5,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData search_bookmark = IconData(
+    0xf5b8,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData search_calendar = IconData(
+    0xf4af,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData search_data = IconData(
+    0xf3f1,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData search_issue = IconData(
+    0xf09a,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData search_issue_mirrored = IconData(
+    0xf09b,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData search_nearby = IconData(
+    0xe820,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData secondary_nav = IconData(
+    0xf814,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData section = IconData(
+    0xec0c,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData sections = IconData(
+    0xef76,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData security_camera = IconData(
+    0xeb35,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData security_group = IconData(
+    0xed85,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData security_test = IconData(
+    0xe48f,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData see_do = IconData(
+    0xe808,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData select_all = IconData(
+    0xe8b3,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData sell = IconData(
+    0xeb0c,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData semibold_weight = IconData(
+    0xf4f0,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData send = IconData(
+    0xe724,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData send_mirrored = IconData(
+    0xea63,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData sentiment_analysis = IconData(
+    0xe393,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData separator = IconData(
+    0xf35e,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData server = IconData(
+    0xf201,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData server_enviroment = IconData(
+    0xf29f,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData server_processes = IconData(
+    0xf1fe,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData service_activity = IconData(
+    0xeff1,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData service_off = IconData(
+    0xe3fd,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData set_action = IconData(
+    0xf071,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData settings = IconData(
+    0xe713,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData settings_add = IconData(
+    0xe35a,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData settings_secure = IconData(
+    0xe4d2,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData settings_sync = IconData(
+    0xe359,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData shake_device = IconData(
+    0xf80a,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData shape_solid = IconData(
+    0xe422,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData shapes = IconData(
+    0xec7c,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData share = IconData(
+    0xe72d,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData shared_database = IconData(
+    0xe3d9,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData shared_notes = IconData(
+    0xf481,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData sharei_o_s = IconData(
+    0xef79,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData sharepoint2013_logo_inverse = IconData(
+    0xe480,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData sharepoint_app_icon16 = IconData(
+    0xe365,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData sharepoint_logo = IconData(
+    0xf27e,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData sharepoint_logo_inverse = IconData(
+    0xed18,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData shield = IconData(
+    0xea18,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData shield_alert = IconData(
+    0xf7d7,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData shield_solid = IconData(
+    0xf340,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData shirt = IconData(
+    0xed00,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData shop = IconData(
+    0xe719,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData shop_server = IconData(
+    0xf2b6,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData shopping_cart = IconData(
+    0xe7bf,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData shopping_cart_solid = IconData(
+    0xf342,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData show_grid = IconData(
+    0xf7de,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData show_results = IconData(
+    0xe8bc,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData show_results_mirrored = IconData(
+    0xea65,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData show_time_as = IconData(
+    0xf787,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData show_visual_filter = IconData(
+    0xf4de,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData showers = IconData(
+    0xe46c,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData side_panel = IconData(
+    0xef52,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData side_panel_mirrored = IconData(
+    0xf221,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData sign_out = IconData(
+    0xf3b1,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData signin = IconData(
+    0xf286,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData simplified_view = IconData(
+    0xe5c1,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData single_bookmark = IconData(
+    0xedff,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData single_bookmark_solid = IconData(
+    0xee00,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData single_column = IconData(
+    0xf1d3,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData single_column_edit = IconData(
+    0xf321,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData site_scan = IconData(
+    0xebec,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData six_point_star = IconData(
+    0xf504,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData size_legacy = IconData(
+    0xe2b2,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData ski_resorts = IconData(
+    0xeb45,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData skip_back10 = IconData(
+    0xed3c,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData skip_forward30 = IconData(
+    0xed3d,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData skype_arrow = IconData(
+    0xf748,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData skype_check = IconData(
+    0xef80,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData skype_circle_arrow = IconData(
+    0xf747,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData skype_circle_check = IconData(
+    0xef7d,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData skype_circle_clock = IconData(
+    0xef7e,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData skype_circle_minus = IconData(
+    0xef7f,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData skype_circle_slash = IconData(
+    0xf825,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData skype_clock = IconData(
+    0xef81,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData skype_for_business_logo = IconData(
+    0xf0fc,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData skype_for_business_logo16 = IconData(
+    0xf40f,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData skype_for_business_logo_fill = IconData(
+    0xf27d,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData skype_for_business_logo_fill16 = IconData(
+    0xf410,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData skype_logo = IconData(
+    0xeb6f,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData skype_logo16 = IconData(
+    0xf40e,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData skype_message = IconData(
+    0xef83,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData skype_minus = IconData(
+    0xef82,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData skype_slash = IconData(
+    0xf826,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData sleet = IconData(
+    0xe474,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData slider = IconData(
+    0xf527,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData slider_handle_size = IconData(
+    0xf528,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData slider_thumb = IconData(
+    0xec13,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData slideshow = IconData(
+    0xe786,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData smart_glass_remote = IconData(
+    0xf80b,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData snap_to_grid = IconData(
+    0xf7e4,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData snooze = IconData(
+    0xf4bd,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData snow = IconData(
+    0xe9c8,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData snow_shower_day = IconData(
+    0xe9fd,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData snow_shower_night = IconData(
+    0xea11,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData snowflake = IconData(
+    0xeb46,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData soccer = IconData(
+    0xeb21,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData social_listening_logo = IconData(
+    0xed7c,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData sort = IconData(
+    0xe8cb,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData sort_down = IconData(
+    0xee69,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData sort_lines = IconData(
+    0xe9d0,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData sort_lines_ascending = IconData(
+    0xe43a,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData sort_up = IconData(
+    0xee68,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData source = IconData(
+    0xeb1b,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData spacer = IconData(
+    0xf40d,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData speakers = IconData(
+    0xe7f5,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData special_event = IconData(
+    0xf536,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData speech = IconData(
+    0xefa9,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData speech_off = IconData(
+    0xf8ba,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData speed_high = IconData(
+    0xec4a,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData spelling = IconData(
+    0xf87b,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData split = IconData(
+    0xedbc,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData split_object = IconData(
+    0xf547,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData sprint = IconData(
+    0xf3b0,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData squalls = IconData(
+    0xe9cc,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData square_shape = IconData(
+    0xf1a6,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData square_shape_solid = IconData(
+    0xf63d,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData stack = IconData(
+    0xf26f,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData stack_column_chart = IconData(
+    0xe9fc,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData stack_indicator = IconData(
+    0xe7ff,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData stacked_bar_chart = IconData(
+    0xf24d,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData stacked_bar_chart_full = IconData(
+    0xf668,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData stacked_column_chart2 = IconData(
+    0xf666,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData stacked_column_chart2_fill = IconData(
+    0xf831,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData stacked_line_chart = IconData(
+    0xf24e,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData staff_notebook_logo16 = IconData(
+    0xf48e,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData staff_notebook_logo32 = IconData(
+    0xf48c,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData staff_notebook_logo_fill16 = IconData(
+    0xf48f,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData staff_notebook_logo_fill32 = IconData(
+    0xf48d,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData staff_notebook_logo_inverted16 = IconData(
+    0xf491,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData staff_notebook_logo_inverted32 = IconData(
+    0xf490,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData starburst = IconData(
+    0xef78,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData starburst_solid = IconData(
+    0xf33c,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData status_circle_block = IconData(
+    0xf140,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData status_circle_block2 = IconData(
+    0xf141,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData status_circle_checkmark = IconData(
+    0xf13e,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData status_circle_error_x = IconData(
+    0xf13d,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData status_circle_exclamation = IconData(
+    0xf13c,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData status_circle_info = IconData(
+    0xf13f,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData status_circle_inner = IconData(
+    0xf137,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData status_circle_outer = IconData(
+    0xf136,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData status_circle_question_mark = IconData(
+    0xf142,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData status_circle_ring = IconData(
+    0xf138,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData status_circle_sync = IconData(
+    0xf143,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData status_error_full = IconData(
+    0xeb90,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData status_triangle = IconData(
+    0xea82,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData status_triangle_exclamation = IconData(
+    0xf13b,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData status_triangle_inner = IconData(
+    0xf13a,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData status_triangle_outer = IconData(
+    0xf139,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData step = IconData(
+    0xf241,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData step_insert = IconData(
+    0xf242,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData step_shared = IconData(
+    0xf243,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData step_shared_add = IconData(
+    0xf244,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData step_shared_insert = IconData(
+    0xf245,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData sticky_notes_outline_app_icon = IconData(
+    0xe36a,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData sticky_notes_solid_app_icon = IconData(
+    0xe36b,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData stock_down = IconData(
+    0xeb0f,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData stock_up = IconData(
+    0xeb11,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData stop = IconData(
+    0xe71a,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData stop_solid = IconData(
+    0xee95,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData stopwatch = IconData(
+    0xe916,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData storage_acount = IconData(
+    0xe435,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData storage_optical = IconData(
+    0xe958,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData store_logo16 = IconData(
+    0xea96,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData store_logo_med20 = IconData(
+    0xea04,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData storyboard = IconData(
+    0xf308,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData stream_discover = IconData(
+    0xf7d9,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData stream_logo = IconData(
+    0xf329,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData stream_playlist = IconData(
+    0xe669,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData streaming = IconData(
+    0xe93e,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData streaming_dataflow = IconData(
+    0xe668,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData streaming_dataset = IconData(
+    0xe667,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData streaming_off = IconData(
+    0xf2bb,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData street = IconData(
+    0xe913,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData streetside_split_minimize = IconData(
+    0xe802,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData strikethrough = IconData(
+    0xede0,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData strikethrough_korean = IconData(
+    0xe5d4,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData subscribe = IconData(
+    0xeda1,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData subscript = IconData(
+    0xeddf,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData substitutions_in = IconData(
+    0xeb31,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData subtract_shape = IconData(
+    0xf8fc,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData suitcase = IconData(
+    0xedd3,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData summary_chart = IconData(
+    0xe9fe,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData sun_add = IconData(
+    0xef69,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData sun_question_mark = IconData(
+    0xef6a,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData sunny = IconData(
+    0xe9bd,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData superscript = IconData(
+    0xedde,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData survey_question_response = IconData(
+    0xe4f2,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData survey_questions = IconData(
+    0xf01b,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData sway_logo16 = IconData(
+    0xf484,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData sway_logo32 = IconData(
+    0xf482,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData sway_logo_fill16 = IconData(
+    0xf485,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData sway_logo_fill32 = IconData(
+    0xf483,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData sway_logo_inverse = IconData(
+    0xed29,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData switch_user = IconData(
+    0xe748,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData switch_widget = IconData(
+    0xe8ab,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData switcher_start_end = IconData(
+    0xe810,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData sync = IconData(
+    0xe895,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData sync_error = IconData(
+    0xea6a,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData sync_folder = IconData(
+    0xe8f7,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData sync_occurence = IconData(
+    0xf4a3,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData sync_occurence_cancel = IconData(
+    0xf7e7,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData sync_status = IconData(
+    0xf751,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData sync_status_solid = IconData(
+    0xf752,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData sync_to_p_c = IconData(
+    0xee6e,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData system = IconData(
+    0xe770,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData t_f_v_c_logo = IconData(
+    0xf44d,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData t_v_monitor = IconData(
+    0xe7f4,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData t_v_monitor_selected = IconData(
+    0xec77,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData tab = IconData(
+    0xe7e9,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData tab_center = IconData(
+    0xf100,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData tab_one_column = IconData(
+    0xf849,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData tab_three_column = IconData(
+    0xf84b,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData tab_two_column = IconData(
+    0xf84a,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData table = IconData(
+    0xed86,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData table_branded_column = IconData(
+    0xe3f1,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData table_branded_row = IconData(
+    0xe3ee,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData table_column = IconData(
+    0xe4bd,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData table_computed = IconData(
+    0xf8f5,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData table_first_column = IconData(
+    0xe3ef,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData table_group = IconData(
+    0xf6d9,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData table_header_row = IconData(
+    0xe3ec,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData table_last_column = IconData(
+    0xe3f0,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData table_link = IconData(
+    0xf77a,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData table_permission = IconData(
+    0xe619,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData table_total_row = IconData(
+    0xe3ed,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData tablet = IconData(
+    0xe70a,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData tablet_mode = IconData(
+    0xebfc,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData tablet_selected = IconData(
+    0xec74,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData tag = IconData(
+    0xe8ec,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData tag_group = IconData(
+    0xe3f6,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData tag_solid = IconData(
+    0xf70e,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData tag_unknown = IconData(
+    0xf6df,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData tag_unknown12 = IconData(
+    0xf6e1,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData tag_unknown12_mirror = IconData(
+    0xf6e2,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData tag_unknown_mirror = IconData(
+    0xf6e0,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData task_add = IconData(
+    0xe4fd,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData task_group = IconData(
+    0xf2ae,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData task_group_mirrored = IconData(
+    0xf2af,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData task_list = IconData(
+    0xe3b6,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData task_logo = IconData(
+    0xf493,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData task_manager = IconData(
+    0xedb7,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData task_manager_mirrored = IconData(
+    0xedb8,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData task_solid = IconData(
+    0xf333,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData taskboard = IconData(
+    0xf1c2,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData taxi = IconData(
+    0xf4a1,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData team_favorite = IconData(
+    0xf2ad,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData teams_logo = IconData(
+    0xf27b,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData teams_logo16 = IconData(
+    0xf40a,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData teams_logo_inverse = IconData(
+    0xf27a,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData teamwork = IconData(
+    0xea12,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData teeth = IconData(
+    0xf4a0,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData telemarketer = IconData(
+    0xe7b9,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData temporary_access_pass = IconData(
+    0xe4ad,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData temporary_user = IconData(
+    0xee58,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData tennis = IconData(
+    0xeb33,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData test_add = IconData(
+    0xe4dc,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData test_auto_solid = IconData(
+    0xf3a8,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData test_beaker = IconData(
+    0xf3a5,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData test_beaker_solid = IconData(
+    0xf3a6,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData test_case = IconData(
+    0xf3af,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData test_explore_solid = IconData(
+    0xf3a7,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData test_impact_solid = IconData(
+    0xf3aa,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData test_parameter = IconData(
+    0xf3ad,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData test_plan = IconData(
+    0xf3ab,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData test_remove = IconData(
+    0xe4e1,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData test_step = IconData(
+    0xf3ac,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData test_suite = IconData(
+    0xf3ae,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData test_user_solid = IconData(
+    0xf3a9,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData text_align_bottom = IconData(
+    0xe3e2,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData text_align_middle = IconData(
+    0xe3e1,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData text_align_top = IconData(
+    0xe3e0,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData text_box = IconData(
+    0xedc2,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData text_callout = IconData(
+    0xf2a2,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData text_document = IconData(
+    0xf029,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData text_document_edit = IconData(
+    0xe43b,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData text_document_settings = IconData(
+    0xe4aa,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData text_document_shared = IconData(
+    0xf02b,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData text_field = IconData(
+    0xedc3,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData text_overflow = IconData(
+    0xf51f,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData text_paragraph_option = IconData(
+    0xe3e3,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData text_recognition = IconData(
+    0xe394,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData text_rotate270_degrees = IconData(
+    0xe3e7,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData text_rotate90_degrees = IconData(
+    0xe3e6,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData text_rotate_horizontal = IconData(
+    0xe3e5,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData text_rotation = IconData(
+    0xe3e4,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData this_p_c = IconData(
+    0xec4e,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData three_quarter_circle = IconData(
+    0xf503,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData thumbnail_view = IconData(
+    0xe7b6,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData thumbnail_view_mirrored = IconData(
+    0xea67,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData thunderstorms = IconData(
+    0xe9c6,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData ticket = IconData(
+    0xeb54,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData tiles = IconData(
+    0xeca5,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData tiles2 = IconData(
+    0xef7c,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData time_entry = IconData(
+    0xef95,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData time_picker = IconData(
+    0xe367,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData time_sheet = IconData(
+    0xea05,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData timeline = IconData(
+    0xed9c,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData timeline_delivery = IconData(
+    0xf2ab,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData timeline_matrix_view = IconData(
+    0xf361,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData timeline_progress = IconData(
+    0xf2aa,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData timer = IconData(
+    0xe91e,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData title = IconData(
+    0xf23b,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData title_mirrored = IconData(
+    0xf23c,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData to_do_logo_bottom = IconData(
+    0xf4b3,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData to_do_logo_inverse = IconData(
+    0xf4bc,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData to_do_logo_outline = IconData(
+    0xf75b,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData to_do_logo_top = IconData(
+    0xf4b4,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData toggle_border = IconData(
+    0xec12,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData toggle_filled = IconData(
+    0xec11,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData toggle_left = IconData(
+    0xf19e,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData toggle_right = IconData(
+    0xf19f,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData toggle_thumb = IconData(
+    0xec14,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData toll = IconData(
+    0xf160,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData toolbox = IconData(
+    0xeced,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData total = IconData(
+    0xe9df,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData touch = IconData(
+    0xe815,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData touch_pointer = IconData(
+    0xe7c9,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData trackers = IconData(
+    0xeadf,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData trackers_mirrored = IconData(
+    0xee92,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData train = IconData(
+    0xe7c0,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData train_solid = IconData(
+    0xeb4d,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData transfer_call = IconData(
+    0xed95,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData transition = IconData(
+    0xf3bc,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData transition_effect = IconData(
+    0xf5b4,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData transition_pop = IconData(
+    0xf5b2,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData transition_push = IconData(
+    0xf5b3,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData translate = IconData(
+    0xe7b2,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData transportation = IconData(
+    0xebf1,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData trending12 = IconData(
+    0xf62d,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData triangle_down12 = IconData(
+    0xeed1,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData triangle_left12 = IconData(
+    0xeed2,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData triangle_right12 = IconData(
+    0xeed3,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData triangle_shape = IconData(
+    0xf1a7,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData triangle_shape_solid = IconData(
+    0xf63e,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData triangle_solid = IconData(
+    0xea08,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData triangle_solid_down12 = IconData(
+    0xeecd,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData triangle_solid_left12 = IconData(
+    0xeece,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData triangle_solid_right12 = IconData(
+    0xeecf,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData triangle_solid_up12 = IconData(
+    0xeecc,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData triangle_up12 = IconData(
+    0xeed0,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData trigger_approval = IconData(
+    0xf3b2,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData trigger_auto = IconData(
+    0xf24a,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData trigger_phrase = IconData(
+    0xe5ff,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData trigger_user = IconData(
+    0xf24b,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData trim = IconData(
+    0xe78a,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData trim_end = IconData(
+    0xf8bc,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData trim_start = IconData(
+    0xf8bb,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData triple_column = IconData(
+    0xf1d5,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData triple_column_edit = IconData(
+    0xf323,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData triple_column_wide = IconData(
+    0xf66e,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData trophy = IconData(
+    0xed3f,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData trophy2 = IconData(
+    0xf1ae,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData trophy2_solid = IconData(
+    0xf337,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData turn_right = IconData(
+    0xe7db,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData twelve_point_star = IconData(
+    0xf505,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData type_script_language = IconData(
+    0xf2f7,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData u_r_l_block = IconData(
+    0xe3fe,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData umbrella = IconData(
+    0xec04,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData un_set_color = IconData(
+    0xf3f9,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData unavailable_offline = IconData(
+    0xe545,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData underline = IconData(
+    0xe8dc,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData underline_a = IconData(
+    0xe5cc,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData underline_korean = IconData(
+    0xe5bb,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData underline_p = IconData(
+    0xe5cd,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData underline_russian = IconData(
+    0xe5b8,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData underline_s = IconData(
+    0xe5b4,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData underline_serbian = IconData(
+    0xe5cb,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData undo = IconData(
+    0xe7a7,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData uneditable = IconData(
+    0xed1d,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData uneditable2 = IconData(
+    0xf876,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData uneditable2_mirrored = IconData(
+    0xf877,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData uneditable_mirrored = IconData(
+    0xf4b9,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData uneditable_solid12 = IconData(
+    0xf4b7,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData uneditable_solid_mirrored12 = IconData(
+    0xf4b8,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData unfavorite = IconData(
+    0xe8d9,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData ungroup_object = IconData(
+    0xf4f2,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData unite_shape = IconData(
+    0xf8fb,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData unknown = IconData(
+    0xe9ce,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData unknown_call = IconData(
+    0xed97,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData unknown_mirrored = IconData(
+    0xf22e,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData unknown_mirrored_solid = IconData(
+    0xf2e2,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData unknown_solid = IconData(
+    0xf2e1,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData unlock = IconData(
+    0xe785,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData unlock_solid = IconData(
+    0xf304,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData unpin = IconData(
+    0xe77a,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData unpublish_content = IconData(
+    0xe31f,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData unstack_selected = IconData(
+    0xe7fe,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData unsubscribe = IconData(
+    0xeda0,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData unsync_folder = IconData(
+    0xe8f6,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData unsync_occurence = IconData(
+    0xf4a4,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData untag = IconData(
+    0xf60b,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData up = IconData(
+    0xe74a,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData update_restore = IconData(
+    0xe777,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData upgrade_analysis = IconData(
+    0xea0b,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData upload = IconData(
+    0xe898,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData upper_case = IconData(
+    0xe5ed,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData usb = IconData(
+    0xe88e,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData user_clapper = IconData(
+    0xe666,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData user_event = IconData(
+    0xf69c,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData user_followed = IconData(
+    0xf25c,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData user_gauge = IconData(
+    0xf6ed,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData user_optional = IconData(
+    0xf767,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData user_pause = IconData(
+    0xf2ba,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData user_remove = IconData(
+    0xf69b,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData user_sync = IconData(
+    0xf2b9,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData user_warning = IconData(
+    0xe368,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData user_window = IconData(
+    0xe4ed,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData v_s_t_s_alt_logo1 = IconData(
+    0xf382,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData v_s_t_s_alt_logo2 = IconData(
+    0xf383,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData v_s_t_s_logo = IconData(
+    0xf381,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData vacation = IconData(
+    0xf49f,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData vaccination = IconData(
+    0xeae0,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData vaccination_recent = IconData(
+    0xe550,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData variable = IconData(
+    0xf305,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData variable2 = IconData(
+    0xf86d,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData variable3 = IconData(
+    0xe4d1,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData variable_group = IconData(
+    0xf31b,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData vb = IconData(
+    0xf2f2,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData venn_diagram = IconData(
+    0xf273,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData verified_brand = IconData(
+    0xf7bd,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData verified_brand_solid = IconData(
+    0xf6ad,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData version_control_push = IconData(
+    0xf664,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData vertical_distribute_center = IconData(
+    0xf4fa,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData video = IconData(
+    0xe714,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData video360_generic = IconData(
+    0xf609,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData video_add = IconData(
+    0xe430,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData video_light_off = IconData(
+    0xea74,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData video_off = IconData(
+    0xf4b0,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData video_off2 = IconData(
+    0xe43c,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData video_search = IconData(
+    0xf4ea,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData video_solid = IconData(
+    0xea0c,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData view = IconData(
+    0xe890,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData view_all = IconData(
+    0xe8a9,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData view_all2 = IconData(
+    0xef56,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData view_dashboard = IconData(
+    0xf246,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData view_in_a_r = IconData(
+    0xe41f,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData view_list = IconData(
+    0xf247,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData view_list_group = IconData(
+    0xf248,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData view_list_tree = IconData(
+    0xf249,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData view_original = IconData(
+    0xe7b4,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData virtual_network = IconData(
+    0xf815,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData visio_diagram = IconData(
+    0xf2a0,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData visio_diagram_sync = IconData(
+    0xf762,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData visio_document = IconData(
+    0xf2a9,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData visio_logo = IconData(
+    0xf2a7,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData visio_logo16 = IconData(
+    0xf3a3,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData visio_logo_inverse = IconData(
+    0xed7d,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData visio_logo_inverse16 = IconData(
+    0xf3a2,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData visual_basic_language = IconData(
+    0xf2f1,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData visual_studio_for_windows = IconData(
+    0xf5d0,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData visual_studio_for_windows_alt = IconData(
+    0xec22,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData visually_impaired = IconData(
+    0xf866,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData visuals_folder = IconData(
+    0xf520,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData visuals_store = IconData(
+    0xf521,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData voicemail_forward = IconData(
+    0xed87,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData voicemail_i_r_m = IconData(
+    0xf421,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData voicemail_reply = IconData(
+    0xed88,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData volume0 = IconData(
+    0xe992,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData volume1 = IconData(
+    0xe993,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData volume2 = IconData(
+    0xe994,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData volume3 = IconData(
+    0xe995,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData volume_disabled = IconData(
+    0xea85,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData waffle = IconData(
+    0xed89,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData waffle_office365 = IconData(
+    0xf4e0,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData waitlist_confirm = IconData(
+    0xf550,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData waitlist_confirm_mirrored = IconData(
+    0xf551,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const IconData warning = IconData(
+    0xe7ba,
+    fontFamily: 'FluentIcons',
+    fontPackage: 'fluent_ui',
+  );
+  static const Map<String, IconData> allIcons = {
     'a_a_d_logo': a_a_d_logo,
     'a_t_p_logo': a_t_p_logo,
     'accept': accept,
@@ -3540,7 +12386,8 @@ class FluentIcons {
     'office_video_logo_fill': office_video_logo_fill,
     'office_video_logo_inverse': office_video_logo_inverse,
     'offline_one_drive_parachute': offline_one_drive_parachute,
-    'offline_one_drive_parachute_disabled': offline_one_drive_parachute_disabled,
+    'offline_one_drive_parachute_disabled':
+        offline_one_drive_parachute_disabled,
     'offline_storage': offline_storage,
     'offline_storage_solid': offline_storage_solid,
     'onboarding': onboarding,

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,10 +1,10 @@
 name: fluent_ui
 description: Implements Windows UI in Flutter. Based on the official documentation
-version: 3.9.1
+version: 3.9.2
 homepage: https://github.com/bdlukaa/fluent_ui
 
 environment:
-  sdk: '>=2.14.4 <3.0.0'
+  sdk: ">=2.14.4 <3.0.0"
   flutter: ">=2.8.0"
 
 dependencies:


### PR DESCRIPTION
<!-- Add a description of what this PR is changing or adding, and why. Consider mentioning issues -->

This PR fixes some linting warnings pointed by [pana](https://pub.dev/packages/pana) on pub.dev's [score](https://pub.dev/packages/fluent_ui/score).
It also updates `icon_generator.dart` to generate prettier output.

## Pre-launch Checklist

<!-- Mark all that applyes -->

- [X] I have run `dartfmt` on all changed files <!-- REQUIRED --> 
- [X] I have updated `CHANGELOG.md` with my changes <!-- REQUIRED --> 
- [X] I have run "optimize/organize imports" on all changed files
- [X] I have addressed all analyzer warnings as best I could
- [X] I have added/updated relevant documentation
- [X] I have run `flutter pub publish --dry-run` and addressed any warnings