### PR TITLE
Fix left arrow key not moving to parent item on collapsed TreeViewItem

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - Ensure the TabView scroll controller has clients before using it ([#615](https://github.com/bdlukaa/fluent_ui/issues/615))
 - TabView now waits a time to resize after closed ([#617](https://github.com/bdlukaa/fluent_ui/issues/617))
 - `ToggleButton` border width is uniform ([#610](https://github.com/bdlukaa/fluent_ui/issues/610))
+- Fix left arrow key not moving to parent item on collapsed `TreeViewItem` ([#632](https://github.com/bdlukaa/fluent_ui/issues/632)) 
 
 ## 4.0.3+1
 

--- a/lib/src/controls/navigation/tree_view.dart
+++ b/lib/src/controls/navigation/tree_view.dart
@@ -833,14 +833,18 @@ class _TreeViewItem extends StatelessWidget {
                 const SingleActivator(LogicalKeyboardKey.arrowLeft):
                     VoidCallbackIntent(() {
                   if (item.expanded) {
-                    // if the item is already expanded, close it
+                    // if the item is expanded, close it
                     onExpandToggle();
+                  } else if (item.parent != null) {
+                    // if the item is already closed and has a parent
+                    // focus the parent
+                    item.parent!.focusNode.requestFocus();
                   }
                 }),
                 const SingleActivator(LogicalKeyboardKey.arrowRight):
                     VoidCallbackIntent(() {
                   if (item.expanded) {
-                    // if the item is already expanded, move to its first child
+                    // if the item is already expanded, focus its first child
                     FocusScope.of(context).nextFocus();
                   } else {
                     // expand the item


### PR DESCRIPTION
When pressing the left arrow key on an already collapsed TreeViewItem the focus moves moves to the item's parent it it has one. If it has no parent nothing happens.

Fixes https://github.com/bdlukaa/fluent_ui/issues/632

## Pre-launch Checklist
- [x] I have updated `CHANGELOG.md` with my changes <!-- REQUIRED --> 
- [x] I have run "dart format ." on the project <!-- REQUIRED --> 
- [x] I have added/updated relevant documentation