### PR TITLE
Revert attribute content and add assert with pane attribute

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,10 +2,10 @@ Date format: DD/MM/YYYY
 
 ## [next]
 
-- **BREAKING** Removed `NavigationBody`. Use `PaneItem.body` instead ([#510](https://github.com/bdlukaa/fluent_ui/pull/510)):
+- **BREAKING** Removed `NavigationBody`. Use `PaneItem.body` instead ([#510](https://github.com/bdlukaa/fluent_ui/pull/510)/[#531](https://github.com/bdlukaa/fluent_ui/pull/531)):  
   Before:
   ```dart
-  NavigationBody(
+  NavigationView(
     pane: NavigationPane(
       items: [
         PaneItem(icon: Icon(FluentIcons.add)),
@@ -23,9 +23,9 @@ Date format: DD/MM/YYYY
   ),
   ```
   
-  Now:
+  Now:  
   ```dart
-  NavigationBody(
+  NavigationView(
     ...
     pane: NavigationPane(
       items: [
@@ -45,6 +45,19 @@ Date format: DD/MM/YYYY
     ),
   ),
   ```
+  
+  Or if you didn't have panes, you can use the content like that:  
+  ```dart
+  NavigationView(
+    content: ScaffoldPage(
+      header: PageHeader(
+        title: titleRow,
+      ),
+      content: child,
+    ),
+  ),
+  ```
+  *Note: one attribute of pane or content attribute must be null*
 
   You can use `NavigationView.transitionsBuilder`
 - Fixes memory leaks on `NavigationView`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,7 +57,7 @@ Date format: DD/MM/YYYY
     ),
   ),
   ```
-  *Note: one attribute of pane or content attribute must be null*
+  *Note: one attribute of pane or content must be null*
 
   You can use `NavigationView.transitionsBuilder`
 - Fixes memory leaks on `NavigationView`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,7 +46,7 @@ Date format: DD/MM/YYYY
   ),
   ```
   
-  Or if you didn't have panes, you can use the content like that:  
+  Or if you don't have a pane, you can use the content like the following:  
   ```dart
   NavigationView(
     content: ScaffoldPage(

--- a/lib/src/controls/navigation/navigation_view/view.dart
+++ b/lib/src/controls/navigation/navigation_view/view.dart
@@ -5,9 +5,13 @@ import 'package:flutter/foundation.dart';
 import 'package:flutter/rendering.dart';
 
 part 'body.dart';
+
 part 'indicators.dart';
+
 part 'pane.dart';
+
 part 'pane_items.dart';
+
 part 'style.dart';
 
 /// The default size used by the app top bar.
@@ -34,11 +38,14 @@ class NavigationView extends StatefulWidget {
     Key? key,
     this.appBar,
     this.pane,
+    this.content,
     this.clipBehavior = Clip.antiAlias,
     this.contentShape,
     this.onOpenSearch,
     this.transitionBuilder,
-  }) : super(key: key);
+  })  : assert((pane != null && content == null) ||
+            (pane == null && content != null)),
+        super(key: key);
 
   /// The app bar of the app.
   final NavigationAppBar? appBar;
@@ -46,6 +53,11 @@ class NavigationView extends StatefulWidget {
   /// The navigation pane, that can be displayed either on the
   /// left, on the top, or above the body.
   final NavigationPane? pane;
+
+  /// The content of the pane.
+  ///
+  /// Usually an [NavigationBody].
+  final Widget? content;
 
   /// {@macro flutter.rendering.ClipRectLayer.clipBehavior}
   ///
@@ -591,10 +603,10 @@ class NavigationViewState extends State<NavigationView> {
               paneResult = content;
           }
         }
-      } else {
+      } else if(widget.content != null) {
         paneResult = Column(children: [
           appBar,
-          // Expanded(child: widget.content),
+          Expanded(child: widget.content!),
         ]);
       }
       return Mica(

--- a/lib/src/controls/navigation/navigation_view/view.dart
+++ b/lib/src/controls/navigation/navigation_view/view.dart
@@ -613,7 +613,7 @@ class NavigationViewState extends State<NavigationView> {
           appBar,
           Expanded(child: widget.content!),
         ]);
-      } else{
+      } else {
         throw 'Either pane or content must be provided';
       }
       return Mica(

--- a/lib/src/controls/navigation/navigation_view/view.dart
+++ b/lib/src/controls/navigation/navigation_view/view.dart
@@ -603,7 +603,7 @@ class NavigationViewState extends State<NavigationView> {
               paneResult = content;
           }
         }
-      } else if(widget.content != null) {
+      } else if (widget.content != null) {
         paneResult = Column(children: [
           appBar,
           Expanded(child: widget.content!),

--- a/lib/src/controls/navigation/navigation_view/view.dart
+++ b/lib/src/controls/navigation/navigation_view/view.dart
@@ -43,8 +43,11 @@ class NavigationView extends StatefulWidget {
     this.contentShape,
     this.onOpenSearch,
     this.transitionBuilder,
-  })  : assert((pane != null && content == null) ||
-            (pane == null && content != null)),
+  })  : assert(
+          (pane != null && content == null) ||
+              (pane == null && content != null),
+          'Either pane or content must be provided',
+        ),
         super(key: key);
 
   /// The app bar of the app.
@@ -56,7 +59,9 @@ class NavigationView extends StatefulWidget {
 
   /// The content of the pane.
   ///
-  /// Usually an [NavigationBody].
+  /// If [pane] is provided, this is ignored
+  ///
+  /// Usually a [ScaffoldPage]
   final Widget? content;
 
   /// {@macro flutter.rendering.ClipRectLayer.clipBehavior}
@@ -608,6 +613,8 @@ class NavigationViewState extends State<NavigationView> {
           appBar,
           Expanded(child: widget.content!),
         ]);
+      } else{
+        throw 'Either pane or content must be provided';
       }
       return Mica(
         backgroundColor: theme.backgroundColor,


### PR DESCRIPTION
<!-- Add a description of what this PR is changing or adding, and why. Consider mentioning issues -->

## Pre-launch Checklist

<!-- Mark all that applies -->

- [x] I have updated `CHANGELOG.md` with my changes <!-- REQUIRED --> 
- [x] I have run "dart format ." on the project <!-- REQUIRED --> 
- [x] I have added/updated relevant documentation

I have some case where I use the navigation view like this:

```dart
return NavigationView(
  content: ScaffoldPage(
    header: PageHeader(
      title: titleRow,
    ),
    content: Padding(
      padding: const EdgeInsets.symmetric(horizontal: 25),
      child: child,
    ),
  ),
);

And after the PR #510 this is not possible, we need to do something like that:

```dart
return NavigationView(
  pane: NavigationPane(
      displayMode: PaneDisplayMode.minimal,
      items: [
        PaneItem(
          icon: const SizedBox.shrink(),
          body: ScaffoldPage(
            header: PageHeader(
              title: titleRow,
            ),
            content: Padding(
              padding: const EdgeInsets.symmetric(horizontal: 25),
              child: child,
            ),
          ),
        )
      ]
  ),
);
```

With this fix, we can use one solution with `pane` or `content` (but one of these must be null !).