### PR TITLE
Implement basic command bars

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ Date format: DD/MM/YYYY
 - TreeView now implemented with ListView and optionally allows vertical scrolling ([#255](https://github.com/bdlukaa/fluent_ui/pull/225))
 - TreeViewItem now has custom primary key (`value` field)
 - Added `onSelectionChanged` callback to `TreeView`
+- Implement `CommandBar` (dynamic overflow not yet supported)
+- Add `HorizontalScrollView` helper widget, with mouse wheel horizontal scrolling
 
 ## [3.9.1] - Input Update - [25/02/2022]
 

--- a/README.md
+++ b/README.md
@@ -85,6 +85,7 @@ Unofficial implementation of Fluent UI for [Flutter](flutter.dev). It's written 
   - [TreeView](#treeview)
     - [Scrollable tree view](#scrollable-tree-view)
     - [Lazily load nodes](#lazily-load-nodes)
+  - [CommandBar](#commandbar)
 - [Mobile Widgets](#mobile-widgets)
   - [Chip](#chip)
   - [Pill Button Bar](#pill-button-bar)
@@ -1553,6 +1554,44 @@ TreeView(
   items: items,
 );
 ```
+
+## CommandBar
+
+A `CommandBar` control provides quick access to common tasks. This could be application-level or page-level commands. [Learn More](https://docs.microsoft.com/en-us/windows/apps/design/controls/command-bar)
+
+![CommandBar Simple](https://docs.microsoft.com/en-us/windows/apps/design/controls/images/controls-appbar-icons.png)
+
+The `CommandBar` is composed of a number of `CommandBarItem` widgets, which could be `CommandBarButton` or any custom widget (e.g., a "split button" widget).
+
+A `CommandBarCard` can be used to create a raised card around a `CommandBar`. While this is not officially part of the Fluent design language, the concept is commonly used in the Office desktop apps for the app-level command bar.
+
+Different behaviors can be selected when the width of the `CommandBarItem` widgets exceeds the constraints, as determined by the specified `CommandBarOverflowBehavior`, including wrapping, clipping, scrolling, and no wrapping (will overflow).
+
+Here is an example of a simple command bar:
+
+```dart
+CommandBar(
+  wrapType: CommandBarOverflowBehavior.scrolling,
+  children: [
+    CommandBarButton(
+      icon: FluentIcons.add,
+      label: const Text('Add'),
+      onPressed: () {},
+    ),
+    CommandBarButton(
+      icon: FluentIcons.edit,
+      label: const Text('Edit'),
+      onPressed: () {},
+    ),
+    CommandBarButton(
+      icon: FluentIcons.more,
+      onPressed: () {},
+    ),
+  ],
+),
+```
+
+**Help Wanted**: The current implementation does not implement the open/closed state, nor does it implement the secondary commands "more" button with dynamic overflow of items into the secondary commands menu.
 
 # Mobile Widgets
 

--- a/example/lib/screens/others.dart
+++ b/example/lib/screens/others.dart
@@ -13,8 +13,71 @@ class _OthersState extends State<Others> {
   int currentIndex = 0;
 
   final flyoutController = FlyoutController();
+  final scrollController = ScrollController();
 
   bool checked = false;
+
+  final simpleCommandBarItems = <Widget>[
+    Tooltip(
+      message: "Create something new!",
+      child: CommandBarButton(
+        icon: FluentIcons.add,
+        label: const Text('New'),
+        onPressed: () {},
+      ),
+    ),
+    Tooltip(
+      message: "Delete what is currently selected",
+      child: CommandBarButton(
+        icon: FluentIcons.delete,
+        label: const Text('Delete'),
+        onPressed: () {},
+      ),
+    ),
+    CommandBarButton(
+      icon: FluentIcons.archive,
+      label: const Text('Archive'),
+      onPressed: () {},
+    ),
+    CommandBarButton(
+      icon: FluentIcons.move,
+      label: const Text('Move'),
+      onPressed: () {},
+    ),
+  ];
+
+  final moreCommandBarItems = <Widget>[
+    CommandBarButton(
+      icon: FluentIcons.reply,
+      label: const Text('Reply'),
+      onPressed: () {},
+    ),
+    CommandBarButton(
+      icon: FluentIcons.reply_all,
+      label: const Text('Reply All'),
+      onPressed: () {},
+    ),
+    CommandBarButton(
+      icon: FluentIcons.forward,
+      label: const Text('Forward'),
+      onPressed: () {},
+    ),
+    CommandBarButton(
+      icon: FluentIcons.search,
+      label: const Text('Search'),
+      onPressed: () {},
+    ),
+    CommandBarButton(
+      icon: FluentIcons.pin,
+      label: const Text('Pin'),
+      onPressed: () {},
+    ),
+    CommandBarButton(
+      icon: FluentIcons.unpin,
+      label: const Text('Unpin'),
+      onPressed: () {},
+    ),
+  ];
 
   final items = [
     TreeViewItem(
@@ -94,6 +157,7 @@ class _OthersState extends State<Others> {
   @override
   void dispose() {
     flyoutController.dispose();
+    scrollController.dispose();
     super.dispose();
   }
 
@@ -166,6 +230,7 @@ class _OthersState extends State<Others> {
   @override
   Widget build(BuildContext context) {
     return ScaffoldPage.scrollable(
+      scrollController: scrollController,
       header: const PageHeader(title: Text('Others')),
       children: [
         const SizedBox(height: 10.0),
@@ -397,6 +462,7 @@ class _OthersState extends State<Others> {
                 child: TreeView(
                   items: treeViewItemsSimple,
                   shrinkWrap: false,
+                  scrollPrimary: false,
                 ),
               ),
             ),
@@ -415,6 +481,7 @@ class _OthersState extends State<Others> {
                 child: TreeView(
                   selectionMode: TreeViewSelectionMode.single,
                   shrinkWrap: false,
+                  scrollPrimary: false,
                   items: treeViewItemsSingleSelection,
                   onItemInvoked: (item) async =>
                       debugPrint('onItemInvoked: $item'),
@@ -438,6 +505,7 @@ class _OthersState extends State<Others> {
                 child: TreeView(
                   selectionMode: TreeViewSelectionMode.multiple,
                   shrinkWrap: false,
+                  scrollPrimary: false,
                   items: treeViewItemsMultipleSelection,
                   onItemInvoked: (item) async =>
                       debugPrint('onItemInvoked: $item'),
@@ -465,6 +533,108 @@ class _OthersState extends State<Others> {
               ),
             ),
           ],
+        ),
+        const SizedBox(height: 20.0),
+        InfoLabel(
+          label: 'Simple command bar (no wrapping)',
+          child: CommandBar(
+            wrapType: CommandBarOverflowBehavior.noWrap,
+            children: [
+              ...simpleCommandBarItems,
+            ],
+          ),
+        ),
+        const SizedBox(height: 20.0),
+        InfoLabel(
+          label: 'Command bar with many items (wrapping)',
+          child: CommandBar(
+            wrapType: CommandBarOverflowBehavior.wrap,
+            children: [
+              ...simpleCommandBarItems,
+              ...moreCommandBarItems,
+            ],
+          ),
+        ),
+        const SizedBox(height: 20.0),
+        InfoLabel(
+          label: 'Command bar with many items (clipped)',
+          child: ConstrainedBox(
+            constraints: const BoxConstraints(maxWidth: 230),
+            child: CommandBarCard(
+              child: CommandBar(
+                wrapType: CommandBarOverflowBehavior.clip,
+                children: [
+                  ...simpleCommandBarItems,
+                  ...moreCommandBarItems,
+                ],
+              ),
+            ),
+          ),
+        ),
+        const SizedBox(height: 20.0),
+        InfoLabel(
+          label:
+              'Carded complex command bar with many items (horizontal scrolling)',
+          child: CommandBarCard(
+            child: Row(
+              children: [
+                Expanded(
+                  child: CommandBar(
+                    wrapType: CommandBarOverflowBehavior.scrolling,
+                    parentVerticalScrollController: scrollController,
+                    children: [
+                      ...simpleCommandBarItems,
+                      ...moreCommandBarItems,
+                    ],
+                  ),
+                ),
+                // Right-aligned button(s)
+                CommandBar(
+                  wrapType: CommandBarOverflowBehavior.noWrap,
+                  children: [
+                    CommandBarButton(
+                      icon: FluentIcons.refresh,
+                      onPressed: () {},
+                    ),
+                  ],
+                ),
+              ],
+            ),
+          ),
+        ),
+        const SizedBox(height: 20.0),
+        InfoLabel(
+          label: 'Carded complex command bar with many items (wrapping)',
+          child: CommandBarCard(
+            child: Row(
+              children: [
+                Expanded(
+                  child: CommandBar(
+                    wrapType: CommandBarOverflowBehavior.wrap,
+                    parentVerticalScrollController: scrollController,
+                    children: [
+                      ...simpleCommandBarItems,
+                      ...moreCommandBarItems,
+                    ],
+                  ),
+                ),
+                // Right-aligned button(s)
+                CommandBar(
+                  wrapType: CommandBarOverflowBehavior.noWrap,
+                  children: [
+                    CommandBarButton(
+                      icon: FluentIcons.refresh,
+                      onPressed: () {},
+                    ),
+                    CommandBarButton(
+                      icon: FluentIcons.more,
+                      onPressed: () {},
+                    ),
+                  ],
+                ),
+              ],
+            ),
+          ),
         ),
       ],
     );

--- a/lib/fluent_ui.dart
+++ b/lib/fluent_ui.dart
@@ -66,6 +66,7 @@ export 'src/controls/navigation/tree_view.dart';
 export 'src/controls/surfaces/calendar/calendar_view.dart';
 export 'src/controls/surfaces/bottom_sheet.dart';
 export 'src/controls/surfaces/card.dart';
+export 'src/controls/surfaces/commandbar.dart';
 export 'src/controls/surfaces/dialog.dart';
 export 'src/controls/surfaces/expander.dart';
 export 'src/controls/surfaces/flyout/flyout.dart';
@@ -97,4 +98,5 @@ export 'src/styles/theme.dart';
 export 'src/styles/typography.dart';
 
 export 'src/styles/focus.dart';
+export 'src/utils/horizontal_scroll_view.dart';
 export 'src/utils/label.dart';

--- a/lib/src/controls/navigation/tree_view.dart
+++ b/lib/src/controls/navigation/tree_view.dart
@@ -360,6 +360,8 @@ class TreeView extends StatefulWidget {
     this.onItemInvoked,
     this.loadingWidget = kTreeViewLoadingIndicator,
     this.shrinkWrap = true,
+    this.scrollPrimary,
+    this.scrollController,
     this.cacheExtent,
     this.itemExtent,
     this.addRepaintBoundaries = true,
@@ -395,6 +397,12 @@ class TreeView extends StatefulWidget {
 
   /// {@macro flutter.widgets.scroll_view.shrinkWrap}
   final bool shrinkWrap;
+
+  /// {@macro flutter.widgets.scroll_view.primary}
+  final bool? scrollPrimary;
+
+  /// {@macro flutter.widgets.scroll_view.controller}
+  final ScrollController? scrollController;
 
   /// {@macro flutter.rendering.RenderViewportBase.cacheExtent}
   final double? cacheExtent;
@@ -464,6 +472,11 @@ class _TreeViewState extends State<TreeView> {
       constraints: const BoxConstraints(minHeight: 28.0),
       child: ListView.builder(
         scrollDirection: Axis.vertical,
+        // If shrinkWrap is true, then we default to not using the primary
+        // scroll controller (should not normally need any controller in
+        // this case).
+        primary: widget.scrollPrimary ?? (widget.shrinkWrap ? false : null),
+        controller: widget.scrollController,
         shrinkWrap: widget.shrinkWrap,
         cacheExtent: widget.cacheExtent,
         itemExtent: widget.itemExtent,

--- a/lib/src/controls/surfaces/commandbar.dart
+++ b/lib/src/controls/surfaces/commandbar.dart
@@ -1,0 +1,178 @@
+import 'package:fluent_ui/fluent_ui.dart';
+
+/// A card with appropriate margins, padding, and elevation for it to
+/// contain one or more [CommandBar]s.
+class CommandBarCard extends StatelessWidget {
+  final Widget child;
+  final double elevation;
+  final EdgeInsetsGeometry? margin;
+  final EdgeInsets padding;
+
+  const CommandBarCard({
+    Key? key,
+    required this.child,
+    this.margin,
+    this.padding = const EdgeInsets.symmetric(horizontal: 6.0, vertical: 4.0),
+    this.elevation = 2.0,
+  }) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      margin: margin,
+      child: Card(
+        padding: padding,
+        elevation: elevation,
+        child: child,
+      ),
+    );
+  }
+}
+
+/// The type of wrapping used for the items inside of the CommandBar.
+///
+///   * [CommandBarOverflowBehavior.scrolling] will cause items to scroll horizontally.
+///   * [CommandBarOverflowBehavior.noWrap] will expand the size of the CommandBar based
+///      on the size of the contained items.
+///   * [CommandBarOverflowBehavior.wrap] will wrap items onto additional lines as needed.
+///   * [CommandBarOverflowBehavior.clip] will keep items on one line and clip as needed.
+enum CommandBarOverflowBehavior {
+  scrolling,
+  noWrap,
+  wrap,
+  clip,
+  // TODO: Implement support for an overflow button and dynamically overflowing items into the "SecondaryCommands" flyout
+}
+
+/// Command bars provide quick access to common tasks. This could be
+/// application-level or page-level commands.
+///
+/// A command bar is composed of a series of [CommandBarItem]s, which each could
+/// be a [CommandBarButton] or a custom [CommandBarItem].
+///
+/// If there is not enough horizontal space to display all items, the wrapping
+/// behavior is determined by [wrapType].
+///
+/// ![CommandBar example](https://docs.microsoft.com/en-us/windows/apps/design/controls/images/controls-appbar-icons.png)
+///
+/// See also:
+///
+///   * <https://docs.microsoft.com/en-us/windows/apps/design/controls/command-bar>
+class CommandBar extends StatelessWidget {
+  final List<Widget> children;
+  final CommandBarOverflowBehavior wrapType;
+  final bool _isExpanded;
+  final ScrollController? parentVerticalScrollController;
+
+  const CommandBar(
+      {Key? key,
+      required this.children,
+      this.wrapType = CommandBarOverflowBehavior.scrolling,
+      this.parentVerticalScrollController})
+      : _isExpanded = !(wrapType == CommandBarOverflowBehavior.noWrap),
+        super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    late Widget w;
+    switch (wrapType) {
+      case CommandBarOverflowBehavior.scrolling:
+        w = HorizontalScrollView(
+          child: Row(children: children),
+          parentVerticalScrollController: parentVerticalScrollController,
+        );
+        break;
+      case CommandBarOverflowBehavior.noWrap:
+        w = Row(children: children);
+        break;
+      case CommandBarOverflowBehavior.wrap:
+        w = Wrap(
+          children: children,
+        );
+        break;
+      case CommandBarOverflowBehavior.clip:
+        w = SingleChildScrollView(
+          scrollDirection: Axis.horizontal,
+          physics: const NeverScrollableScrollPhysics(),
+          child: Row(children: children),
+        );
+        break;
+    }
+    if (_isExpanded) {
+      w = Row(children: [Expanded(child: w)]);
+    }
+    return w;
+  }
+}
+
+/// An individual control displayed within a [CommandBar]. This widget ensures
+/// that the child widget has the proper margin so the item has the proper
+/// minimum height and width expected of a control within a [CommandBar].
+class CommandBarItem extends StatelessWidget {
+  final Widget child;
+
+  const CommandBarItem({Key? key, required this.child}) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      margin: const EdgeInsets.symmetric(vertical: 6.0, horizontal: 3.0),
+      child: child,
+    );
+  }
+}
+
+/// Buttons are the most common control to put within a [CommandBar].
+/// They are composed of an (optional) icon and an optional
+class CommandBarButton extends StatelessWidget {
+  final IconData? icon;
+  final Color? iconColor;
+  final String? iconSemanticLabel;
+  final TextDirection? iconTextDirection;
+  final Widget? label;
+  final VoidCallback? onPressed;
+  final VoidCallback? onLongPress;
+  final FocusNode? focusNode;
+  final bool autofocus;
+
+  const CommandBarButton(
+      {Key? key,
+      this.icon,
+      this.iconColor,
+      this.iconSemanticLabel,
+      this.iconTextDirection,
+      required this.onPressed,
+      this.onLongPress,
+      this.focusNode,
+      this.autofocus = false,
+      this.label})
+      : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    return IconButton(
+      onPressed: onPressed,
+      onLongPress: onLongPress,
+      focusNode: focusNode,
+      autofocus: autofocus,
+      icon: CommandBarItem(
+        child: Row(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            if (icon != null) ...[
+              Icon(
+                icon,
+                size: 16,
+                color: iconColor,
+                semanticLabel: iconSemanticLabel,
+                textDirection: iconTextDirection,
+              ),
+              if (label != null) const SizedBox(width: 10),
+            ],
+            if (label != null) label!,
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/src/utils/horizontal_scroll_view.dart
+++ b/lib/src/utils/horizontal_scroll_view.dart
@@ -1,0 +1,80 @@
+import 'package:fluent_ui/fluent_ui.dart';
+import 'package:flutter/gestures.dart';
+
+/// A specialized kind of [SingleChildScrollView] that only scrolls
+/// horizontally, and allows the mouse wheel to control scrolling.
+class HorizontalScrollView extends StatefulWidget {
+  final Widget child;
+  final ScrollPhysics? scrollPhysics;
+
+  /// Whether or not the mouse wheel can be used to scroll
+  /// horizontally. On desktop platforms under a default Flutter
+  /// configuration, this may be the only way to scroll horizontally
+  /// unless the user has a trackpad.
+  final bool mouseWheelScrolls;
+
+  /// If this widget is contained in another widget that can scroll vertically,
+  /// when a mouse wheel event is received it will also trigger a vertical
+  /// scroll. Specify the scroll controller for this parent widget that
+  /// controls the vertical scrolling and it will offset the vertical scroll
+  /// on a mouse wheel event, so that it does not vertically scroll at all.
+  final ScrollController? parentVerticalScrollController;
+
+  const HorizontalScrollView({
+    Key? key,
+    required this.child,
+    this.scrollPhysics,
+    this.mouseWheelScrolls = true,
+    this.parentVerticalScrollController,
+  }) : super(key: key);
+
+  @override
+  _HorizontalScrollViewState createState() => _HorizontalScrollViewState();
+}
+
+class _HorizontalScrollViewState extends State<HorizontalScrollView> {
+  late final ScrollController _controller;
+
+  @override
+  void initState() {
+    super.initState();
+    _controller = ScrollController();
+  }
+
+  @override
+  void dispose() {
+    _controller.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Listener(
+      onPointerSignal: widget.mouseWheelScrolls
+          ? (event) {
+              if (event is PointerScrollEvent) {
+                _controller.animateTo(_controller.offset + event.scrollDelta.dy,
+                    duration: const Duration(milliseconds: 100),
+                    curve: Curves.ease);
+                if (widget.parentVerticalScrollController != null &&
+                    widget
+                        .parentVerticalScrollController!.positions.isNotEmpty) {
+                  widget.parentVerticalScrollController!.jumpTo(widget
+                          .parentVerticalScrollController!
+                          .positions
+                          .last
+                          .pixels -
+                      event.scrollDelta.dy);
+                }
+              }
+            }
+          : null,
+      child: SingleChildScrollView(
+        scrollDirection: Axis.horizontal,
+        physics: widget.scrollPhysics ?? const ClampingScrollPhysics(),
+        controller: _controller,
+        child: widget.child,
+      ),
+    );
+  }
+}


### PR DESCRIPTION
This is a first implementation of command bars as described in #231.

A `CommandBar` control provides quick access to common tasks. This could be application-level or page-level commands.

Refer to [the spec](https://docs.microsoft.com/en-us/windows/apps/design/controls/command-bar).

The current implementation does not implement the open/closed state, nor does it implement the secondary commands "more" button with dynamic overflow of items into the secondary commands menu.

Also, during implementation of the example, I realized that I needed control over the `primary` and `controller` properties of the `ListView` inside of the `TreeView`, so this also adds these properties to `TreeView`.

Here is what the examples look like with the various overflow behaviors:

![image](https://user-images.githubusercontent.com/88254524/159105153-0f7d5f7a-b432-40a0-a0b9-62b4213c8b56.png)

And here is what it looks like alongside the large `TreeView`:

![image](https://user-images.githubusercontent.com/88254524/159105166-0af75829-d5bf-4875-9902-a4736fd8cb58.png)

## Pre-launch Checklist

- [X] I have updated `CHANGELOG.md` with my changes <!-- REQUIRED --> 
- [X] I have run "optimize/organize imports" on all changed files
- [X] I have added/updated relevant documentation