### PR TITLE
NavigationView: Make compatible the use of PaneItems and content attribute again

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,3 @@
-## 4.0.4 - Unreleased
-
-- `NavigationView`: Make compatible the use of PaneItems and content attribute again ([#595](https://github.com/bdlukaa/fluent_ui/pull/595))
-
 ## 4.0.3+1
 
 - Update documentation

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 4.0.4 - Unreleased
+
+- `NavigationView`: Make compatible the use of PaneItems and content attribute again ([#595](https://github.com/bdlukaa/fluent_ui/pull/595))
+
 ## 4.0.3+1
 
 - Update documentation

--- a/lib/src/controls/navigation/navigation_view/pane_items.dart
+++ b/lib/src/controls/navigation/navigation_view/pane_items.dart
@@ -24,7 +24,7 @@ class PaneItem extends NavigationPaneItem {
   /// Creates a pane item.
   PaneItem({
     required this.icon,
-    required this.body,
+    this.body,
     this.title,
     this.trailing,
     this.infoBadge,
@@ -66,7 +66,7 @@ class PaneItem extends NavigationPaneItem {
   final Widget? trailing;
 
   /// The body of the view attached to this tab
-  final Widget body;
+  final Widget? body;
 
   /// {@macro flutter.widgets.Focus.focusNode}
   final FocusNode? focusNode;
@@ -538,7 +538,7 @@ class PaneItemExpander extends PaneItem {
   PaneItemExpander({
     required super.icon,
     required this.items,
-    required super.body,
+    super.body,
     super.title,
     super.infoBadge,
     super.trailing = kDefaultTrailing,

--- a/test/navigation_view_test.dart
+++ b/test/navigation_view_test.dart
@@ -29,4 +29,188 @@ void main() {
       );
     },
   );
+
+  testWidgets(
+      'Either content or PaneItems with bodies - case "content", no items',
+      (WidgetTester tester) async {
+    await tester.pumpWidget(
+      FluentApp(
+        home: FluentApp(
+          home: NavigationView(
+            content: const Text("ContentWidget"),
+          ),
+        ),
+      ),
+    );
+
+    expect(find.text('ContentWidget'), findsOneWidget);
+  });
+
+  testWidgets(
+      'Either content or PaneItems with bodies - case "content", items with no bodies',
+      (WidgetTester tester) async {
+    await tester.pumpWidget(
+      FluentApp(
+        home: FluentApp(
+          home: NavigationView(
+            content: const Text("ContentWidget"),
+            pane: NavigationPane(selected: 0, items: [
+              PaneItem(
+                icon: const Icon(FluentIcons.add),
+                title: const Text("Item1"),
+              ),
+              PaneItemExpander(
+                  icon: const Icon(FluentIcons.add),
+                  title: const Text("Expander 1"),
+                  items: [
+                    PaneItem(
+                      icon: const Icon(FluentIcons.add),
+                      title: const Text("Item1-1"),
+                    ),
+                  ])
+            ]),
+          ),
+        ),
+      ),
+    );
+
+    expect(find.text('ContentWidget'), findsOneWidget);
+    expect(find.text('Item1-1'), findsNothing);
+    expect(find.text('Item1-1'), findsNothing);
+  });
+
+  testWidgets(
+      'Either content or PaneItems with bodies - case "content", items with bodies',
+      (WidgetTester tester) async {
+    expect(
+        () async => await tester.pumpWidget(
+              FluentApp(
+                home: FluentApp(
+                  home: NavigationView(
+                    content: const Text("ContentWidget"),
+                    pane: NavigationPane(selected: 0, items: [
+                      PaneItem(
+                        icon: const Icon(FluentIcons.add),
+                        title: const Text("Item1"),
+                        body: const Text("Body Item1"),
+                      ),
+                      PaneItemExpander(
+                          icon: const Icon(FluentIcons.add),
+                          title: const Text("Expander 1"),
+                          body: const Text("Body Expander 1"),
+                          items: [
+                            PaneItem(
+                              icon: const Icon(FluentIcons.add),
+                              title: const Text("Item1-1"),
+                              body: const Text("Body Item1-1"),
+                            ),
+                          ])
+                    ]),
+                  ),
+                ),
+              ),
+            ),
+        throwsAssertionError);
+  });
+
+  testWidgets(
+      'Either content or PaneItems with bodies - case without "content", items without bodies',
+      (WidgetTester tester) async {
+    expect(
+        () async => await tester.pumpWidget(
+              FluentApp(
+                home: FluentApp(
+                  home: NavigationView(
+                    pane: NavigationPane(selected: 0, items: [
+                      PaneItem(
+                        icon: const Icon(FluentIcons.add),
+                        title: const Text("Item1"),
+                      ),
+                      PaneItemExpander(
+                          icon: const Icon(FluentIcons.add),
+                          title: const Text("Expander 1"),
+                          body: const Text("Body Expander 1"),
+                          items: [
+                            PaneItem(
+                              icon: const Icon(FluentIcons.add),
+                              title: const Text("Item1-1"),
+                            ),
+                          ])
+                    ]),
+                  ),
+                ),
+              ),
+            ),
+        throwsAssertionError);
+  });
+
+  testWidgets(
+      'Either content or PaneItems with bodies - case without "content", items with bodies',
+      (WidgetTester tester) async {
+    await tester.pumpWidget(
+      FluentApp(
+        home: FluentApp(
+          home: NavigationView(
+            pane: NavigationPane(selected: 0, items: [
+              PaneItem(
+                icon: const Icon(FluentIcons.add),
+                title: const Text("Item1"),
+                body: const Text("Body Item1"),
+              ),
+              PaneItemExpander(
+                  icon: const Icon(FluentIcons.add),
+                  title: const Text("Expander 1"),
+                  body: const Text("Body Expander 1"),
+                  items: [
+                    PaneItem(
+                      icon: const Icon(FluentIcons.add),
+                      title: const Text("Item1-1"),
+                      body: const Text("Body Item1-1"),
+                    ),
+                  ])
+            ]),
+          ),
+        ),
+      ),
+    );
+
+    expect(find.text('Body Item1'), findsOneWidget);
+    expect(find.text('Body Expander 1'), findsNothing);
+    expect(find.text('Body Item1-1'), findsNothing);
+  });
+
+  testWidgets(
+      'Either content or PaneItems with bodies - case without "content", items with bodies, expander selected',
+          (WidgetTester tester) async {
+        await tester.pumpWidget(
+          FluentApp(
+            home: FluentApp(
+              home: NavigationView(
+                pane: NavigationPane(selected: 1, items: [
+                  PaneItem(
+                    icon: const Icon(FluentIcons.add),
+                    title: const Text("Item1"),
+                    body: const Text("Body Item1"),
+                  ),
+                  PaneItemExpander(
+                      icon: const Icon(FluentIcons.add),
+                      title: const Text("Expander 1"),
+                      body: const Text("Body Expander 1"),
+                      items: [
+                        PaneItem(
+                          icon: const Icon(FluentIcons.add),
+                          title: const Text("Item1-1"),
+                          body: const Text("Body Item1-1"),
+                        ),
+                      ])
+                ]),
+              ),
+            ),
+          ),
+        );
+
+        expect(find.text('Body Item1'), findsNothing);
+        expect(find.text('Body Expander 1'), findsOneWidget);
+        expect(find.text('Body Item1-1'), findsNothing);
+      });
 }

--- a/test/navigation_view_test.dart
+++ b/test/navigation_view_test.dart
@@ -181,36 +181,36 @@ void main() {
 
   testWidgets(
       'Either content or PaneItems with bodies - case without "content", items with bodies, expander selected',
-          (WidgetTester tester) async {
-        await tester.pumpWidget(
-          FluentApp(
-            home: FluentApp(
-              home: NavigationView(
-                pane: NavigationPane(selected: 1, items: [
-                  PaneItem(
-                    icon: const Icon(FluentIcons.add),
-                    title: const Text("Item1"),
-                    body: const Text("Body Item1"),
-                  ),
-                  PaneItemExpander(
-                      icon: const Icon(FluentIcons.add),
-                      title: const Text("Expander 1"),
-                      body: const Text("Body Expander 1"),
-                      items: [
-                        PaneItem(
-                          icon: const Icon(FluentIcons.add),
-                          title: const Text("Item1-1"),
-                          body: const Text("Body Item1-1"),
-                        ),
-                      ])
-                ]),
+      (WidgetTester tester) async {
+    await tester.pumpWidget(
+      FluentApp(
+        home: FluentApp(
+          home: NavigationView(
+            pane: NavigationPane(selected: 1, items: [
+              PaneItem(
+                icon: const Icon(FluentIcons.add),
+                title: const Text("Item1"),
+                body: const Text("Body Item1"),
               ),
-            ),
+              PaneItemExpander(
+                  icon: const Icon(FluentIcons.add),
+                  title: const Text("Expander 1"),
+                  body: const Text("Body Expander 1"),
+                  items: [
+                    PaneItem(
+                      icon: const Icon(FluentIcons.add),
+                      title: const Text("Item1-1"),
+                      body: const Text("Body Item1-1"),
+                    ),
+                  ])
+            ]),
           ),
-        );
+        ),
+      ),
+    );
 
-        expect(find.text('Body Item1'), findsNothing);
-        expect(find.text('Body Expander 1'), findsOneWidget);
-        expect(find.text('Body Item1-1'), findsNothing);
-      });
+    expect(find.text('Body Item1'), findsNothing);
+    expect(find.text('Body Expander 1'), findsOneWidget);
+    expect(find.text('Body Item1-1'), findsNothing);
+  });
 }


### PR DESCRIPTION
Make `PaneItems` "body" attribute not longer required and compatible with `content` attribute. Related with https://github.com/bdlukaa/fluent_ui/pull/531#issuecomment-1297353238 (TL;DR: we want to use `LazyIndexedStack` in `content` in order to have state preservation when `PaneItem` is changed)

## Pre-launch Checklist

<!-- Mark all that applies -->

- [x] I have updated `CHANGELOG.md` with my changes <!-- REQUIRED --> 
- [x] I have run "dart format ." on the project <!-- REQUIRED --> 
- [x] I have added/updated relevant documentation