### PR TITLE
updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## [next]
+
+- `PageHeader` now gives appropriate bounds to its `commandBar` ([#642](https://github.com/bdlukaa/fluent_ui/issues/642))
+
 ## 4.1.1
 
 - Ensure acrylic is updated only if it's mounted ([#634](https://github.com/bdlukaa/fluent_ui/issues/634))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## [next]
 
 - `PageHeader` now gives appropriate bounds to its `commandBar` ([#642](https://github.com/bdlukaa/fluent_ui/issues/642))
+- Ensure `NavigationView` body state is not lost when resizing window
 
 ## 4.1.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 - `PageHeader` now gives appropriate bounds to its `commandBar` ([#642](https://github.com/bdlukaa/fluent_ui/issues/642))
 - Ensure `NavigationView` body state is not lost when resizing window
+- Ensure `TabView`' tabs' state are not lost when changing selected tab ([#607](https://github.com/bdlukaa/fluent_ui/pull/607))
 
 ## 4.1.1
 

--- a/example/lib/screens/forms/auto_suggest_box.dart
+++ b/example/lib/screens/forms/auto_suggest_box.dart
@@ -57,7 +57,7 @@ class _AutoSuggestBoxPageState extends State<AutoSuggestBoxPage>
             ),
             Expanded(
               child: Padding(
-                padding: const EdgeInsets.only(left: 8.0),
+                padding: const EdgeInsetsDirectional.only(start: 8.0),
                 child: Text(selectedCat ?? ''),
               ),
             ),
@@ -122,7 +122,7 @@ const cats = <String>[
             ),
             Expanded(
               child: Padding(
-                padding: const EdgeInsets.only(left: 8.0),
+                padding: const EdgeInsetsDirectional.only(start: 8.0),
                 child: Text(selectedObjectCat != null
                     ? 'Cat #${selectedObjectCat!.id} "${selectedObjectCat!.name}" ${selectedObjectCat!.hasTag ? '[🏷 TAGGED]' : "[❌ NON TAGGED]"}'
                     : ''),

--- a/example/lib/screens/forms/combobox.dart
+++ b/example/lib/screens/forms/combobox.dart
@@ -68,7 +68,7 @@ class _ComboBoxPageState extends State<ComboBoxPage> with PageMixin {
                     },
             ),
             Container(
-              margin: const EdgeInsets.only(top: 8.0),
+              margin: const EdgeInsetsDirectional.only(top: 8.0),
               height: 30,
               width: 100,
               color: colors[selectedColor],
@@ -110,7 +110,7 @@ ComboBox<String>(
               placeholder: const Text('Select a cat breed'),
             ),
             Container(
-              margin: const EdgeInsets.only(top: 8.0),
+              margin: const EdgeInsetsDirectional.only(top: 8.0),
               height: 30,
               child: Text(selectedCat ?? ''),
             ),
@@ -198,7 +198,7 @@ ComboBox<String>(
               ),
             ),
             Container(
-              margin: const EdgeInsets.only(top: 8.0),
+              margin: const EdgeInsetsDirectional.only(top: 8.0),
               constraints: const BoxConstraints(minHeight: 50.0),
               child: Text(
                 'You can set the font size for this text',
@@ -298,7 +298,7 @@ EditableComboBox<int>(
               ),
             ),
             Container(
-              margin: const EdgeInsets.only(top: 8.0),
+              margin: const EdgeInsetsDirectional.only(top: 8.0),
               height: 30,
               width: 100,
               color: colors[selectedColor],

--- a/example/lib/screens/forms/date_picker.dart
+++ b/example/lib/screens/forms/date_picker.dart
@@ -31,7 +31,7 @@ class _DatePickerPageState extends State<DatePickerPage> with PageMixin {
         subtitle(content: const Text('A simple DatePicker with a header')),
         CardHighlight(
           child: Align(
-            alignment: Alignment.centerLeft,
+            alignment: AlignmentDirectional.centerStart,
             child: DatePicker(
               header: 'Pick a date',
               selected: simpleTime,
@@ -49,7 +49,7 @@ DatePicker(
         subtitle(content: const Text('A DatePicker with year hidden')),
         CardHighlight(
           child: Align(
-            alignment: Alignment.centerLeft,
+            alignment: AlignmentDirectional.centerStart,
             child: DatePicker(
               selected: hiddenTime,
               onChanged: (v) => setState(() => hiddenTime = v),

--- a/example/lib/screens/forms/time_picker.dart
+++ b/example/lib/screens/forms/time_picker.dart
@@ -32,7 +32,7 @@ class _TimePickerPageState extends State<TimePickerPage> with PageMixin {
         subtitle(content: const Text('A simple TimePicker')),
         CardHighlight(
           child: Align(
-            alignment: Alignment.centerLeft,
+            alignment: AlignmentDirectional.centerStart,
             child: TimePicker(
               selected: simpleTime,
               onChanged: (time) => setState(() => simpleTime = time),
@@ -52,7 +52,7 @@ TimePicker(
         ),
         CardHighlight(
           child: Align(
-            alignment: Alignment.centerLeft,
+            alignment: AlignmentDirectional.centerStart,
             child: TimePicker(
               header: 'Arrival time',
               selected: arrivalTime,
@@ -76,7 +76,7 @@ TimePicker(
         ),
         CardHighlight(
           child: Align(
-            alignment: Alignment.centerLeft,
+            alignment: AlignmentDirectional.centerStart,
             child: TimePicker(
               header: '24 hour clock',
               selected: hhTime,

--- a/example/lib/screens/home.dart
+++ b/example/lib/screens/home.dart
@@ -26,7 +26,7 @@ class _HomePageState extends State<HomePage> with PageMixin {
     return ScaffoldPage.scrollable(
       header: PageHeader(
         title: const Text('Fluent UI for Flutter Showcase App'),
-        commandBar: Row(children: [
+        commandBar: Row(mainAxisAlignment: MainAxisAlignment.end, children: [
           Link(
             uri: Uri.parse('https://github.com/bdlukaa/fluent_ui'),
             builder: (context, open) => Tooltip(

--- a/example/lib/screens/inputs/button.dart
+++ b/example/lib/screens/inputs/button.dart
@@ -270,7 +270,8 @@ ToggleButton(
                 3,
                 (index) {
                   return Padding(
-                    padding: EdgeInsets.only(bottom: index == 2 ? 0.0 : 14.0),
+                    padding: EdgeInsetsDirectional.only(
+                        bottom: index == 2 ? 0.0 : 14.0),
                     child: RadioButton(
                       checked: radioButtonSelected == index,
                       onChanged: radioButtonDisabled

--- a/example/lib/screens/inputs/toggle_switch.dart
+++ b/example/lib/screens/inputs/toggle_switch.dart
@@ -35,7 +35,7 @@ class _ToggleSwitchPageState extends State<ToggleSwitchPage> with PageMixin {
         subtitle(content: const Text('A simple ToggleSwitch')),
         CardHighlight(
           child: Align(
-            alignment: Alignment.centerLeft,
+            alignment: AlignmentDirectional.centerStart,
             child: ToggleSwitch(
               checked: firstValue,
               onChanged:

--- a/example/lib/screens/settings.dart
+++ b/example/lib/screens/settings.dart
@@ -102,7 +102,7 @@ class Settings extends ScrollablePage {
       ...List.generate(ThemeMode.values.length, (index) {
         final mode = ThemeMode.values[index];
         return Padding(
-          padding: const EdgeInsets.only(bottom: 8.0),
+          padding: const EdgeInsetsDirectional.only(bottom: 8.0),
           child: RadioButton(
             checked: appTheme.mode == mode,
             onChanged: (value) {
@@ -129,7 +129,7 @@ class Settings extends ScrollablePage {
       ...List.generate(PaneDisplayMode.values.length, (index) {
         final mode = PaneDisplayMode.values[index];
         return Padding(
-          padding: const EdgeInsets.only(bottom: 8.0),
+          padding: const EdgeInsetsDirectional.only(bottom: 8.0),
           child: RadioButton(
             checked: appTheme.displayMode == mode,
             onChanged: (value) {
@@ -148,7 +148,7 @@ class Settings extends ScrollablePage {
       ...List.generate(NavigationIndicators.values.length, (index) {
         final mode = NavigationIndicators.values[index];
         return Padding(
-          padding: const EdgeInsets.only(bottom: 8.0),
+          padding: const EdgeInsetsDirectional.only(bottom: 8.0),
           child: RadioButton(
             checked: appTheme.indicator == mode,
             onChanged: (value) {
@@ -186,7 +186,7 @@ class Settings extends ScrollablePage {
         ...List.generate(currentWindowEffects.length, (index) {
           final mode = currentWindowEffects[index];
           return Padding(
-            padding: const EdgeInsets.only(bottom: 8.0),
+            padding: const EdgeInsetsDirectional.only(bottom: 8.0),
             child: RadioButton(
               checked: appTheme.windowEffect == mode,
               onChanged: (value) {
@@ -209,7 +209,7 @@ class Settings extends ScrollablePage {
       ...List.generate(TextDirection.values.length, (index) {
         final direction = TextDirection.values[index];
         return Padding(
-          padding: const EdgeInsets.only(bottom: 8.0),
+          padding: const EdgeInsetsDirectional.only(bottom: 8.0),
           child: RadioButton(
             checked: appTheme.textDirection == direction,
             onChanged: (value) {
@@ -237,7 +237,7 @@ class Settings extends ScrollablePage {
             final locale = supportedLocales[index];
 
             return Padding(
-              padding: const EdgeInsets.only(bottom: 8.0),
+              padding: const EdgeInsetsDirectional.only(bottom: 8.0),
               child: RadioButton(
                 checked: currentLocale == locale,
                 onChanged: (value) {
@@ -275,7 +275,7 @@ class Settings extends ScrollablePage {
         child: Container(
           height: 40,
           width: 40,
-          alignment: Alignment.center,
+          alignment: AlignmentDirectional.center,
           child: appTheme.color == color
               ? Icon(
                   FluentIcons.check_mark,

--- a/example/lib/screens/surface/acrylic.dart
+++ b/example/lib/screens/surface/acrylic.dart
@@ -203,7 +203,7 @@ class _AcrylicChildren extends StatelessWidget {
         color: Colors.blue.lightest,
       ),
       Align(
-        alignment: Alignment.center,
+        alignment: AlignmentDirectional.center,
         child: Container(
           height: 152,
           width: 152,
@@ -211,7 +211,7 @@ class _AcrylicChildren extends StatelessWidget {
         ),
       ),
       Align(
-        alignment: Alignment.bottomRight,
+        alignment: AlignmentDirectional.bottomEnd,
         child: Container(
           height: 100,
           width: 80,

--- a/example/lib/screens/surface/commandbars.dart
+++ b/example/lib/screens/surface/commandbars.dart
@@ -2,7 +2,14 @@ import 'package:fluent_ui/fluent_ui.dart';
 
 import '../../widgets/page.dart';
 
-class CommandBarsPage extends ScrollablePage {
+class CommandBarsPage extends StatefulWidget {
+  const CommandBarsPage({Key? key}) : super(key: key);
+
+  @override
+  State<CommandBarsPage> createState() => _CommandBarsPageState();
+}
+
+class _CommandBarsPageState extends State<CommandBarsPage> with PageMixin {
   final simpleCommandBarItems = <CommandBarItem>[
     CommandBarBuilderItem(
       builder: (context, mode, w) => Tooltip(
@@ -109,30 +116,37 @@ class CommandBarsPage extends ScrollablePage {
     ),
   ];
 
-  CommandBarsPage({super.key});
-
   @override
-  Widget buildHeader(BuildContext context) {
-    return const PageHeader(title: Text('CommandBar'));
-  }
-
-  @override
-  List<Widget> buildScrollable(BuildContext context) {
-    return [
-      const SizedBox(height: 20.0),
-      InfoLabel(
-        label: 'Simple command bar (no wrapping)',
-        child: CommandBar(
-          overflowBehavior: CommandBarOverflowBehavior.noWrap,
+  Widget build(BuildContext context) {
+    return ScaffoldPage.scrollable(
+      header: PageHeader(
+        title: const Text('CommandBar'),
+        commandBar: CommandBar(
+          mainAxisAlignment: MainAxisAlignment.end,
           primaryItems: [
             ...simpleCommandBarItems,
           ],
         ),
       ),
-      const SizedBox(height: 20.0),
-      InfoLabel(
-        label: 'Command bar with many items (wrapping, auto-compact < 600px)',
-        child: CommandBar(
+      children: [
+        const Text(
+          'Command bars provide users with easy access to your app\'s most '
+          'common tasks. Command bars can provide access to app-level or '
+          'page-specific commands and can be used with any navigation pattern.',
+        ),
+        subtitle(content: const Text('Simple command bar (no wrapping)')),
+        CommandBar(
+          overflowBehavior: CommandBarOverflowBehavior.noWrap,
+          primaryItems: [
+            ...simpleCommandBarItems,
+          ],
+        ),
+        subtitle(
+          content: const Text(
+            'Command bar with many items (wrapping, auto-compact < 600px)',
+          ),
+        ),
+        CommandBar(
           overflowBehavior: CommandBarOverflowBehavior.wrap,
           compactBreakpointWidth: 600,
           primaryItems: [
@@ -141,11 +155,12 @@ class CommandBarsPage extends ScrollablePage {
             ...moreCommandBarItems,
           ],
         ),
-      ),
-      const SizedBox(height: 20.0),
-      InfoLabel(
-        label: 'Carded compact command bar with many items (clipped)',
-        child: ConstrainedBox(
+        subtitle(
+          content: const Text(
+            'Carded compact command bar with many items (clipped)',
+          ),
+        ),
+        ConstrainedBox(
           constraints: const BoxConstraints(maxWidth: 230),
           child: CommandBarCard(
             child: CommandBar(
@@ -159,11 +174,12 @@ class CommandBarsPage extends ScrollablePage {
             ),
           ),
         ),
-      ),
-      const SizedBox(height: 20.0),
-      InfoLabel(
-        label: 'Carded command bar with many items (dynamic overflow)',
-        child: CommandBarCard(
+        subtitle(
+          content: const Text(
+            'Carded compact command bar with many items (dynamic overflow)',
+          ),
+        ),
+        CommandBarCard(
           child: CommandBar(
             overflowBehavior: CommandBarOverflowBehavior.dynamicOverflow,
             primaryItems: [
@@ -175,12 +191,12 @@ class CommandBarsPage extends ScrollablePage {
             ],
           ),
         ),
-      ),
-      const SizedBox(height: 20.0),
-      InfoLabel(
-        label:
+        subtitle(
+          content: const Text(
             'End-aligned command bar with many items (dynamic overflow, auto-compact < 900px)',
-        child: CommandBar(
+          ),
+        ),
+        CommandBar(
           mainAxisAlignment: MainAxisAlignment.end,
           overflowBehavior: CommandBarOverflowBehavior.dynamicOverflow,
           compactBreakpointWidth: 900,
@@ -192,12 +208,12 @@ class CommandBarsPage extends ScrollablePage {
             ...evenMoreCommandBarItems,
           ],
         ),
-      ),
-      const SizedBox(height: 20.0),
-      InfoLabel(
-        label:
+        subtitle(
+          content: const Text(
             'End-aligned command bar with permanent secondary items (dynamic overflow)',
-        child: CommandBar(
+          ),
+        ),
+        CommandBar(
           mainAxisAlignment: MainAxisAlignment.end,
           overflowBehavior: CommandBarOverflowBehavior.dynamicOverflow,
           primaryItems: [
@@ -207,79 +223,77 @@ class CommandBarsPage extends ScrollablePage {
           ],
           secondaryItems: evenMoreCommandBarItems,
         ),
-      ),
-      const SizedBox(height: 20.0),
-      InfoLabel(
-        label: 'Command bar with secondary items (wrapping)',
-        child: CommandBar(
+        subtitle(
+          content: const Text(
+            'Command bar with secondary items (wrapping)',
+          ),
+        ),
+        CommandBar(
           overflowBehavior: CommandBarOverflowBehavior.wrap,
           primaryItems: simpleCommandBarItems,
           secondaryItems: moreCommandBarItems,
         ),
-      ),
-      const SizedBox(height: 20.0),
-      InfoLabel(
-        label:
+        subtitle(
+          content: const Text(
             'Carded complex command bar with many items (horizontal scrolling)',
-        child: CommandBarCard(
-          child: Row(
-            children: [
-              Expanded(
-                child: CommandBar(
-                  overflowBehavior: CommandBarOverflowBehavior.scrolling,
-                  primaryItems: [
-                    ...simpleCommandBarItems,
-                    const CommandBarSeparator(),
-                    ...moreCommandBarItems,
-                  ],
-                ),
-              ),
-              // End-aligned button(s)
-              CommandBar(
-                overflowBehavior: CommandBarOverflowBehavior.noWrap,
-                primaryItems: [
-                  CommandBarButton(
-                    icon: const Icon(FluentIcons.refresh),
-                    onPressed: () {},
-                  ),
-                ],
-              ),
-            ],
           ),
         ),
-      ),
-      const SizedBox(height: 20.0),
-      InfoLabel(
-        label: 'Carded complex command bar with many items (dynamic overflow)',
-        child: CommandBarCard(
-          child: Row(
-            children: [
-              Expanded(
-                child: CommandBar(
-                  overflowBehavior: CommandBarOverflowBehavior.dynamicOverflow,
-                  overflowItemAlignment: MainAxisAlignment.end,
-                  primaryItems: [
-                    ...simpleCommandBarItems,
-                    const CommandBarSeparator(),
-                    ...moreCommandBarItems,
-                  ],
-                  secondaryItems: evenMoreCommandBarItems,
-                ),
-              ),
-              // End-aligned button(s)
-              CommandBar(
-                overflowBehavior: CommandBarOverflowBehavior.noWrap,
+        CommandBarCard(
+          child: Row(children: [
+            Expanded(
+              child: CommandBar(
+                overflowBehavior: CommandBarOverflowBehavior.scrolling,
                 primaryItems: [
-                  CommandBarButton(
-                    icon: const Icon(FluentIcons.refresh),
-                    onPressed: () {},
-                  ),
+                  ...simpleCommandBarItems,
+                  const CommandBarSeparator(),
+                  ...moreCommandBarItems,
                 ],
               ),
-            ],
+            ),
+            // End-aligned button(s)
+            CommandBar(
+              overflowBehavior: CommandBarOverflowBehavior.noWrap,
+              primaryItems: [
+                CommandBarButton(
+                  icon: const Icon(FluentIcons.refresh),
+                  onPressed: () {},
+                ),
+              ],
+            ),
+          ]),
+        ),
+        subtitle(
+          content: const Text(
+            'Carded complex command bar with many items (dynamic overflow)',
           ),
         ),
-      ),
-    ];
+        CommandBarCard(
+          child: Row(children: [
+            Expanded(
+              child: CommandBar(
+                overflowBehavior: CommandBarOverflowBehavior.dynamicOverflow,
+                overflowItemAlignment: MainAxisAlignment.end,
+                primaryItems: [
+                  ...simpleCommandBarItems,
+                  const CommandBarSeparator(),
+                  ...moreCommandBarItems,
+                ],
+                secondaryItems: evenMoreCommandBarItems,
+              ),
+            ),
+            // End-aligned button(s)
+            CommandBar(
+              overflowBehavior: CommandBarOverflowBehavior.noWrap,
+              primaryItems: [
+                CommandBarButton(
+                  icon: const Icon(FluentIcons.refresh),
+                  onPressed: () {},
+                ),
+              ],
+            ),
+          ]),
+        ),
+      ],
+    );
   }
 }

--- a/example/lib/screens/surface/expander.dart
+++ b/example/lib/screens/surface/expander.dart
@@ -78,7 +78,7 @@ class _ExpanderPageState extends State<ExpanderPage> with PageMixin {
                 children: crosts
                     .map(
                       (e) => Padding(
-                        padding: const EdgeInsets.only(bottom: 8.0),
+                        padding: const EdgeInsetsDirectional.only(bottom: 8.0),
                         child: RadioButton(
                           checked: crost == e,
                           onChanged: (selected) {
@@ -95,7 +95,8 @@ class _ExpanderPageState extends State<ExpanderPage> with PageMixin {
                 crossAxisAlignment: CrossAxisAlignment.start,
                 children: sizes
                     .map((e) => Padding(
-                          padding: const EdgeInsets.only(bottom: 8.0),
+                          padding:
+                              const EdgeInsetsDirectional.only(bottom: 8.0),
                           child: RadioButton(
                             checked: size == e,
                             onChanged: (selected) {

--- a/example/lib/screens/surface/flyouts.dart
+++ b/example/lib/screens/surface/flyouts.dart
@@ -33,7 +33,7 @@ class _FlyoutShowcaseState extends State<FlyoutPage> {
         const SizedBox(height: 10.0),
         CardHighlight(
           child: Align(
-            alignment: Alignment.centerLeft,
+            alignment: AlignmentDirectional.centerStart,
             child: Flyout(
               controller: buttonController,
               content: (context) {
@@ -132,7 +132,7 @@ Flyout(
     return Column(crossAxisAlignment: CrossAxisAlignment.start, children: [
       Text('Flyout on hover', style: typography.subtitle),
       Padding(
-        padding: const EdgeInsets.only(top: 10.0),
+        padding: const EdgeInsetsDirectional.only(top: 10.0),
         child: Flyout(
           openMode: FlyoutOpenMode.hover,
           content: (context) {
@@ -154,7 +154,7 @@ Flyout(
     return Column(crossAxisAlignment: CrossAxisAlignment.start, children: [
       Text('Flyout on click/press', style: typography.subtitle),
       Padding(
-        padding: const EdgeInsets.only(top: 10.0),
+        padding: const EdgeInsetsDirectional.only(top: 10.0),
         child: Flyout(
           openMode: FlyoutOpenMode.press,
           content: (context) {
@@ -176,7 +176,7 @@ Flyout(
     return Column(crossAxisAlignment: CrossAxisAlignment.start, children: [
       Text('Flyout on long click/press', style: typography.subtitle),
       Padding(
-        padding: const EdgeInsets.only(top: 10.0),
+        padding: const EdgeInsetsDirectional.only(top: 10.0),
         child: Flyout(
           openMode: FlyoutOpenMode.longPress,
           content: (context) {
@@ -198,7 +198,7 @@ Flyout(
     return Column(crossAxisAlignment: CrossAxisAlignment.start, children: [
       Text('Flyout with controller', style: typography.subtitle),
       Padding(
-        padding: const EdgeInsets.only(top: 10.0),
+        padding: const EdgeInsetsDirectional.only(top: 10.0),
         child: Flyout(
           controller: flyoutController,
           content: (context) {
@@ -223,7 +223,7 @@ Flyout(
     return Column(crossAxisAlignment: CrossAxisAlignment.start, children: [
       Text('Flyout displayed at start', style: typography.subtitle),
       Padding(
-        padding: const EdgeInsets.only(top: 10.0),
+        padding: const EdgeInsetsDirectional.only(top: 10.0),
         child: Flyout(
           openMode: FlyoutOpenMode.press,
           placement: FlyoutPlacement.start,
@@ -246,7 +246,7 @@ Flyout(
     return Column(crossAxisAlignment: CrossAxisAlignment.start, children: [
       Text('Flyout displayed at center', style: typography.subtitle),
       Padding(
-        padding: const EdgeInsets.only(top: 10.0),
+        padding: const EdgeInsetsDirectional.only(top: 10.0),
         child: Flyout(
           openMode: FlyoutOpenMode.press,
           placement: FlyoutPlacement.center,
@@ -269,7 +269,7 @@ Flyout(
     return Column(crossAxisAlignment: CrossAxisAlignment.start, children: [
       Text('Flyout displayed at end', style: typography.subtitle),
       Padding(
-        padding: const EdgeInsets.only(top: 10.0),
+        padding: const EdgeInsetsDirectional.only(top: 10.0),
         child: Flyout(
           openMode: FlyoutOpenMode.press,
           placement: FlyoutPlacement.end,
@@ -292,7 +292,7 @@ Flyout(
     return Column(crossAxisAlignment: CrossAxisAlignment.start, children: [
       Text('Flyout displayed at custom position', style: typography.subtitle),
       Padding(
-        padding: const EdgeInsets.only(top: 10.0),
+        padding: const EdgeInsetsDirectional.only(top: 10.0),
         child: Flyout(
           openMode: FlyoutOpenMode.press,
           placement: FlyoutPlacement.full,

--- a/example/lib/screens/surface/info_bars.dart
+++ b/example/lib/screens/surface/info_bars.dart
@@ -65,7 +65,7 @@ class _InfoBarsPageState extends State<InfoBarsPage> with PageMixin {
                   content: const Text('Is open'),
                 ),
                 Container(
-                  margin: const EdgeInsets.only(top: 10.0),
+                  margin: const EdgeInsetsDirectional.only(top: 10.0),
                   width: 150.0,
                   child: ComboBox<InfoBarSeverity>(
                     isExpanded: true,

--- a/example/lib/screens/surface/tooltip.dart
+++ b/example/lib/screens/surface/tooltip.dart
@@ -19,7 +19,7 @@ class TooltipPage extends ScrollablePage {
       subtitle(content: const Text('Button with a simple tooltip')),
       CardHighlight(
         child: Align(
-          alignment: Alignment.centerLeft,
+          alignment: AlignmentDirectional.centerStart,
           child: Tooltip(
             message: 'Simple ToolTip',
             child: Button(
@@ -43,7 +43,7 @@ class TooltipPage extends ScrollablePage {
       ),
       CardHighlight(
         child: Align(
-          alignment: Alignment.centerLeft,
+          alignment: AlignmentDirectional.centerStart,
           child: Tooltip(
             message: 'Horizontal ToolTip',
             displayHorizontally: true,

--- a/example/lib/screens/theming/icons.dart
+++ b/example/lib/screens/theming/icons.dart
@@ -82,9 +82,9 @@ class _IconsPageState extends State<IconsPage> {
         ),
       ),
       content: GridView.builder(
-        padding: EdgeInsets.only(
-          left: PageHeader.horizontalPadding(context),
-          right: PageHeader.horizontalPadding(context),
+        padding: EdgeInsetsDirectional.only(
+          start: PageHeader.horizontalPadding(context),
+          end: PageHeader.horizontalPadding(context),
         ),
         gridDelegate: const SliverGridDelegateWithMaxCrossAxisExtent(
           maxCrossAxisExtent: 150,
@@ -126,7 +126,7 @@ class _IconsPageState extends State<IconsPage> {
                         children: [
                           Icon(e.value, size: 40),
                           Padding(
-                            padding: const EdgeInsets.only(top: 8.0),
+                            padding: const EdgeInsetsDirectional.only(top: 8.0),
                             child: Text(
                               snakeCasetoSentenceCase(e.key),
                               textAlign: TextAlign.center,

--- a/example/lib/widgets/material_equivalents.dart
+++ b/example/lib/widgets/material_equivalents.dart
@@ -280,7 +280,7 @@ class _MaterialEquivalentsState extends State<MaterialEquivalents> {
             .map(
               (children) => Container(
                 constraints: const BoxConstraints(minHeight: 50.0),
-                alignment: Alignment.center,
+                alignment: AlignmentDirectional.center,
                 child: children[index],
               ),
             )

--- a/example/lib/widgets/page.dart
+++ b/example/lib/widgets/page.dart
@@ -8,7 +8,7 @@ mixin PageMixin {
   Widget description({required Widget content}) {
     return Builder(builder: (context) {
       return Padding(
-        padding: const EdgeInsets.only(bottom: 4.0),
+        padding: const EdgeInsetsDirectional.only(bottom: 4.0),
         child: DefaultTextStyle(
           style: FluentTheme.of(context).typography.body!,
           child: content,
@@ -20,7 +20,7 @@ mixin PageMixin {
   Widget subtitle({required Widget content}) {
     return Builder(builder: (context) {
       return Padding(
-        padding: const EdgeInsets.only(top: 14.0, bottom: 2.0),
+        padding: const EdgeInsetsDirectional.only(top: 14.0, bottom: 2.0),
         child: DefaultTextStyle(
           style: FluentTheme.of(context).typography.subtitle!,
           child: content,
@@ -49,7 +49,7 @@ abstract class Page extends StatelessWidget {
   Widget description({required Widget content}) {
     return Builder(builder: (context) {
       return Padding(
-        padding: const EdgeInsets.only(bottom: 4.0),
+        padding: const EdgeInsetsDirectional.only(bottom: 4.0),
         child: DefaultTextStyle(
           style: FluentTheme.of(context).typography.body!,
           child: content,
@@ -61,7 +61,7 @@ abstract class Page extends StatelessWidget {
   Widget subtitle({required Widget content}) {
     return Builder(builder: (context) {
       return Padding(
-        padding: const EdgeInsets.only(top: 14.0, bottom: 2.0),
+        padding: const EdgeInsetsDirectional.only(top: 14.0, bottom: 2.0),
         child: DefaultTextStyle(
           style: FluentTheme.of(context).typography.subtitle!,
           child: content,

--- a/example/lib/widgets/sponsor.dart
+++ b/example/lib/widgets/sponsor.dart
@@ -104,7 +104,7 @@ class _Tier extends StatelessWidget {
             crossAxisAlignment: CrossAxisAlignment.start,
             children: [
               const Padding(
-                padding: EdgeInsets.only(right: 6.0, top: 9.0),
+                padding: EdgeInsetsDirectional.only(end: 6.0, top: 9.0),
                 child: Icon(FluentIcons.circle_fill, size: 4.0),
               ),
               Expanded(child: Text(benefit)),

--- a/lib/src/controls/form/auto_suggest_box.dart
+++ b/lib/src/controls/form/auto_suggest_box.dart
@@ -465,7 +465,7 @@ class _AutoSuggestBoxState<T> extends State<AutoSuggestBox<T>> {
       final overlayY = globalOffset.dy + box.size.height;
       final maxHeight = screenHeight - overlayY;
 
-      Widget child = Positioned(
+      Widget child = PositionedDirectional(
         width: box.size.width,
         child: CompositedTransformFollower(
           link: _layerLink,
@@ -815,7 +815,7 @@ class _AutoSuggestBoxOverlayState<T> extends State<_AutoSuggestBoxOverlay<T>> {
               if (sortedItems.isEmpty) {
                 result = widget.noResultsFoundBuilder?.call(context) ??
                     Padding(
-                      padding: const EdgeInsets.only(bottom: 4.0),
+                      padding: const EdgeInsetsDirectional.only(bottom: 4.0),
                       child: _AutoSuggestBoxOverlayTile(
                         text: Text(localizations.noResultsFoundLabel),
                         selected: false,
@@ -827,7 +827,7 @@ class _AutoSuggestBoxOverlayState<T> extends State<_AutoSuggestBoxOverlay<T>> {
                   controller: scrollController,
                   key: ValueKey<int>(sortedItems.length),
                   shrinkWrap: true,
-                  padding: const EdgeInsets.only(bottom: 4.0),
+                  padding: const EdgeInsetsDirectional.only(bottom: 4.0),
                   itemCount: sortedItems.length,
                   itemBuilder: (context, index) {
                     final item = sortedItems[index];

--- a/lib/src/controls/form/combo_box.dart
+++ b/lib/src/controls/form/combo_box.dart
@@ -188,7 +188,7 @@ class _ComboBoxItemButtonState<T> extends State<_ComboBoxItemButton<T>> {
               child: widget.route.items[widget.itemIndex],
             ),
             if (states.isFocused)
-              AnimatedPositioned(
+              AnimatedPositionedDirectional(
                 duration: theme.fastAnimationDuration,
                 curve: theme.animationCurve,
                 top: states.isPressing ? 10.0 : 8.0,

--- a/lib/src/controls/form/combo_box.dart
+++ b/lib/src/controls/form/combo_box.dart
@@ -13,9 +13,9 @@ const Duration _kComboBoxMenuDuration = Duration(milliseconds: 300);
 const double _kMenuItemBottomPadding = 6.0;
 const double kComboBoxItemHeight = kPickerHeight + _kMenuItemBottomPadding;
 const EdgeInsets _kMenuItemPadding = EdgeInsets.symmetric(horizontal: 12.0);
-const EdgeInsetsGeometry _kAlignedButtonPadding = EdgeInsets.only(
-  right: 8.0,
-  left: 12.0,
+const EdgeInsetsGeometry _kAlignedButtonPadding = EdgeInsetsDirectional.only(
+  start: 12.0,
+  end: 8.0,
 );
 const EdgeInsets _kAlignedMenuMargin = EdgeInsets.zero;
 const EdgeInsets _kListPadding = EdgeInsets.only(top: _kMenuItemBottomPadding);
@@ -169,9 +169,9 @@ class _ComboBoxItemButtonState<T> extends State<_ComboBoxItemButton<T>> {
       builder: (context, states) {
         final theme = FluentTheme.of(context);
         return Padding(
-          padding: const EdgeInsets.only(
-            right: 6.0,
-            left: 6.0,
+          padding: const EdgeInsetsDirectional.only(
+            end: 6.0,
+            start: 6.0,
             // bottom: 4.0,
           ),
           child: Stack(fit: StackFit.loose, children: [
@@ -217,7 +217,8 @@ class _ComboBoxItemButtonState<T> extends State<_ComboBoxItemButton<T>> {
     }
 
     return Padding(
-      padding: const EdgeInsets.only(bottom: _kMenuItemBottomPadding),
+      padding:
+          const EdgeInsetsDirectional.only(bottom: _kMenuItemBottomPadding),
       child: child,
     );
   }
@@ -971,7 +972,7 @@ class ComboBox<T> extends StatefulWidget {
   /// @override
   /// Widget build(BuildContext context) {
   ///   return Container(
-  ///     alignment: Alignment.center,
+  ///     alignment: AlignmentDirectional.center,
   ///     color: Colors.blue,
   ///     child: ComboBox<String>(
   ///       value: comboboxValue,

--- a/lib/src/controls/form/form_row.dart
+++ b/lib/src/controls/form/form_row.dart
@@ -43,7 +43,7 @@ class FormRow extends StatelessWidget {
           ),
         if (error != null)
           Container(
-            margin: const EdgeInsets.only(top: 2.0),
+            margin: const EdgeInsetsDirectional.only(top: 2.0),
             alignment: AlignmentDirectional.centerStart,
             child: DefaultTextStyle(
               style: const TextStyle(

--- a/lib/src/controls/form/pickers/pickers.dart
+++ b/lib/src/controls/form/pickers/pickers.dart
@@ -52,7 +52,7 @@ Widget PickerHighlightTile() {
     );
     return Positioned.fill(
       child: Container(
-        alignment: Alignment.center,
+        alignment: AlignmentDirectional.center,
         height: kOneLineTileHeight,
         padding: const EdgeInsets.all(6.0),
         child: ListTile(
@@ -215,10 +215,10 @@ class PickerNavigatorIndicator extends StatelessWidget {
               child: Stack(children: [
                 child,
                 if (show) ...[
-                  Positioned(
+                  PositionedDirectional(
                     top: 0,
-                    left: 0,
-                    right: 0,
+                    start: 0,
+                    end: 0,
                     height: kOneLineTileHeight,
                     child: Button(
                       focusable: false,
@@ -231,10 +231,10 @@ class PickerNavigatorIndicator extends StatelessWidget {
                       ),
                     ),
                   ),
-                  Positioned(
+                  PositionedDirectional(
                     bottom: 0,
-                    left: 0,
-                    right: 0,
+                    start: 0,
+                    end: 0,
                     height: kOneLineTileHeight,
                     child: Button(
                       focusable: false,
@@ -370,8 +370,8 @@ class _PickerState extends State<Picker> {
         }();
 
         final view = Stack(children: [
-          Positioned(
-            left: x,
+          PositionedDirectional(
+            start: x,
             top: y,
             height: widget.pickerHeight,
             width: width,

--- a/lib/src/controls/form/selection_controls.dart
+++ b/lib/src/controls/form/selection_controls.dart
@@ -307,7 +307,11 @@ class _FluentTextSelectionToolbar extends StatelessWidget {
           elevation: 4.0,
           shape: RoundedRectangleBorder(borderRadius: radius),
           child: Container(
-            padding: const EdgeInsets.only(top: 5.0, left: 5.0, right: 5.0),
+            padding: const EdgeInsetsDirectional.only(
+              top: 5.0,
+              start: 5.0,
+              end: 5.0,
+            ),
             child: SizedBox(
               width: _kToolbarWidth,
               child: Column(
@@ -348,7 +352,7 @@ class _FluentTextSelectionToolbarButton extends StatelessWidget {
         final theme = FluentTheme.of(context);
         final radius = BorderRadius.circular(4.0);
         return Padding(
-          padding: const EdgeInsets.only(bottom: 5.0),
+          padding: const EdgeInsetsDirectional.only(bottom: 5.0),
           child: FocusBorder(
             focused: states.isFocused,
             renderOutside: true,
@@ -364,11 +368,11 @@ class _FluentTextSelectionToolbarButton extends StatelessWidget {
                   ),
                   borderRadius: radius,
                 ),
-                padding: const EdgeInsets.only(
+                padding: const EdgeInsetsDirectional.only(
                   top: 4.0,
                   bottom: 4.0,
-                  left: 10.0,
-                  right: 8.0,
+                  start: 10.0,
+                  end: 8.0,
                 ),
                 child: Row(mainAxisSize: MainAxisSize.min, children: [
                   Padding(

--- a/lib/src/controls/inputs/buttons/button.dart
+++ b/lib/src/controls/inputs/buttons/button.dart
@@ -42,10 +42,10 @@ class Button extends BaseButton {
       //   return 0.3;
       // }),
       shadowColor: ButtonState.all(theme.shadowColor),
-      padding: ButtonState.all(const EdgeInsets.only(
-        left: 11.0,
+      padding: ButtonState.all(const EdgeInsetsDirectional.only(
+        start: 11.0,
         top: 5.0,
-        right: 11.0,
+        end: 11.0,
         bottom: 5.0,
       )),
       shape: ButtonState.resolveWith((states) {

--- a/lib/src/controls/inputs/checkbox.dart
+++ b/lib/src/controls/inputs/checkbox.dart
@@ -95,7 +95,7 @@ class Checkbox extends StatelessWidget {
           : () => onChanged!(checked == null ? null : !(checked!)),
       builder: (context, state) {
         Widget child = AnimatedContainer(
-          alignment: Alignment.center,
+          alignment: AlignmentDirectional.center,
           duration: FluentTheme.of(context).fastAnimationDuration,
           curve: FluentTheme.of(context).animationCurve,
           padding: style.padding,
@@ -432,7 +432,7 @@ class _Icon extends StatelessWidget {
         case TextDirection.rtl:
           iconWidget = Transform(
             transform: Matrix4.identity()..scale(-1.0, 1.0, 1.0),
-            alignment: Alignment.center,
+            alignment: AlignmentDirectional.center,
             transformHitTests: false,
             child: iconWidget,
           );

--- a/lib/src/controls/inputs/pill_button_bar.dart
+++ b/lib/src/controls/inputs/pill_button_bar.dart
@@ -114,7 +114,7 @@ class _PillButtonBarItem extends StatelessWidget {
         final Color unselectedColor = theme.unselectedColor?.resolve(states) ??
             FluentTheme.of(context).accentColor.dark;
         return Align(
-          alignment: Alignment.center,
+          alignment: AlignmentDirectional.center,
           child: Container(
             decoration: BoxDecoration(
               color: selected ? selectedColor : unselectedColor,
@@ -124,7 +124,7 @@ class _PillButtonBarItem extends StatelessWidget {
               minWidth: _kMinButtonWidth + visualDensity.horizontal,
               maxHeight: _kMaxButtonHeight + visualDensity.vertical,
             ),
-            alignment: Alignment.center,
+            alignment: AlignmentDirectional.center,
             padding: EdgeInsets.symmetric(
               horizontal: 16.0 + visualDensity.horizontal,
               vertical: 3.0,

--- a/lib/src/controls/inputs/rating.dart
+++ b/lib/src/controls/inputs/rating.dart
@@ -268,7 +268,9 @@ class _RatingBarState extends State<RatingBar> {
                       );
                       if (index != widget.amount - 1) {
                         return Padding(
-                          padding: EdgeInsets.only(right: widget.starSpacing),
+                          padding: EdgeInsetsDirectional.only(
+                            end: widget.starSpacing,
+                          ),
                           child: icon,
                         );
                       }

--- a/lib/src/controls/inputs/toggle_switch.dart
+++ b/lib/src/controls/inputs/toggle_switch.dart
@@ -170,7 +170,9 @@ class _ToggleSwitchState extends State<ToggleSwitch> {
       builder: (context, states) {
         Widget child = AnimatedContainer(
           alignment: _alignment ??
-              (widget.checked ? Alignment.centerRight : Alignment.centerLeft),
+              (widget.checked
+                  ? AlignmentDirectional.centerEnd
+                  : AlignmentDirectional.centerStart),
           height: 20,
           width: 40,
           duration: style.animationDuration ?? Duration.zero,

--- a/lib/src/controls/navigation/bottom_navigation.dart
+++ b/lib/src/controls/navigation/bottom_navigation.dart
@@ -148,7 +148,7 @@ class _BottomNavigationItem extends StatelessWidget {
             ),
             if (item.title != null)
               Padding(
-                padding: const EdgeInsets.only(top: 1.0),
+                padding: const EdgeInsetsDirectional.only(top: 1.0),
                 child: DefaultTextStyle(
                   style: FluentTheme.of(context).typography.caption!.copyWith(
                         color: selected

--- a/lib/src/controls/navigation/navigation_view/body.dart
+++ b/lib/src/controls/navigation/navigation_view/body.dart
@@ -77,16 +77,24 @@ class _NavigationBody extends StatefulWidget {
 }
 
 class _NavigationBodyState extends State<_NavigationBody> {
-  final _pageKey = GlobalKey();
-  final _pageController = PageController();
+  final _pageKey = GlobalKey<State<PageView>>();
+  PageController? _pageController;
+
+  PageController get pageController => _pageController!;
 
   @override
   void didChangeDependencies() {
     super.didChangeDependencies();
     final view = InheritedNavigationView.of(context);
+    final selected = view.pane?.selected ?? 0;
+    MediaQuery.of(context);
 
-    if (_pageController.hasClients && view.oldIndex != view.pane?.selected) {
-      _pageController.jumpToPage(view.pane?.selected ?? 0);
+    _pageController ??= PageController(initialPage: selected);
+
+    if (pageController.hasClients) {
+      if (view.oldIndex != selected || pageController.page != selected) {
+        pageController.jumpToPage(selected);
+      }
     }
   }
 
@@ -139,19 +147,19 @@ class _NavigationBodyState extends State<_NavigationBody> {
             key: _pageKey,
             physics: const NeverScrollableScrollPhysics(),
             allowImplicitScrolling: false,
-            controller: _pageController,
+            controller: pageController,
             itemCount: view.pane!.effectiveItems.length,
             itemBuilder: (context, index) {
               final bool isSelected = view.pane!.selected == index;
-              return view.pane!.effectiveItems.map((item) {
-                return ExcludeFocus(
-                  key: item.bodyKey,
-                  excluding: !isSelected,
-                  child: FocusTraversalGroup(
-                    child: widget.paneBodyBuilder?.call(item.body) ?? item.body,
-                  ),
-                );
-              }).elementAt(index);
+              final item = view.pane!.effectiveItems[index];
+
+              return ExcludeFocus(
+                key: item.bodyKey,
+                excluding: !isSelected,
+                child: FocusTraversalGroup(
+                  child: widget.paneBodyBuilder?.call(item.body) ?? item.body,
+                ),
+              );
             },
           ),
         ),

--- a/lib/src/controls/navigation/navigation_view/indicators.dart
+++ b/lib/src/controls/navigation/navigation_view/indicators.dart
@@ -349,7 +349,7 @@ class _StickyNavigationIndicatorState
                   child: Container(width: 2.5, decoration: decoration),
                 )
               : Align(
-                  alignment: Alignment.bottomCenter,
+                  alignment: AlignmentDirectional.bottomCenter,
                   child: Container(height: 2.5, decoration: decoration),
                 ),
           builder: (context, child) {
@@ -361,8 +361,8 @@ class _StickyNavigationIndicatorState
             }
             return Padding(
               padding: isHorizontal
-                  ? EdgeInsets.only(
-                      left: () {
+                  ? EdgeInsetsDirectional.only(
+                      start: () {
                         final x = offsets![itemIndex].dx;
                         if (parent != null) {
                           final isOpen =

--- a/lib/src/controls/navigation/navigation_view/pane.dart
+++ b/lib/src/controls/navigation/navigation_view/pane.dart
@@ -730,7 +730,7 @@ class _TopNavigationPaneState extends State<_TopNavigationPane> {
         ),
         if (widget.pane.autoSuggestBox != null)
           Container(
-            margin: const EdgeInsets.only(left: 30.0),
+            margin: const EdgeInsetsDirectional.only(start: 30.0),
             constraints: const BoxConstraints(minWidth: 100.0, maxWidth: 215.0),
             child: widget.pane.autoSuggestBox!,
           ),
@@ -1041,7 +1041,8 @@ class _CompactNavigationPane extends StatelessWidget {
   Widget build(BuildContext context) {
     assert(debugCheckHasFluentTheme(context));
     final theme = NavigationPaneTheme.of(context);
-    const EdgeInsetsGeometry topPadding = EdgeInsets.only(bottom: 8.0);
+    const EdgeInsetsGeometry topPadding =
+        EdgeInsetsDirectional.only(bottom: 8.0);
     final bool showReplacement =
         pane.autoSuggestBox != null && pane.autoSuggestBoxReplacement != null;
     return AnimatedContainer(
@@ -1051,7 +1052,7 @@ class _CompactNavigationPane extends StatelessWidget {
       width: pane.size?.compactWidth ?? kCompactNavigationPaneWidth,
       child: Align(
         key: pane.paneKey,
-        alignment: Alignment.topCenter,
+        alignment: AlignmentDirectional.topCenter,
         child: Column(crossAxisAlignment: CrossAxisAlignment.start, children: [
           () {
             if (pane.menuButton != null) return pane.menuButton!;
@@ -1206,7 +1207,8 @@ class _OpenNavigationPaneState extends State<_OpenNavigationPane>
   @override
   Widget build(BuildContext context) {
     assert(debugCheckHasFluentTheme(context));
-    const EdgeInsetsGeometry topPadding = EdgeInsets.only(bottom: 6.0);
+    const EdgeInsetsGeometry topPadding =
+        EdgeInsetsDirectional.only(bottom: 6.0);
     final menuButton = () {
       if (widget.pane.menuButton != null) return widget.pane.menuButton!;
       if (widget.onToggle != null) {
@@ -1255,7 +1257,7 @@ class _OpenNavigationPaneState extends State<_OpenNavigationPane>
                       menuButton ?? const SizedBox.shrink(),
                       Expanded(
                         child: Align(
-                          alignment: Alignment.centerLeft,
+                          alignment: AlignmentDirectional.centerStart,
                           child: widget.pane.header!,
                         ),
                       ),
@@ -1269,7 +1271,7 @@ class _OpenNavigationPaneState extends State<_OpenNavigationPane>
               Container(
                 padding: theme.iconPadding ?? EdgeInsets.zero,
                 height: 41.0,
-                alignment: Alignment.center,
+                alignment: AlignmentDirectional.center,
                 margin: topPadding,
                 child: widget.pane.autoSuggestBox!,
               ),

--- a/lib/src/controls/navigation/navigation_view/pane_items.dart
+++ b/lib/src/controls/navigation/navigation_view/pane_items.dart
@@ -121,9 +121,6 @@ class PaneItem extends NavigationPaneItem {
     assert(mode != PaneDisplayMode.auto);
 
     assert(debugCheckHasFluentTheme(context));
-    assert(debugCheckHasDirectionality(context));
-
-    final direction = Directionality.of(context);
 
     final NavigationPaneThemeData theme = NavigationPaneTheme.of(context);
     final String titleText = title?.getProperty<String>() ?? '';
@@ -189,21 +186,25 @@ class PaneItem extends NavigationPaneItem {
               return Container(
                 key: itemKey,
                 height: 36.0,
-                alignment: Alignment.center,
+                alignment: AlignmentDirectional.center,
                 child: Padding(
                   padding: theme.iconPadding ?? EdgeInsets.zero,
                   child: IconTheme.merge(
                     data: iconThemeData,
                     child: Align(
-                      alignment: Alignment.centerLeft,
+                      alignment: AlignmentDirectional.centerStart,
                       child: () {
                         if (infoBadge != null) {
                           return Stack(
-                            alignment: Alignment.center,
+                            alignment: AlignmentDirectional.center,
                             clipBehavior: Clip.none,
                             children: [
                               icon,
-                              Positioned(right: -8, top: -8, child: infoBadge!),
+                              PositionedDirectional(
+                                end: -8,
+                                top: -8,
+                                child: infoBadge!,
+                              ),
                             ],
                           );
                         }
@@ -259,8 +260,7 @@ class PaneItem extends NavigationPaneItem {
                 return Stack(key: itemKey, clipBehavior: Clip.none, children: [
                   result,
                   if (infoBadge != null)
-                    Positioned.directional(
-                      textDirection: direction,
+                    PositionedDirectional(
                       end: -3,
                       top: 3,
                       child: infoBadge!,
@@ -277,7 +277,7 @@ class PaneItem extends NavigationPaneItem {
           label: titleText.isEmpty ? null : titleText,
           selected: selected,
           child: Container(
-            margin: const EdgeInsets.only(right: 6.0, left: 6.0),
+            margin: const EdgeInsets.symmetric(horizontal: 6.0),
             decoration: BoxDecoration(
               color: () {
                 final ButtonState<Color?> tileColor = this.tileColor ??
@@ -334,7 +334,7 @@ class PaneItem extends NavigationPaneItem {
     }();
 
     return Padding(
-      padding: const EdgeInsets.only(bottom: 4.0),
+      padding: const EdgeInsetsDirectional.only(bottom: 4.0),
       child: () {
         // If there is an indicator and the item is an effective item
         if (maybeBody?.pane?.indicator != null &&
@@ -821,7 +821,7 @@ class __PaneItemExpanderState extends State<_PaneItemExpander>
                         horizontal: 10.0,
                         vertical: 8.0,
                       ),
-                      margin: const EdgeInsets.only(bottom: 4.0),
+                      margin: const EdgeInsetsDirectional.only(bottom: 4.0),
                       child: DefaultTextStyle(
                         style: navigationTheme.itemHeaderTextStyle ??
                             const TextStyle(),
@@ -878,7 +878,7 @@ class _PaneItemExpanderMenuItem extends MenuFlyoutItemInterface {
               horizontal: 10.0,
               vertical: 8.0,
             ),
-            margin: const EdgeInsets.only(bottom: 4.0),
+            margin: const EdgeInsetsDirectional.only(bottom: 4.0),
             decoration: BoxDecoration(
               color: ButtonThemeData.uncheckedInputColor(
                 theme,

--- a/lib/src/controls/navigation/navigation_view/view.dart
+++ b/lib/src/controls/navigation/navigation_view/view.dart
@@ -573,7 +573,7 @@ class NavigationViewState extends State<NavigationView> {
                           key: _overlayKey,
                           backgroundColor: overlayBackgroundColor(),
                           child: Padding(
-                            padding: EdgeInsets.only(
+                            padding: EdgeInsetsDirectional.only(
                               top: appBarPadding.resolve(direction).top,
                             ),
                             child: _CompactNavigationPane(
@@ -617,10 +617,10 @@ class NavigationViewState extends State<NavigationView> {
               break;
             case PaneDisplayMode.minimal:
               paneResult = Stack(children: [
-                Positioned(
+                PositionedDirectional(
                   top: widget.appBar?.finalHeight(context) ?? 0.0,
-                  left: 0.0,
-                  right: 0.0,
+                  start: 0.0,
+                  end: 0.0,
                   bottom: 0.0,
                   child: content,
                 ),
@@ -852,10 +852,8 @@ class _NavigationAppBar extends StatelessWidget {
   Widget build(BuildContext context) {
     assert(debugCheckHasMediaQuery(context));
     assert(debugCheckHasFluentLocalizations(context));
-    assert(debugCheckHasDirectionality(context));
 
     final mediaQuery = MediaQuery.of(context);
-    final direction = Directionality.of(context);
 
     final PaneDisplayMode displayMode =
         InheritedNavigationView.maybeOf(context)?.displayMode ??
@@ -900,7 +898,7 @@ class _NavigationAppBar extends StatelessWidget {
       case PaneDisplayMode.compact:
         result = Stack(children: [
           Align(
-            alignment: Alignment.centerLeft,
+            alignment: AlignmentDirectional.centerStart,
             child: Row(mainAxisSize: MainAxisSize.min, children: [
               leading,
               if (additionalLeading != null) additionalLeading!,
@@ -908,14 +906,13 @@ class _NavigationAppBar extends StatelessWidget {
             ]),
           ),
           if (appBar.actions != null)
-            Positioned.directional(
-              textDirection: direction,
+            PositionedDirectional(
               start: 0,
               end: 0.0,
               top: 0.0,
               bottom: 0.0,
               child: Align(
-                alignment: Alignment.topRight,
+                alignment: AlignmentDirectional.topEnd,
                 child: appBar.actions!,
               ),
             ),
@@ -929,7 +926,7 @@ class _NavigationAppBar extends StatelessWidget {
     return Container(
       color: appBar.backgroundColor,
       height: appBar.finalHeight(context),
-      padding: EdgeInsets.only(top: topPadding),
+      padding: EdgeInsetsDirectional.only(top: topPadding),
       child: result,
     );
   }

--- a/lib/src/controls/navigation/tab_view.dart
+++ b/lib/src/controls/navigation/tab_view.dart
@@ -582,7 +582,12 @@ class _TabViewState extends State<TabView> {
         ),
       ),
       if (widget.tabs.isNotEmpty)
-        Expanded(child: widget.tabs[widget.currentIndex].body),
+        Expanded(
+          child: IndexedStack(
+            index: widget.currentIndex,
+            children: widget.tabs.map((tab) => tab.body).toList(),
+          ),
+        ),
     ]);
     if (widget.shortcutsEnabled) {
       void onClosePressed() {

--- a/lib/src/controls/navigation/tab_view.dart
+++ b/lib/src/controls/navigation/tab_view.dart
@@ -416,14 +416,14 @@ class _TabViewState extends State<TabView> {
       ScrollConfiguration(
         behavior: const _TabViewScrollBehavior(),
         child: Container(
-          margin: const EdgeInsets.only(top: 4.5),
-          padding: const EdgeInsets.only(left: 8),
+          margin: const EdgeInsetsDirectional.only(top: 4.5),
+          padding: const EdgeInsetsDirectional.only(start: 8),
           height: _kTileHeight,
           width: double.infinity,
           child: Row(children: [
             if (widget.header != null)
               Padding(
-                padding: const EdgeInsets.only(right: 12.0),
+                padding: const EdgeInsetsDirectional.only(end: 12.0),
                 child: DefaultTextStyle(
                   style: headerFooterTextStyle,
                   child: widget.header!,
@@ -572,7 +572,7 @@ class _TabViewState extends State<TabView> {
             ),
             if (widget.footer != null)
               Padding(
-                padding: const EdgeInsets.only(left: 12.0),
+                padding: const EdgeInsetsDirectional.only(start: 12.0),
                 child: DefaultTextStyle(
                   style: headerFooterTextStyle,
                   child: widget.footer!,

--- a/lib/src/controls/navigation/tree_view.dart
+++ b/lib/src/controls/navigation/tree_view.dart
@@ -1010,10 +1010,10 @@ class _TreeViewItem extends StatelessWidget {
                 ),
               ),
               if (selected && selectionMode == TreeViewSelectionMode.single)
-                Positioned(
+                PositionedDirectional(
                   top: 6.0,
                   bottom: 6.0,
-                  left: 0.0,
+                  start: 0.0,
                   child: Container(
                     width: 3.0,
                     decoration: BoxDecoration(

--- a/lib/src/controls/surfaces/bottom_sheet.dart
+++ b/lib/src/controls/surfaces/bottom_sheet.dart
@@ -688,9 +688,9 @@ class BottomSheet extends StatelessWidget {
     assert(debugCheckHasFluentTheme(context));
     final theme = BottomSheetTheme.of(context);
     return Padding(
-      padding: const EdgeInsets.only(top: 8.0),
+      padding: const EdgeInsetsDirectional.only(top: 8.0),
       child: Align(
-        alignment: Alignment.center,
+        alignment: AlignmentDirectional.center,
         child: Container(
           width: 40,
           height: 4.0,

--- a/lib/src/controls/surfaces/commandbar.dart
+++ b/lib/src/controls/surfaces/commandbar.dart
@@ -236,7 +236,7 @@ class _CommandBarState extends State<CommandBar> {
       overflowWidget = Flyout(
         content: (context) => FlyoutContent(
           constraints: const BoxConstraints(maxWidth: 250.0),
-          padding: const EdgeInsets.only(top: 8.0),
+          padding: const EdgeInsetsDirectional.only(top: 8.0),
           child: ListView(
             shrinkWrap: true,
             children: allSecondaryItems
@@ -520,7 +520,7 @@ class CommandBarButton extends CommandBarItem {
         );
       case CommandBarItemDisplayMode.inSecondary:
         return Padding(
-          padding: const EdgeInsets.only(right: 8.0, left: 8.0),
+          padding: const EdgeInsetsDirectional.only(end: 8.0, start: 8.0),
           child: FlyoutListTile(
             key: key,
             onPressed: onPressed,
@@ -582,7 +582,7 @@ class CommandBarSeparator extends CommandBarItem {
           style: DividerThemeData(
             thickness: thickness,
             decoration: color != null ? BoxDecoration(color: color) : null,
-            horizontalMargin: const EdgeInsets.only(bottom: 5.0),
+            horizontalMargin: const EdgeInsetsDirectional.only(bottom: 5.0),
           ),
         );
     }

--- a/lib/src/controls/surfaces/dialog.dart
+++ b/lib/src/controls/surfaces/dialog.dart
@@ -85,7 +85,7 @@ class ContentDialog extends StatelessWidget {
       FluentTheme.of(context).dialogTheme.merge(this.style),
     );
     return Align(
-      alignment: Alignment.center,
+      alignment: AlignmentDirectional.center,
       child: Container(
         constraints: constraints,
         decoration: style.decoration,
@@ -131,7 +131,7 @@ class ContentDialog extends StatelessWidget {
                   child: () {
                     if (actions!.length == 1) {
                       return Align(
-                        alignment: Alignment.centerRight,
+                        alignment: AlignmentDirectional.centerEnd,
                         child: actions!.first,
                       );
                     }
@@ -404,7 +404,7 @@ class ContentDialogThemeData {
         boxShadow: kElevationToShadow[6],
       ),
       padding: const EdgeInsets.all(20),
-      titlePadding: const EdgeInsets.only(bottom: 12),
+      titlePadding: const EdgeInsetsDirectional.only(bottom: 12),
       actionsSpacing: 10,
       actionsDecoration: BoxDecoration(
         color: style.micaBackgroundColor,

--- a/lib/src/controls/surfaces/expander.dart
+++ b/lib/src/controls/surfaces/expander.dart
@@ -235,7 +235,7 @@ class ExpanderState extends State<Expander>
                           ButtonThemeData.uncheckedInputColor(_theme, states),
                       borderRadius: BorderRadius.circular(4.0),
                     ),
-                    alignment: Alignment.center,
+                    alignment: AlignmentDirectional.center,
                     child: widget.icon ??
                         RotationTransition(
                           turns: Tween<double>(begin: 0, end: 0.5)

--- a/lib/src/controls/surfaces/flyout/content.dart
+++ b/lib/src/controls/surfaces/flyout/content.dart
@@ -90,7 +90,7 @@ class FlyoutListTile extends StatelessWidget {
     this.focusNode,
     this.autofocus = false,
     this.semanticLabel,
-    this.margin = const EdgeInsets.only(bottom: 5.0),
+    this.margin = const EdgeInsetsDirectional.only(bottom: 5.0),
     this.selected = false,
   }) : super(key: key);
 
@@ -197,7 +197,7 @@ class FlyoutListTile extends StatelessWidget {
             ]),
           ),
           if (selected)
-            Positioned(
+            PositionedDirectional(
               top: 0,
               bottom: 0,
               child: Container(

--- a/lib/src/controls/surfaces/flyout/menu.dart
+++ b/lib/src/controls/surfaces/flyout/menu.dart
@@ -175,7 +175,7 @@ class MenuFlyoutSeparator extends MenuFlyoutItemInterface {
     return SizedBox(
       width: size.width,
       child: const Padding(
-        padding: EdgeInsets.only(bottom: 5.0),
+        padding: EdgeInsetsDirectional.only(bottom: 5.0),
         child: Divider(
           style: DividerThemeData(horizontalMargin: EdgeInsets.zero),
         ),

--- a/lib/src/controls/surfaces/list_tile.dart
+++ b/lib/src/controls/surfaces/list_tile.dart
@@ -293,7 +293,7 @@ class ListTile extends StatelessWidget {
                                       .defaultBrushFor(theme.brightness)
                                   : Colors.transparent,
                             ),
-                            margin: const EdgeInsets.only(right: 8.0),
+                            margin: const EdgeInsetsDirectional.only(end: 8.0),
                           ),
                         ),
                       ),

--- a/lib/src/controls/surfaces/snackbar.dart
+++ b/lib/src/controls/surfaces/snackbar.dart
@@ -14,7 +14,7 @@ const Duration snackbarLongDuration = Duration(seconds: 4);
 /// the snackbar will long forever, and have to be dismissed manually.
 ///
 /// [alignment] is used to align the snackbar within the screen. Defaults
-/// to [Alignment.bottomCenter]
+/// to [AlignmentDirectional.bottomCenter]
 ///
 /// [margin] is the margin applied to snackbar. Defaults to 16 logical
 /// pixels on all sides
@@ -32,7 +32,7 @@ OverlayEntry showSnackbar(
   BuildContext context,
   Widget snackbar, {
   Duration? duration = snackbarShortDuration,
-  Alignment alignment = Alignment.bottomCenter,
+  AlignmentGeometry alignment = AlignmentDirectional.bottomCenter,
   EdgeInsetsGeometry margin = const EdgeInsets.all(16.0),
   VoidCallback? onDismiss,
 }) {
@@ -151,8 +151,9 @@ class SnackbarState extends State<Snackbar>
               widget.content,
               if (widget.action != null)
                 Padding(
-                  padding: EdgeInsets.only(
-                    left: widget.extended ? 0 : 16.0 + visualDensity.horizontal,
+                  padding: EdgeInsetsDirectional.only(
+                    start:
+                        widget.extended ? 0 : 16.0 + visualDensity.horizontal,
                     top: !widget.extended ? 0 : 8.0 + visualDensity.vertical,
                   ),
                   child: ButtonTheme.merge(

--- a/lib/src/layout/page.dart
+++ b/lib/src/layout/page.dart
@@ -36,10 +36,10 @@ class ScaffoldPage extends StatefulWidget {
   })  : content = Builder(builder: (context) {
           return ListView(
             controller: scrollController,
-            padding: EdgeInsets.only(
+            padding: EdgeInsetsDirectional.only(
               bottom: kPageDefaultVerticalPadding,
-              left: PageHeader.horizontalPadding(context),
-              right: PageHeader.horizontalPadding(context),
+              start: PageHeader.horizontalPadding(context),
+              end: PageHeader.horizontalPadding(context),
             ),
             children: children,
           );
@@ -56,10 +56,10 @@ class ScaffoldPage extends StatefulWidget {
     this.resizeToAvoidBottomInset = true,
   })  : content = Builder(builder: (context) {
           return Padding(
-            padding: EdgeInsets.only(
+            padding: EdgeInsetsDirectional.only(
               bottom: kPageDefaultVerticalPadding,
-              left: PageHeader.horizontalPadding(context),
-              right: PageHeader.horizontalPadding(context),
+              start: PageHeader.horizontalPadding(context),
+              end: PageHeader.horizontalPadding(context),
             ),
             child: content,
           );
@@ -136,7 +136,7 @@ class _ScaffoldPageState extends State<ScaffoldPage> {
     return PageStorage(
       bucket: _bucket,
       child: Padding(
-        padding: EdgeInsets.only(
+        padding: EdgeInsetsDirectional.only(
           bottom: widget.resizeToAvoidBottomInset
               ? mediaQuery.viewInsets.bottom
               : 0.0,
@@ -148,7 +148,7 @@ class _ScaffoldPageState extends State<ScaffoldPage> {
               // not a parent widget of this page. this happens because, if a navigation
               // view is not used, the page would be uncolored.
               color: view == null ? theme.scaffoldBackgroundColor : null,
-              padding: EdgeInsets.only(
+              padding: EdgeInsetsDirectional.only(
                 top: widget.padding?.top ?? kPageDefaultVerticalPadding,
               ),
               child: Column(

--- a/lib/src/layout/page.dart
+++ b/lib/src/layout/page.dart
@@ -222,10 +222,9 @@ class PageHeader extends StatelessWidget {
     final horizontalPadding = padding ?? PageHeader.horizontalPadding(context);
 
     return Padding(
-      padding: EdgeInsets.only(
+      padding: EdgeInsetsDirectional.only(
         bottom: 18.0,
-        left: leading != null ? 0 : horizontalPadding,
-        right: horizontalPadding,
+        start: leading != null ? 0 : horizontalPadding,
       ),
       child: Row(children: [
         if (leading != null) leading!,
@@ -235,7 +234,19 @@ class PageHeader extends StatelessWidget {
             child: title ?? const SizedBox(),
           ),
         ),
-        if (commandBar != null) commandBar!,
+        SizedBox(width: horizontalPadding),
+        if (commandBar != null) ...[
+          Flexible(
+            child: ConstrainedBox(
+              constraints: const BoxConstraints(minWidth: 160.0),
+              child: Align(
+                alignment: AlignmentDirectional.centerEnd,
+                child: commandBar!,
+              ),
+            ),
+          ),
+          SizedBox(width: horizontalPadding),
+        ],
       ]),
     );
   }

--- a/lib/src/styles/acrylic.dart
+++ b/lib/src/styles/acrylic.dart
@@ -400,7 +400,7 @@ class _AcrylicGuts extends StatelessWidget {
                             "assets/AcrylicNoise.png",
                             package: "fluent_ui",
                           ),
-                          alignment: Alignment.topLeft,
+                          alignment: AlignmentDirectional.topStart,
                           repeat: ImageRepeat.repeat,
                         ),
                         backgroundBlendMode: BlendMode.srcOver,

--- a/lib/src/styles/focus.dart
+++ b/lib/src/styles/focus.dart
@@ -101,9 +101,9 @@ class FocusBorder extends StatelessWidget {
         clipBehavior: clipBehavior,
         children: [
           child,
-          Positioned.fill(
-            left: renderOutside ? -borderWidth : 0,
-            right: renderOutside ? -borderWidth : 0,
+          PositionedDirectional(
+            start: renderOutside ? -borderWidth : 0,
+            end: renderOutside ? -borderWidth : 0,
             top: renderOutside ? -borderWidth : 0,
             bottom: renderOutside ? -borderWidth : 0,
             child: _buildBorder(style, focused),

--- a/lib/src/utils/horizontal_scroll_view.dart
+++ b/lib/src/utils/horizontal_scroll_view.dart
@@ -59,7 +59,7 @@ class _HorizontalScrollViewState extends State<HorizontalScrollView> {
                     _controller.animateTo(
                         _controller.offset + event.scrollDelta.dy,
                         duration: const Duration(milliseconds: 100),
-                        curve: Curves.ease);
+                        curve: Curves.ease,);
                   }
                 });
               }

--- a/lib/src/utils/horizontal_scroll_view.dart
+++ b/lib/src/utils/horizontal_scroll_view.dart
@@ -57,9 +57,10 @@ class _HorizontalScrollViewState extends State<HorizontalScrollView> {
                     // jump beyond the boundaries and then "rebound" like jumpTo
                     // would do if used here).
                     _controller.animateTo(
-                        _controller.offset + event.scrollDelta.dy,
-                        duration: const Duration(milliseconds: 100),
-                        curve: Curves.ease,);
+                      _controller.offset + event.scrollDelta.dy,
+                      duration: const Duration(milliseconds: 100),
+                      curve: Curves.ease,
+                    );
                   }
                 });
               }

--- a/lib/src/utils/label.dart
+++ b/lib/src/utils/label.dart
@@ -53,13 +53,13 @@ class InfoLabel extends StatelessWidget {
       children: [
         if (isHeader)
           Padding(
-            padding: const EdgeInsets.only(bottom: 4.0),
+            padding: const EdgeInsetsDirectional.only(bottom: 4.0),
             child: labelWidget,
           ),
         if (child != null) Flexible(child: child!),
         if (!isHeader)
           Padding(
-            padding: const EdgeInsets.only(left: 4.0),
+            padding: const EdgeInsetsDirectional.only(start: 4.0),
             child: labelWidget,
           ),
       ],


### PR DESCRIPTION
<!-- Add a description of what this PR is changing or adding, and why. Consider mentioning issues -->

Fixes #642

- `PageHeader` now gives appropriate bounds to its `commandBar` ([#642](https://github.com/bdlukaa/fluent_ui/issues/642))
- Ensure `NavigationView` body state is not lost when resizing window
- Ensure `TabView`' tabs' state are not lost when changing selected tab ([#607](https://github.com/bdlukaa/fluent_ui/pull/607))

## Pre-launch Checklist

<!-- Mark all that applies -->

- [x] I have updated `CHANGELOG.md` with my changes <!-- REQUIRED --> 
- [x] I have run "dart format ." on the project <!-- REQUIRED --> 
- [ ] I have added/updated relevant documentation