### PR TITLE
Restyle CommandBar Flyout

### DIFF
--- a/lib/src/controls/surfaces/commandbar.dart
+++ b/lib/src/controls/surfaces/commandbar.dart
@@ -225,7 +225,7 @@ class _CommandBarState extends State<CommandBar> {
       overflowWidget = Flyout(
         child: overflowItem.build(context, primaryMode),
         content: FlyoutContent(
-          padding: const EdgeInsets.only(top: 8.0, right: 8.0, left: 8.0),
+          padding: const EdgeInsets.only(top: 8.0),
           child: ListView(
             shrinkWrap: true,
             children: allSecondaryItems
@@ -493,13 +493,16 @@ class CommandBarButton extends CommandBarItem {
           ),
         );
       case CommandBarItemDisplayMode.inSecondary:
-        return FlyoutListTile(
-          key: key,
-          onPressed: onPressed,
-          focusNode: focusNode,
-          autofocus: autofocus,
-          icon: icon,
-          text: label ?? const SizedBox.shrink(),
+        return Padding(
+          padding: const EdgeInsets.only(right: 8.0, left: 8.0),
+          child: FlyoutListTile(
+            key: key,
+            onPressed: onPressed,
+            focusNode: focusNode,
+            autofocus: autofocus,
+            icon: icon,
+            text: label ?? const SizedBox.shrink(),
+          ),
         );
     }
   }

--- a/lib/src/controls/surfaces/commandbar.dart
+++ b/lib/src/controls/surfaces/commandbar.dart
@@ -184,11 +184,10 @@ class _CommandBarState extends State<CommandBar> {
       case CrossAxisAlignment.center:
         return WrapCrossAlignment.center;
       case CrossAxisAlignment.stretch:
-        throw UnsupportedError(
-            'CommandBar does not support CrossAxisAlignment.stretch');
       case CrossAxisAlignment.baseline:
         throw UnsupportedError(
-            'CommandBar does not support CrossAxisAlignment.baseline');
+          'CommandBar does not support ${widget.crossAxisAlignment}',
+        );
     }
   }
 
