### PR TITLE
[Example Project] Colorful Code Snippets

### DIFF
--- a/example/lib/screens/inputs/button.dart
+++ b/example/lib/screens/inputs/button.dart
@@ -37,7 +37,7 @@ class _ButtonPageState extends State<ButtonPage> with PageMixin {
         CardHighlight(
           child: Row(children: [
             Button(
-              child: const Text('Standart Button'),
+              child: const Text('Standard Button'),
               onPressed: simpleDisabled ? null : () {},
             ),
             const Spacer(),
@@ -52,7 +52,7 @@ class _ButtonPageState extends State<ButtonPage> with PageMixin {
             ),
           ]),
           codeSnippet: '''Button(
-  child: const Text('Standart Button'),
+  child: const Text('Standard Button'),
   onPressed: disabled ? null : () => debugPrint('pressed button'),
 )''',
         ),

--- a/example/lib/widgets/card_highlight.dart
+++ b/example/lib/widgets/card_highlight.dart
@@ -2,8 +2,7 @@ import 'dart:math';
 
 import 'package:fluent_ui/fluent_ui.dart';
 import 'package:flutter/services.dart';
-import 'package:flutter_highlight/flutter_highlight.dart';
-import 'package:flutter_highlight/themes/github.dart';
+import 'package:flutter_syntax_view/flutter_syntax_view.dart';
 
 class CardHighlight extends StatefulWidget {
   const CardHighlight({
@@ -95,15 +94,11 @@ class _CardHighlightState extends State<CardHighlight>
               )
             : null,
         header: const Text('Source code'),
-        content: HighlightView(
-          widget.codeSnippet,
-          language: 'dart',
-          theme: theme.brightness.isDark ? fluentHighlightTheme : githubTheme,
-          textStyle: const TextStyle(
-            fontFamily: 'monospace',
-            fontSize: 14.0,
-            wordSpacing: 1.0,
-          ),
+        content: SyntaxView(
+          code: widget.codeSnippet,
+          syntaxTheme: theme.brightness.isDark
+              ? SyntaxTheme.vscodeDark()
+              : SyntaxTheme.vscodeLight(),
         ),
       ),
     ]);

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -104,15 +104,6 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "1.0.0+2"
-  flutter_highlight:
-    dependency: "direct main"
-    description:
-      path: flutter_highlight
-      ref: b5e7de8bc95f4e8e30534d7b1da5b41979caab01
-      resolved-ref: b5e7de8bc95f4e8e30534d7b1da5b41979caab01
-      url: "https://github.com/shreyas1599/highlight.dart.git"
-    source: git
-    version: "0.7.0"
   flutter_lints:
     dependency: "direct dev"
     description:
@@ -139,6 +130,15 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "2.1.6"
+  flutter_syntax_view:
+    dependency: "direct main"
+    description:
+      path: "."
+      ref: HEAD
+      resolved-ref: "8b0fb4944fc36f691e40fdc944d08b7bc16973ea"
+      url: "https://github.com/YehudaKremer/flutter_syntax_view.git"
+    source: git
+    version: "4.0.0"
   flutter_test:
     dependency: "direct dev"
     description: flutter
@@ -149,13 +149,6 @@ packages:
     description: flutter
     source: sdk
     version: "0.0.0"
-  highlight:
-    dependency: transitive
-    description:
-      name: highlight
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "0.7.0"
   http:
     dependency: "direct main"
     description:

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -23,11 +23,9 @@ dependencies:
   email_validator: ^2.0.1
   http: ^0.13.4
   flutter_markdown: ^0.6.10+5
-  flutter_highlight:
+  flutter_syntax_view: 
     git:
-      url: https://github.com/shreyas1599/highlight.dart.git
-      path: flutter_highlight
-      ref: b5e7de8bc95f4e8e30534d7b1da5b41979caab01
+      url: https://github.com/YehudaKremer/flutter_syntax_view.git
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
Use `flutter_syntax_view` package to display the code snippets with more vivid colors:

Light mode:
![2](https://user-images.githubusercontent.com/946652/195308270-a826caab-bc69-44b9-945d-594f5a0326e5.png)

Dark mode:
![1](https://user-images.githubusercontent.com/946652/195308344-99c686d0-41a2-459f-b386-bacca8cd3ebd.png)

## Pre-launch Checklist

- [x] I have updated `CHANGELOG.md` with my changes -> (this PR is only on the example project, so no)
- [x] I have run "dart format ." on the project
- [x] I have added/updated relevant documentation -> (this PR is only on the example project, so no)