### PR TITLE
fix: PaneItemAction tap event called twice

### DIFF
--- a/lib/src/controls/navigation/navigation_view/pane_items.dart
+++ b/lib/src/controls/navigation/navigation_view/pane_items.dart
@@ -504,7 +504,7 @@ class PaneItemAction extends PaneItem {
     return super.build(
       context,
       selected,
-      onTap,
+      onPressed,
       displayMode: displayMode,
       showTextOnTop: showTextOnTop,
       autofocus: autofocus,


### PR DESCRIPTION
<!-- Add a description of what this PR is changing or adding, and why. Consider mentioning issues -->

## Pre-launch Checklist

<!-- Mark all that applies -->

- [ ] I have updated `CHANGELOG.md` with my changes <!-- REQUIRED --> 
- [x] I have run "dart format ." on the project <!-- REQUIRED --> 
- [ ] I have added/updated relevant documentation