### PR TITLE
Use PageView to build the view content

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 - Fixed `TreeView` selection state behavior for items that are not expanded ([#578](https://github.com/bdlukaa/fluent_ui/issues/578))
 - Added support for Romanian language
+- Ensure the body state in `NavigationView` is properly preserved ([#607](https://github.com/bdlukaa/fluent_ui/pull/607))
 
 ## 4.0.3+1
 

--- a/lib/src/controls/navigation/navigation_view/body.dart
+++ b/lib/src/controls/navigation/navigation_view/body.dart
@@ -85,7 +85,7 @@ class _NavigationBodyState extends State<_NavigationBody> {
     super.didChangeDependencies();
     final view = InheritedNavigationView.of(context);
 
-    if (view.oldIndex != view.pane?.selected) {
+    if (_pageController.hasClients && view.oldIndex != view.pane?.selected) {
       _pageController.jumpToPage(view.pane?.selected ?? 0);
     }
   }

--- a/lib/src/controls/navigation/navigation_view/body.dart
+++ b/lib/src/controls/navigation/navigation_view/body.dart
@@ -145,6 +145,7 @@ class _NavigationBodyState extends State<_NavigationBody> {
               final bool isSelected = view.pane!.selected == index;
               return view.pane!.effectiveItems.map((item) {
                 final body = FocusTraversalGroup(
+                  key: item.bodyKey,
                   child: widget.paneBodyBuilder?.call(item.body) ?? item.body,
                 );
 

--- a/lib/src/controls/navigation/navigation_view/body.dart
+++ b/lib/src/controls/navigation/navigation_view/body.dart
@@ -142,9 +142,14 @@ class _NavigationBodyState extends State<_NavigationBody> {
             controller: _pageController,
             itemCount: view.pane!.effectiveItems.length,
             itemBuilder: (context, index) {
-              return view.pane!.effectiveItems
-                  .map((item) => FocusTraversalGroup(child: item.body))
-                  .elementAt(index);
+              final bool isSelected = view.pane!.selected == index;
+              return view.pane!.effectiveItems.map((item) {
+                final body = FocusTraversalGroup(child: item.body);
+
+                if (!isSelected) return ExcludeFocus(child: body);
+
+                return body;
+              }).elementAt(index);
             },
           ),
         ),

--- a/lib/src/controls/navigation/navigation_view/body.dart
+++ b/lib/src/controls/navigation/navigation_view/body.dart
@@ -14,7 +14,7 @@ class _NavigationBody extends StatefulWidget {
     // ignore: unused_element
     super.key,
     required this.itemKey,
-    required this.child,
+    this.paneBodyBuilder,
     this.transitionBuilder,
     // ignore: unused_element
     this.animationCurve,
@@ -24,7 +24,7 @@ class _NavigationBody extends StatefulWidget {
 
   final ValueKey<int>? itemKey;
 
-  final Widget child;
+  final NavigationContentBuilder? paneBodyBuilder;
 
   /// The transition builder.
   ///
@@ -144,7 +144,9 @@ class _NavigationBodyState extends State<_NavigationBody> {
             itemBuilder: (context, index) {
               final bool isSelected = view.pane!.selected == index;
               return view.pane!.effectiveItems.map((item) {
-                final body = FocusTraversalGroup(child: item.body);
+                final body = FocusTraversalGroup(
+                  child: widget.paneBodyBuilder?.call(item.body) ?? item.body,
+                );
 
                 if (!isSelected) return ExcludeFocus(child: body);
 

--- a/lib/src/controls/navigation/navigation_view/body.dart
+++ b/lib/src/controls/navigation/navigation_view/body.dart
@@ -144,14 +144,13 @@ class _NavigationBodyState extends State<_NavigationBody> {
             itemBuilder: (context, index) {
               final bool isSelected = view.pane!.selected == index;
               return view.pane!.effectiveItems.map((item) {
-                final body = FocusTraversalGroup(
+                return ExcludeFocus(
                   key: item.bodyKey,
-                  child: widget.paneBodyBuilder?.call(item.body) ?? item.body,
+                  excluding: !isSelected,
+                  child: FocusTraversalGroup(
+                    child: widget.paneBodyBuilder?.call(item.body) ?? item.body,
+                  ),
                 );
-
-                if (!isSelected) return ExcludeFocus(child: body);
-
-                return body;
               }).elementAt(index);
             },
           ),

--- a/lib/src/controls/navigation/navigation_view/pane_items.dart
+++ b/lib/src/controls/navigation/navigation_view/pane_items.dart
@@ -1,6 +1,12 @@
 part of 'view.dart';
 
 class NavigationPaneItem with Diagnosticable {
+  /// The key used for the item itself. Useful to find the position and size of
+  /// the pane item within the screen
+  ///
+  /// See also:
+  ///
+  ///   * [PaneItem.build], which assigns
   GlobalKey itemKey = GlobalKey();
 
   NavigationPaneItem();
@@ -21,6 +27,14 @@ class NavigationPaneItem with Diagnosticable {
 ///   * [PaneItemAction], the item used for execute an action on click
 ///   * [PaneItemExpander], which creates hierhical navigation
 class PaneItem extends NavigationPaneItem {
+  /// The key used for the body content
+  ///
+  /// See also:
+  ///
+  ///   * [body], which this is assigned to
+  ///   * [_NavigationBody], which assigns this to every pane body
+  GlobalKey bodyKey = GlobalKey();
+
   /// Creates a pane item.
   PaneItem({
     required this.icon,

--- a/lib/src/controls/navigation/navigation_view/view.dart
+++ b/lib/src/controls/navigation/navigation_view/view.dart
@@ -19,6 +19,8 @@ part 'style.dart';
 /// Value eyeballed from Windows 10 v10.0.19041.928
 const double _kDefaultAppBarHeight = 50.0;
 
+typedef NavigationContentBuilder = Widget Function(Widget? body);
+
 /// The NavigationView control provides top-level navigation for your app. It
 /// adapts to a variety of screen sizes and supports both top and left
 /// navigation styles.
@@ -56,14 +58,13 @@ class NavigationView extends StatefulWidget {
 
   /// Can be used to override the widget that is built from
   /// the [PaneItem.body]. Only used if [pane] is provided.
-  /// If nothing is selected, `selectedPaneItemBody` will be
-  /// null.
+  /// If nothing is selected, `body` will be null.
   ///
   /// This can be useful if you are using router-based navigation,
   /// and the body of the navigation pane is dynamically determined or
   /// affected by the current route rather than just by the currently
   /// selected pane.
-  final Widget Function(Widget? selectedPaneItemBody)? paneBodyBuilder;
+  final NavigationContentBuilder? paneBodyBuilder;
 
   /// The navigation pane, that can be displayed either on the
   /// left, on the top, or above the body.
@@ -361,17 +362,12 @@ class NavigationViewState extends State<NavigationView> {
       late Widget paneResult;
       if (widget.pane != null) {
         final pane = widget.pane!;
-        final paneBodyBuilder = widget.paneBodyBuilder;
         final body = _NavigationBody(
           itemKey: ValueKey(pane.selected ?? -1),
           transitionBuilder: widget.transitionBuilder,
-          child: paneBodyBuilder != null
-              ? paneBodyBuilder(
-                  pane.selected != null ? pane.selectedItem.body : null)
-              : (pane.selected != null
-                  ? pane.selectedItem.body
-                  : const SizedBox.shrink()),
+          paneBodyBuilder: widget.paneBodyBuilder,
         );
+
         if (pane.customPane != null) {
           paneResult = Builder(builder: (context) {
             return PaneScrollConfiguration(


### PR DESCRIPTION
<!-- Add a description of what this PR is changing or adding, and why. Consider mentioning issues -->

`PaneItem.bodyKey` is now assigned to every `PaneItem.body` to preserve its state. Improved, fundamentally, how the current body management works. Additionally, `.bodyKey` can be used to find measurements for the body content, if needed in the future.

Fixed #604

## Pre-launch Checklist

<!-- Mark all that applies -->

- [x] I have updated `CHANGELOG.md` with my changes <!-- REQUIRED --> 
- [x] I have run "dart format ." on the project <!-- REQUIRED --> 
- [x] I have added/updated relevant documentation