### PR TITLE
Fix incompatibility with flutter 3.0.0 and remove required keyword from color property in FluentApp.router()

### DIFF
--- a/lib/src/app.dart
+++ b/lib/src/app.dart
@@ -92,7 +92,7 @@ class FluentApp extends StatefulWidget {
     this.builder,
     this.title = '',
     this.onGenerateTitle,
-    required Color this.color,
+    this.color,
     this.locale,
     this.localizationsDelegates,
     this.localeListResolutionCallback,

--- a/lib/src/controls/form/combo_box.dart
+++ b/lib/src/controls/form/combo_box.dart
@@ -1072,16 +1072,16 @@ class _ComboboxState<T> extends State<Combobox<T>> with WidgetsBindingObserver {
       ),
     };
     focusNode!.addListener(_handleFocusChanged);
-    final FocusManager focusManager = WidgetsBinding.instance!.focusManager;
+    final FocusManager focusManager = WidgetsBinding.instance.focusManager;
     _focusHighlightMode = focusManager.highlightMode;
     focusManager.addHighlightModeListener(_handleFocusHighlightModeChange);
   }
 
   @override
   void dispose() {
-    WidgetsBinding.instance!.removeObserver(this);
+    WidgetsBinding.instance.removeObserver(this);
     _removeComboboxRoute();
-    WidgetsBinding.instance!.focusManager
+    WidgetsBinding.instance.focusManager
         .removeHighlightModeListener(_handleFocusHighlightModeChange);
     focusNode!.removeListener(_handleFocusChanged);
     _internalNode?.dispose();

--- a/lib/src/controls/form/selection_controls.dart
+++ b/lib/src/controls/form/selection_controls.dart
@@ -23,7 +23,7 @@ class _FluentTextSelectionControls extends TextSelectionControls {
     Offset selectionMidpoint,
     List<TextSelectionPoint> endpoints,
     TextSelectionDelegate delegate,
-    ClipboardStatusNotifier clipboardStatus,
+    ClipboardStatusNotifier? clipboardStatus,
     Offset? lastSecondaryTapDownPosition,
   ) {
     return _FluentTextSelectionControlsToolbar(
@@ -100,7 +100,7 @@ class _FluentTextSelectionControlsToolbar extends StatefulWidget {
     required this.lastSecondaryTapDownPosition,
   }) : super(key: key);
 
-  final ClipboardStatusNotifier clipboardStatus;
+  final ClipboardStatusNotifier? clipboardStatus;
   final List<TextSelectionPoint> endpoints;
   final Rect globalEditableRegion;
   final VoidCallback? handleCopy;

--- a/lib/src/controls/navigation/navigation_view/indicators.dart
+++ b/lib/src/controls/navigation/navigation_view/indicators.dart
@@ -47,13 +47,13 @@ class NavigationIndicatorState<T extends NavigationIndicator> extends State<T> {
   void initState() {
     super.initState();
     fetch();
-    WidgetsBinding.instance?.addPostFrameCallback((timeStamp) {
+    WidgetsBinding.instance.addPostFrameCallback((timeStamp) {
       setState(() {});
     });
   }
 
   void fetch() {
-    WidgetsBinding.instance?.addPostFrameCallback((timeStamp) {
+    WidgetsBinding.instance.addPostFrameCallback((timeStamp) {
       final _offsets = pane.effectiveItems._getPaneItemsOffsets(
         pane.paneKey,
       );

--- a/lib/src/controls/surfaces/tooltip.dart
+++ b/lib/src/controls/surfaces/tooltip.dart
@@ -186,18 +186,18 @@ class _TooltipState extends State<Tooltip> with SingleTickerProviderStateMixin {
     super.initState();
     _isConcealed = false;
     _forceRemoval = false;
-    _mouseIsConnected = RendererBinding.instance!.mouseTracker.mouseIsConnected;
+    _mouseIsConnected = RendererBinding.instance.mouseTracker.mouseIsConnected;
     _controller = AnimationController(
       duration: _fadeInDuration,
       reverseDuration: _fadeOutDuration,
       vsync: this,
     )..addStatusListener(_handleStatusChanged);
     // Listen to see when a mouse is added.
-    RendererBinding.instance!.mouseTracker
+    RendererBinding.instance.mouseTracker
         .addListener(_handleMouseTrackerChange);
     // Listen to global pointer events so that we can hide a tooltip immediately
     // if some other control is clicked on.
-    GestureBinding.instance!.pointerRouter.addGlobalRoute(_handlePointerEvent);
+    GestureBinding.instance.pointerRouter.addGlobalRoute(_handlePointerEvent);
   }
 
   @override
@@ -246,7 +246,7 @@ class _TooltipState extends State<Tooltip> with SingleTickerProviderStateMixin {
       return;
     }
     final bool mouseIsConnected =
-        RendererBinding.instance!.mouseTracker.mouseIsConnected;
+        RendererBinding.instance.mouseTracker.mouseIsConnected;
     if (mouseIsConnected != _mouseIsConnected) {
       setState(() {
         _mouseIsConnected = mouseIsConnected;
@@ -459,9 +459,9 @@ class _TooltipState extends State<Tooltip> with SingleTickerProviderStateMixin {
 
   @override
   void dispose() {
-    GestureBinding.instance!.pointerRouter
+    GestureBinding.instance.pointerRouter
         .removeGlobalRoute(_handlePointerEvent);
-    RendererBinding.instance!.mouseTracker
+    RendererBinding.instance.mouseTracker
         .removeListener(_handleMouseTrackerChange);
     _removeEntry();
     _controller.dispose();

--- a/lib/src/layout/dynamic_overflow.dart
+++ b/lib/src/layout/dynamic_overflow.dart
@@ -612,7 +612,7 @@ class RenderDynamicOverflow extends RenderBox
       if (overflowChangedCallback != null) {
         // This will likely trigger setState in a parent widget,
         // so schedule to happen at the end of the frame...
-        SchedulerBinding.instance?.addPostFrameCallback((_) {
+        SchedulerBinding.instance.addPostFrameCallback((_) {
           overflowChangedCallback!(hiddenChildren);
         });
       }

--- a/lib/src/styles/acrylic.dart
+++ b/lib/src/styles/acrylic.dart
@@ -90,7 +90,7 @@ class _AcrylicState extends State<Acrylic> {
   void initState() {
     super.initState();
     _NoiseTextureCacher._instance ??= _NoiseTextureCacher._new();
-    WidgetsBinding.instance!.addPostFrameCallback((timeStamp) {
+    WidgetsBinding.instance.addPostFrameCallback((timeStamp) {
       _updateProperties();
       setState(() {});
     });

--- a/lib/src/utils/horizontal_scroll_view.dart
+++ b/lib/src/utils/horizontal_scroll_view.dart
@@ -49,7 +49,7 @@ class _HorizontalScrollViewState extends State<HorizontalScrollView> {
                 // Make sure we capture this pointer scroll event so that
                 // any scrollable widgets higher up in the hierarchy do not
                 // handle the event also.
-                GestureBinding.instance!.pointerSignalResolver.register(event,
+                GestureBinding.instance.pointerSignalResolver.register(event,
                     (event) {
                   if (event is PointerScrollEvent) {
                     // Use animateTo for a smoother behavior when there are

--- a/lib/src/utils/popup.dart
+++ b/lib/src/utils/popup.dart
@@ -479,7 +479,7 @@ class __PopupContentManagerState extends State<_PopupContentManager> {
 
   @override
   void initState() {
-    WidgetsBinding.instance?.addPostFrameCallback((timeStamp) {
+    WidgetsBinding.instance.addPostFrameCallback((timeStamp) {
       final context = key.currentContext;
       if (context == null) return;
       final RenderBox box = context.findRenderObject() as RenderBox;

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -70,7 +70,7 @@ packages:
       name: collection
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.15.0"
+    version: "1.16.0"
   convert:
     dependency: transitive
     description:
@@ -98,7 +98,7 @@ packages:
       name: fake_async
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.2.0"
+    version: "1.3.0"
   file:
     dependency: transitive
     description:
@@ -183,7 +183,7 @@ packages:
       name: material_color_utilities
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.1.3"
+    version: "0.1.4"
   meta:
     dependency: transitive
     description:
@@ -204,7 +204,7 @@ packages:
       name: path
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.8.0"
+    version: "1.8.1"
   petitparser:
     dependency: transitive
     description:
@@ -244,7 +244,7 @@ packages:
       name: source_span
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.8.1"
+    version: "1.8.2"
   stack_trace:
     dependency: transitive
     description:
@@ -279,7 +279,7 @@ packages:
       name: test_api
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.4.8"
+    version: "0.4.9"
   typed_data:
     dependency: transitive
     description:
@@ -293,7 +293,7 @@ packages:
       name: vector_math
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.1"
+    version: "2.1.2"
   watcher:
     dependency: transitive
     description:
@@ -309,5 +309,5 @@ packages:
     source: hosted
     version: "3.1.0"
 sdks:
-  dart: ">=2.15.0 <3.0.0"
+  dart: ">=2.17.0-0 <3.0.0"
   flutter: ">=2.8.0"


### PR DESCRIPTION
1. Fix incompatibility with flutter 3.0.0
2. Remove required keyword from color property in FluentApp.router()

- [ ] I have updated `CHANGELOG.md` with my changes
- [X] I have run "dart format ." on the project
- [ ] I have added/updated relevant documentation