### PR TITLE
Fix bug: The disabled TextBox blocks the focus traversal by pressing SHIFT+Tab keys

### DIFF
--- a/lib/src/controls/form/text_box.dart
+++ b/lib/src/controls/form/text_box.dart
@@ -649,6 +649,7 @@ class _TextBoxState extends State<TextBox>
             : TextEditingValue(text: widget.initialValue!),
       );
     }
+    _effectiveFocusNode.canRequestFocus = enabled;
     _effectiveFocusNode.addListener(_handleFocusChanged);
   }
 
@@ -657,6 +658,12 @@ class _TextBoxState extends State<TextBox>
       _effectiveFocusNode.nextFocus();
     }
     setState(() {});
+  }
+
+  @override
+  void didChangeDependencies() {
+    super.didChangeDependencies();
+    _effectiveFocusNode.canRequestFocus = enabled;
   }
 
   @override
@@ -674,6 +681,8 @@ class _TextBoxState extends State<TextBox>
     if (wasEnabled && !isEnabled) {
       _effectiveFocusNode.unfocus();
     }
+
+    _effectiveFocusNode.canRequestFocus = enabled;
   }
 
   @override


### PR DESCRIPTION
Fix bug: The disabled TextBox blocks the focus traversal by pressing SHIFT+Tab keys

<!-- Add a description of what this PR is changing or adding, and why. Consider mentioning issues -->
* Bug reproduction steps:  
1. Start fluent_ui example in debug mode
2. Select TextBox example in the left sidebar.
3. Press Tab a few times to switch focus  
4. When the focus switches to the control after the "Disabled" TextBox
5. Then you press "SHIFT+TAB", the focus cannot be switched back to the control before the "Disabled" TextBox.

## Pre-launch Checklist

<!-- Mark all that applies -->

- [ ] I have updated `CHANGELOG.md` with my changes <!-- REQUIRED --> 
- [x] I have run "dart format ." on the project <!-- REQUIRED --> 
- [ ] I have added/updated relevant documentation