### PR TITLE
Added missing German translations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 - Fix assertion in `NavigationViewState` if no pane was currently selected ([#678](https://github.com/bdlukaa/fluent_ui/issues/678))
 - Make `NavigationView.paneBodyBuilder` responsible for state management of the widget it returns, allowing `paneBodyBuilder` to return an `IndexedStack` (common use case) ([#679](https://github.com/bdlukaa/fluent_ui/issues/679))
 - Added support for Belarusian language ([#686](https://github.com/bdlukaa/fluent_ui/pull/686))
+- Added missing German translation for `minute`, `hour`, `day`, `month`, and `year` 
 
 ## 4.1.4
 

--- a/lib/l10n/generated/fluent_localizations_de.dart
+++ b/lib/l10n/generated/fluent_localizations_de.dart
@@ -80,10 +80,10 @@ class FluentLocalizationsDe extends FluentLocalizations {
   String get selectAllActionTooltip => 'Alle Inhalte auswählen';
 
   @override
-  String get hour => 'hour';
+  String get hour => 'Stunde';
 
   @override
-  String get minute => 'minute';
+  String get minute => 'Minute';
 
   @override
   String get am => 'AM';
@@ -92,11 +92,11 @@ class FluentLocalizationsDe extends FluentLocalizations {
   String get pm => 'PM';
 
   @override
-  String get month => 'month';
+  String get month => 'Monat';
 
   @override
-  String get day => 'day';
+  String get day => 'Tag';
 
   @override
-  String get year => 'year';
+  String get year => 'Jahr';
 }

--- a/lib/l10n/intl_de.arb
+++ b/lib/l10n/intl_de.arb
@@ -23,5 +23,12 @@
   "copyActionTooltip": "Ausgewählten Inhalt in die Zwischenablage kopieren",
   "cutActionTooltip": "Ausgewählten Inhalt entfernen und in die Zwischenablage legen",
   "pasteActionTooltip": "Fügt den Inhalt der Zwischenablage an der aktuellen Stelle ein",
-  "selectAllActionTooltip": "Alle Inhalte auswählen"
+  "selectAllActionTooltip": "Alle Inhalte auswählen",
+  "hour": "Stunde",
+  "minute": "Minute",
+  "am": "AM",
+  "pm": "PM",
+  "month": "Monat",
+  "day": "Tag",
+  "year": "Jahr"
 }

--- a/lib/l10n/untranslated.json
+++ b/lib/l10n/untranslated.json
@@ -4,16 +4,6 @@
     "pm"
   ],
 
-  "de": [
-    "hour",
-    "minute",
-    "am",
-    "pm",
-    "month",
-    "day",
-    "year"
-  ],
-
   "ko": [
     "hour",
     "minute",


### PR DESCRIPTION
Added missing German translations for: `minute`, `hour`, `day`, `month`, and `year`.

## Pre-launch Checklist

<!-- Mark all that applies -->

- [x] I have updated `CHANGELOG.md` with my changes <!-- REQUIRED --> 
- [x] I have run "dart format ." on the project <!-- REQUIRED --> 
- [x] I have added/updated relevant documentation