@@ -226,7 +225,7 @@ class _CommandBarState extends State<CommandBar> {
       overflowWidget = Flyout(
         child: overflowItem.build(context, primaryMode),
         content: FlyoutContent(
-          padding: EdgeInsets.zero,
+          padding: const EdgeInsets.only(top: 8.0, right: 8.0, left: 8.0),
           child: ListView(
             shrinkWrap: true,
             children: allSecondaryItems
@@ -494,16 +493,13 @@ class CommandBarButton extends CommandBarItem {
           ),
         );
       case CommandBarItemDisplayMode.inSecondary:
-        return TappableListTile(
+        return FlyoutListTile(
           key: key,
-          onTap: onPressed,
+          onPressed: onPressed,
           focusNode: focusNode,
           autofocus: autofocus,
-          leading: (icon != null)
-              ? IconTheme(
-                  data: IconTheme.of(context).copyWith(size: 16), child: icon!)
-              : null,
-          title: label,
+          icon: icon,
+          text: label ?? const SizedBox.shrink(),
         );
     }
   }
@@ -557,10 +553,7 @@ class CommandBarSeparator extends CommandBarItem {
           style: DividerThemeData(
             thickness: thickness,
             decoration: color != null ? BoxDecoration(color: color) : null,
-            horizontalMargin: const EdgeInsets.symmetric(
-              vertical: 0.0,
-              horizontal: 0.0,
-            ),
+            horizontalMargin: const EdgeInsets.only(bottom: 5.0),
           ),
         );
     }

--- a/lib/src/controls/surfaces/flyout/flyout.dart
+++ b/lib/src/controls/surfaces/flyout/flyout.dart
@@ -163,11 +163,11 @@ class FlyoutListTile extends StatelessWidget {
             color: ButtonThemeData.uncheckedInputColor(theme, states),
             borderRadius: radius,
           ),
-          padding: const EdgeInsets.only(
+          padding: const EdgeInsetsDirectional.only(
             top: 4.0,
             bottom: 4.0,
-            left: 10.0,
-            right: 8.0,
+            start: 10.0,
+            end: 8.0,
           ),
           child: Row(mainAxisSize: MainAxisSize.min, children: [
             if (icon != null)

--- a/lib/src/controls/surfaces/flyout/flyout.dart
+++ b/lib/src/controls/surfaces/flyout/flyout.dart
@@ -82,7 +82,7 @@ class FlyoutContent extends StatelessWidget {
     required this.child,
     this.color,
     this.shape,
-    this.padding = const EdgeInsets.all(12.0),
+    this.padding = const EdgeInsets.all(8.0),
     this.shadowColor,
     this.elevation = 8,
   }) : super(key: key);
@@ -100,25 +100,128 @@ class FlyoutContent extends StatelessWidget {
   Widget build(BuildContext context) {
     assert(debugCheckHasFluentTheme(context));
     final ThemeData theme = FluentTheme.of(context);
-    return Acrylic(
+    return PhysicalModel(
       elevation: elevation,
-      tintAlpha: 1.0,
-      tint: color ?? theme.acrylicBackgroundColor,
-      shape: shape ??
-          RoundedRectangleBorder(
-            borderRadius: BorderRadius.circular(4.0),
-            side: BorderSide(
-              color: theme.inactiveBackgroundColor,
-              width: 0.9,
-            ),
+      color: Colors.transparent,
+      shadowColor: Colors.black,
+      child: Container(
+        decoration: BoxDecoration(
+          color: theme.menuColor,
+          borderRadius: BorderRadius.circular(6.0),
+          border: Border.all(
+            width: 0.25,
+            color: theme.inactiveBackgroundColor,
           ),
-      child: Padding(
+        ),
         padding: padding,
         child: DefaultTextStyle(
           style: theme.typography.body ?? const TextStyle(),
           child: child,
         ),
       ),
+    );
+  }
+}
+
+/// A tile that is used inside of [FlyoutContent]
+class FlyoutListTile extends StatelessWidget {
+  /// Creates a flyout list tile.
+  const FlyoutListTile({
+    Key? key,
+    this.onPressed,
+    this.tooltip,
+    this.icon,
+    required this.text,
+    this.trailing,
+    this.focusNode,
+    this.autofocus = false,
+  }) : super(key: key);
+
+  final VoidCallback? onPressed;
+
+  final String? tooltip;
+  final Widget? icon;
+  final Widget text;
+  final Widget? trailing;
+
+  final FocusNode? focusNode;
+  final bool autofocus;
+
+  @override
+  Widget build(BuildContext context) {
+    return HoverButton(
+      key: key,
+      onPressed: onPressed,
+      focusNode: focusNode,
+      autofocus: autofocus,
+      builder: (context, states) {
+        final theme = FluentTheme.of(context);
+        final radius = BorderRadius.circular(4.0);
+
+        Widget content = Container(
+          decoration: BoxDecoration(
+            color: ButtonThemeData.uncheckedInputColor(theme, states),
+            borderRadius: radius,
+          ),
+          padding: const EdgeInsets.only(
+            top: 4.0,
+            bottom: 4.0,
+            left: 10.0,
+            right: 8.0,
+          ),
+          child: Row(mainAxisSize: MainAxisSize.min, children: [
+            if (icon != null)
+              Padding(
+                padding: const EdgeInsetsDirectional.only(end: 10.0),
+                child: IconTheme.merge(
+                  data: const IconThemeData(size: 16.0),
+                  child: icon!,
+                ),
+              ),
+            Expanded(
+              child: Padding(
+                padding: const EdgeInsetsDirectional.only(end: 10.0),
+                child: DefaultTextStyle(
+                  child: text,
+                  style: TextStyle(
+                    inherit: false,
+                    fontSize: 14.0,
+                    letterSpacing: -0.15,
+                    color: theme.inactiveColor,
+                  ),
+                ),
+              ),
+            ),
+            if (trailing != null)
+              DefaultTextStyle(
+                child: trailing!,
+                style: TextStyle(
+                  inherit: false,
+                  fontSize: 12.0,
+                  color: theme.borderInputColor,
+                  height: 0.7,
+                ),
+              ),
+          ]),
+        );
+
+        if (tooltip != null) {
+          content = Tooltip(
+            message: tooltip,
+            child: content,
+          );
+        }
+
+        return Padding(
+          padding: const EdgeInsets.only(bottom: 5.0),
+          child: FocusBorder(
+            focused: states.isFocused,
+            renderOutside: true,
+            style: FocusThemeData(borderRadius: radius),
+            child: content,
+          ),
+        );
+      },
     );
   }
 }


### PR DESCRIPTION
<!-- Add a description of what this PR is changing or adding, and why. Consider mentioning issues -->

- Added `FlyoutListTile`, that uses the same base as `DropDownButtonItem.build` and the tile for text selection controls. In the future, they should be unified
- Update the `FlyoutContent`, without `Acrylic` and with the recent `FluentTheme.menuColor`

![example 24_03_2022 18_01_28](https://user-images.githubusercontent.com/45696119/160009570-b1ad4a54-9faf-4607-baae-e168ee9ba7f7.png)

@klondikedragon

## Pre-launch Checklist

<!-- Mark all that applyes -->

- [ ] I have updated `CHANGELOG.md` with my changes <!-- REQUIRED -->  _Not necessary since this is a continuation of the CommandBars PR, that hasn't been released_
- [x] I have run "optimize/organize imports" on all changed files
- [x] I have added/updated relevant documentation