### PR TITLE
Add isCompact field to CommandBar

### DIFF
--- a/example/lib/screens/commandbars.dart
+++ b/example/lib/screens/commandbars.dart
@@ -149,12 +149,13 @@ class _CommandBarsState extends State<CommandBars> {
         ),
         const SizedBox(height: 20.0),
         InfoLabel(
-          label: 'Carded command bar with many items (clipped)',
+          label: 'Carded compact command bar with many items (clipped)',
           child: ConstrainedBox(
             constraints: const BoxConstraints(maxWidth: 230),
             child: CommandBarCard(
               child: CommandBar(
                 overflowBehavior: CommandBarOverflowBehavior.clip,
+                isCompact: true,
                 primaryItems: [
                   ...simpleCommandBarItems,
                   const CommandBarSeparator(),

--- a/lib/src/controls/surfaces/commandbar.dart
+++ b/lib/src/controls/surfaces/commandbar.dart
@@ -98,6 +98,20 @@ class CommandBar extends StatefulWidget {
   /// using [CommandBarItemDisplayMode.inPrimary].
   final double? compactBreakpointWidth;
 
+  /// If [compactBreakpointWidth] is null, then specifies whether or not
+  /// primary items should be displayed in compact mode
+  /// ([CommandBarItemDisplayMode.inPrimaryCompact]) or normal mode
+  /// [CommandBarItemDisplayMode.inPrimary].
+  ///
+  /// This can be useful if the CommandBar is used in a setting where
+  /// [compactBreakpointWidth] cannot be used (i.e. because using
+  /// [LayoutBuilder] cannot be used in a context where the intrinsic
+  /// height is also calculated), and you want to specify whether or not
+  /// the primary items should be compact or not.
+  ///
+  /// If [compactBreakpointWidth] is not null this field is ignored.
+  final bool? isCompact;
+
   /// The alignment of the items within the command bar across the main axis
   final MainAxisAlignment mainAxisAlignment;
 
@@ -122,6 +136,7 @@ class CommandBar extends StatefulWidget {
     this.overflowItemBuilder,
     this.overflowBehavior = CommandBarOverflowBehavior.dynamicOverflow,
     this.compactBreakpointWidth,
+    this.isCompact,
     this.mainAxisAlignment = MainAxisAlignment.start,
     this.crossAxisAlignment = CrossAxisAlignment.center,
     this.overflowItemAlignment = MainAxisAlignment.end,
@@ -309,7 +324,10 @@ class _CommandBarState extends State<CommandBar> {
   @override
   Widget build(BuildContext context) {
     if (widget.compactBreakpointWidth == null) {
-      return _buildForPrimaryMode(context, CommandBarItemDisplayMode.inPrimary);
+      var displayMode = (widget.isCompact ?? false)
+          ? CommandBarItemDisplayMode.inPrimaryCompact
+          : CommandBarItemDisplayMode.inPrimary;
+      return _buildForPrimaryMode(context, displayMode);
     } else {
       return LayoutBuilder(
         builder: (context, constraints) {

--- a/lib/src/controls/surfaces/commandbar.dart
+++ b/lib/src/controls/surfaces/commandbar.dart
@@ -93,12 +93,12 @@ class CommandBar extends StatefulWidget {
 
   /// If the width of this widget is less then the indicated amount,
   /// items in the primary area will be rendered using
-  /// [CommandBarItemDisplayMode.inPrimaryCompact]. If this is null
+  /// [CommandBarItemDisplayMode.inPrimaryCompact]. If this is `null`
   /// or the width of this widget is wider, then the items will be rendered
   /// using [CommandBarItemDisplayMode.inPrimary].
   final double? compactBreakpointWidth;
 
-  /// If [compactBreakpointWidth] is null, then specifies whether or not
+  /// If [compactBreakpointWidth] is `null`, then specifies whether or not
   /// primary items should be displayed in compact mode
   /// ([CommandBarItemDisplayMode.inPrimaryCompact]) or normal mode
   /// [CommandBarItemDisplayMode.inPrimary].
@@ -109,7 +109,7 @@ class CommandBar extends StatefulWidget {
   /// height is also calculated), and you want to specify whether or not
   /// the primary items should be compact or not.
   ///
-  /// If [compactBreakpointWidth] is not null this field is ignored.
+  /// If [compactBreakpointWidth] is not `null` this field is ignored.
   final bool? isCompact;
 
   /// The alignment of the items within the command bar across the main axis
@@ -324,7 +324,7 @@ class _CommandBarState extends State<CommandBar> {
   @override
   Widget build(BuildContext context) {
     if (widget.compactBreakpointWidth == null) {
-      var displayMode = (widget.isCompact ?? false)
+      final displayMode = (widget.isCompact ?? false)
           ? CommandBarItemDisplayMode.inPrimaryCompact
           : CommandBarItemDisplayMode.inPrimary;
       return _buildForPrimaryMode(context, displayMode);


### PR DESCRIPTION
Small follow-on tweak to #232 to add an explicit field `isCompact` that can indicate that the primary display area should display the items in compact mode, without relying on `compactBreakpointWidth`. While `compactBreakpointWidth` is convenient, it was breaking things in some of my more complex layouts that already had a `LayoutBuilder` in a parent widget higher in the org tree. This allows use of the `compactBreakpointWidth` for convenience in most cases, or complete control over compact mode using `isCompact` otherwise. Default behavior has not changed.