### PR TITLE
TreeView: onExpand-callback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -90,6 +90,10 @@ Date format: DD/MM/YYYY
     )
     ```
   - Expand/collape items with right and left arrow keys, respectively ([#517](https://github.com/bdlukaa/fluent_ui/issues/517))
+  - Add global onItemExpandToggle callback to TreeView.
+  - Add onExpandToggle callback to TreeViewItem.
+    The new callbacks can be used to load child items lazily, which fixes the unexpected behavior of triggering child loading on invoking an item. The loading of children now can be triggered, only when the item gets expanded; then a loading indicator is shown if the loading takes some time. When loading is complete, the loading indicator is removed and the item gets expanded.
+    -> The 'global' callback gets executed before(!) the item's callback, like the 'global' onItemInvoke' callback gets executed before the onInvoke callback. 
 
 ## [4.0.0-pre.4] - Almost there - [02/09/2022]
 

--- a/example/lib/screens/navigation/tree_view.dart
+++ b/example/lib/screens/navigation/tree_view.dart
@@ -99,73 +99,71 @@ TreeView(
       ),
       subtitle(content: const Text('A TreeView with lazy-loading items')),
       CardHighlight(
-        child: TreeView(
-          shrinkWrap: true,
-          items: lazyItems,
-          onItemInvoked: (item) async => debugPrint('onItemInvoked: $item'),
-          onSelectionChanged: (selectedItems) async => debugPrint(
-              'onSelectionChanged: ${selectedItems.map((i) => i.value)}'),
-          onSecondaryTap: (item, details) async {
-            debugPrint('onSecondaryTap $item at ${details.globalPosition}');
-          },
+        child: Column(
+          children: [
+            TreeView(
+              shrinkWrap: true,
+              items: lazyItems,
+              onItemInvoked: (item) async => debugPrint('onItemInvoked: $item'),
+              onSelectionChanged: (selectedItems) async => debugPrint(
+                  'onSelectionChanged: ${selectedItems.map((i) => i.value)}'),
+              onSecondaryTap: (item, details) async {
+                debugPrint('onSecondaryTap $item at ${details.globalPosition}');
+              },
+            ),
+          ],
         ),
         codeSnippet: r'''final lazyItems = [
   TreeViewItem(
-    content: const Text('Work Documents'),
-    value: 'work_docs',
-    // this means the item children will futurely be inserted
+    content: const Text('Item with lazy loading'),
+    value: 'lazy_load',
+    // This means the item will be expandable, although there are no
+    // children yet.
     lazy: true,
-    // ensure the list is modifiable
+    // Ensure the list is modifiable.
     children: [],
-    onInvoked: (item) async {
-      // if it's already populated, return
-      // we don't want to populate it twice
+    onExpandToggle: (item, getsExpanded) async {
+      // If it's already populated, return.
       if (item.children.isNotEmpty) return;
-      // mark as loading
-      setState(() => item.loading = true);
-      // do your fetching...
+
+      // Do your fetching...
       await Future.delayed(const Duration(seconds: 2));
-      setState(() {
-        item
-          // set loading to false
-          ..loading = false
-          // add the fetched nodes
-          ..children.addAll([
-            TreeViewItem(
-              content: const Text('XYZ Functional Spec'),
-              value: 'xyz_functional_spec',
-            ),
-            TreeViewItem(
-              content: const Text('Feature Schedule'),
-              value: 'feature_schedule',
-            ),
-            TreeViewItem(
-              content: const Text('Overall Project Plan'),
-              value: 'overall_project_plan',
-            ),
-            TreeViewItem(
-              content: const Text(
-                'Feature Resources Allocation (this text should not overflow)',
-                overflow: TextOverflow.ellipsis,
-              ),
-              value: 'feature_resources_alloc',
-            ),
-          ]);
-      });
+      
+      // ...and add the fetched nodes.
+      item.children.addAll([
+        TreeViewItem(
+          content: const Text('Lazy item 1'),
+          value: 'lazy_1',
+        ),
+        TreeViewItem(
+          content: const Text('Lazy item 2'),
+          value: 'lazy_2',
+        ),
+        TreeViewItem(
+          content: const Text('Lazy item 3'),
+          value: 'lazy_3',
+        ),
+        TreeViewItem(
+          content: const Text(
+            'Lazy item 4 (this text should not overflow)',
+            overflow: TextOverflow.ellipsis,
+          ),
+          value: 'lazy_4',
+        ),
+      ]);
     },
   ),
 ];
 
 TreeView(
-  selectionMode: TreeViewSelectionMode.multiple,
   shrinkWrap: true,
   items: lazyItems,
-  onItemInvoked: (item) async => debugPrint('onItemInvoked: \$item'),
+  onItemInvoked: (item) async => debugPrint('onItemInvoked: $item'),
   onSelectionChanged: (selectedItems) async => debugPrint(
-              'onSelectionChanged: \${selectedItems.map((i) => i.value)}'),
+    'onSelectionChanged: ${selectedItems.map((i) => i.value)}'),
   onSecondaryTap: (item, details) async {
     debugPrint('onSecondaryTap $item at ${details.globalPosition}');
-  },
+          },
 )
 ''',
       ),
@@ -223,50 +221,42 @@ TreeView(
 
   late final lazyItems = [
     TreeViewItem(
-      content: const Text('Work Documents'),
-      value: 'work_docs',
-      // this means the item will be expandable
+      content: const Text('Item with lazy loading'),
+      value: 'lazy_load',
+      // This means the item will be expandable, although there are no
+      // children yet.
       lazy: true,
-      // ensure the list is modifiable
+      // Ensure the list is modifiable.
       children: [],
-      onInvoked: (item) async {
-        // if it's already populated, return
+      onExpandToggle: (item, getsExpanded) async {
+        // If it's already populated, return.
         if (item.children.isNotEmpty) return;
-        // mark as loading
-        setState(() => item.loading = true);
-        // do your fetching...
+
+        // Do your fetching...
         await Future.delayed(const Duration(seconds: 2));
-        setState(() {
-          item
-            // set loading to false
-            ..loading = false
-            // add the fetched nodes
-            ..children.addAll([
-              TreeViewItem(
-                content: const Text('XYZ Functional Spec'),
-                value: 'xyz_functional_spec',
-              ),
-              TreeViewItem(
-                content: const Text('Feature Schedule'),
-                value: 'feature_schedule',
-              ),
-              TreeViewItem(
-                content: const Text('Overall Project Plan'),
-                value: 'overall_project_plan',
-              ),
-              TreeViewItem(
-                content: const Text(
-                  'Feature Resources Allocation (this text should not overflow)',
-                  overflow: TextOverflow.ellipsis,
-                ),
-                value: 'feature_resources_alloc',
-              ),
-            ]);
-        });
-        setState(() {
-          item.expanded = true;
-          item.updateSelected();
-        });
+
+        // ...and add the fetched nodes.
+        item.children.addAll([
+          TreeViewItem(
+            content: const Text('Lazy item 1'),
+            value: 'lazy_1',
+          ),
+          TreeViewItem(
+            content: const Text('Lazy item 2'),
+            value: 'lazy_2',
+          ),
+          TreeViewItem(
+            content: const Text('Lazy item 3'),
+            value: 'lazy_3',
+          ),
+          TreeViewItem(
+            content: const Text(
+              'Lazy item 4 (this text should not overflow)',
+              overflow: TextOverflow.ellipsis,
+            ),
+            value: 'lazy_4',
+          ),
+        ]);
       },
     ),
   ];

--- a/lib/src/controls/navigation/tree_view.dart
+++ b/lib/src/controls/navigation/tree_view.dart
@@ -107,6 +107,9 @@ class TreeViewItem with Diagnosticable {
   /// Called when this item is invoked
   final Future<void> Function(TreeViewItem item)? onInvoked;
 
+  /// Called when this items expansion state is toggled.
+  final Future<void> Function(TreeViewItem item)? onExpandToggle;
+
   /// The background color of this item.
   ///
   /// See also:
@@ -149,6 +152,7 @@ class TreeViewItem with Diagnosticable {
     bool? expanded,
     this.selected = false,
     this.onInvoked,
+    this.onExpandToggle,
     this.backgroundColor,
     this.autofocus = false,
     FocusNode? focusNode,
@@ -174,6 +178,7 @@ class TreeViewItem with Diagnosticable {
           expanded: source.expanded,
           selected: source.selected,
           onInvoked: source.onInvoked,
+          onExpandToggle: source.onExpandToggle,
           backgroundColor: source.backgroundColor,
           autofocus: source.autofocus,
           focusNode: source.focusNode,
@@ -283,6 +288,7 @@ class TreeViewItem with Diagnosticable {
         other._anyExpandableSiblings == _anyExpandableSiblings &&
         other.selected == selected &&
         other.onInvoked == onInvoked &&
+        other.onExpandToggle == onExpandToggle &&
         other.backgroundColor == backgroundColor &&
         other._visible == _visible &&
         other.autofocus == autofocus &&
@@ -304,6 +310,7 @@ class TreeViewItem with Diagnosticable {
         _anyExpandableSiblings.hashCode ^
         selected.hashCode ^
         onInvoked.hashCode ^
+        onExpandToggle.hashCode ^
         backgroundColor.hashCode ^
         _visible.hashCode ^
         autofocus.hashCode ^
@@ -416,6 +423,7 @@ class TreeView extends StatefulWidget {
     this.selectionMode = TreeViewSelectionMode.none,
     this.onSelectionChanged,
     this.onItemInvoked,
+    this.onItemExpandToggle,
     this.onSecondaryTap,
     this.loadingWidget = kTreeViewLoadingIndicator,
     this.shrinkWrap = true,
@@ -441,6 +449,9 @@ class TreeView extends StatefulWidget {
 
   /// Called when an item is invoked
   final TreeViewItemInvoked? onItemInvoked;
+
+  /// Called when an item's expand state is toggled.
+  final Future<void> Function(TreeViewItem item)? onItemExpandToggle;
 
   ///  A tap with a secondary button has occurred.
   final TreeViewItemOnSecondaryTap? onSecondaryTap;


### PR DESCRIPTION
This PR adds a global onItemExpandToggle and an item specific onExpandToggle callback function, that can be used to load child items lazily. 

This fixes the unexpected behavior of triggering child loading on invoking an item. The loading of children now can be triggered, when the item gets expanded. Then a loading indicator is shown if the loading takes some time. When loading is complete, the loading indicator is removed and the item gets expanded.

Before:
![Fluent_UI_TreeView_Lazy_onExpand_in_stateless_parent](https://user-images.githubusercontent.com/103884835/191543295-71ec7d7e-3ff2-4a79-816c-c33a8047b09a.gif)
The child items get loaded when the item is invoked.

After:
![Fluent_UI_TreeView_Lazy_onExpand](https://user-images.githubusercontent.com/103884835/191536358-2c25fc8e-bf2b-4edd-a80d-491e7d55eb54.gif)
Nothing happens when the item gets invoked. Child items get loaded when the item gets expanded.

Related Issue:   #522

## Pre-launch Checklist

- [ x ] I have updated `CHANGELOG.md` with my changes <!-- REQUIRED --> 
- [ x ] I have run "dart format ." on the project <!-- REQUIRED --> 
- [ x ] I have added/updated relevant documentation
