### PR TITLE
Public PaneItemKeys for support custom PaneItem

### DIFF
--- a/lib/src/controls/navigation/navigation_view/body.dart
+++ b/lib/src/controls/navigation/navigation_view/body.dart
@@ -255,8 +255,8 @@ class InheritedNavigationView extends InheritedWidget {
 }
 
 /// Makes the [GlobalKey]s for [PaneItem]s accesible on the scope.
-class _PaneItemKeys extends InheritedWidget {
-  const _PaneItemKeys({
+class PaneItemKeys extends InheritedWidget {
+  const PaneItemKeys({
     Key? key,
     required Widget child,
     required this.keys,
@@ -267,12 +267,12 @@ class _PaneItemKeys extends InheritedWidget {
   /// Gets the item global key based on the index
   static GlobalKey of(int index, BuildContext context) {
     final reference =
-        context.dependOnInheritedWidgetOfExactType<_PaneItemKeys>()!;
+        context.dependOnInheritedWidgetOfExactType<PaneItemKeys>()!;
     return reference.keys[index]!;
   }
 
   @override
-  bool updateShouldNotify(_PaneItemKeys oldWidget) {
+  bool updateShouldNotify(PaneItemKeys oldWidget) {
     return keys != oldWidget.keys;
   }
 }

--- a/lib/src/controls/navigation/navigation_view/pane_items.dart
+++ b/lib/src/controls/navigation/navigation_view/pane_items.dart
@@ -289,7 +289,7 @@ class PaneItem extends NavigationPaneItem {
         if (maybeBody?.pane?.indicator != null &&
             index != null &&
             !index.isNegative) {
-          final key = _PaneItemKeys.of(index, context);
+          final key = PaneItemKeys.of(index, context);
 
           return Stack(children: [
             button,

--- a/lib/src/controls/navigation/navigation_view/view.dart
+++ b/lib/src/controls/navigation/navigation_view/view.dart
@@ -527,7 +527,7 @@ class NavigationViewState extends State<NavigationView> {
           minimalPaneOpen: _minimalPaneOpen,
           pane: widget.pane,
           oldIndex: oldIndex,
-          child: _PaneItemKeys(keys: _itemKeys, child: paneResult),
+          child: PaneItemKeys(keys: _itemKeys, child: paneResult),
         ),
       );
     });


### PR DESCRIPTION
when overriding method build of PaneItem should get pane key from PaneItemKeys class.

## Pre-launch Checklist

<!-- Mark all that applyes -->

- [x] I have updated `CHANGELOG.md` with my changes <!-- REQUIRED --> 
- [x] I have run "dart format ." on the project <!-- REQUIRED --> 
- [x] I have added/updated relevant documentation