### PR TITLE
Fix ContentDialog copy code

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 - `TabView` focus on children now works properly ([#648](https://github.com/bdlukaa/fluent_ui/issues/648))
 - `TabView` colors now follow the Win UI 3 theme resources ([#730](https://github.com/bdlukaa/fluent_ui/pull/730))
 - Add myanmar localization ([#682](https://github.com/bdlukaa/fluent_ui/pull/682))
+- Fix `ContentDialog` copy code ([#735](https://github.com/bdlukaa/fluent_ui/pull/735))
 
 ## 4.3.0
 

--- a/example/lib/screens/popups/content_dialog.dart
+++ b/example/lib/screens/popups/content_dialog.dart
@@ -45,7 +45,7 @@ void showContentDialog(BuildContext context) async {
     builder: (context) => ContentDialog(
       title: const Text('Delete file permanently?'),
       content: const Text(
-        'If you delete this file, you won't be able to recover it. Do you want to delete it?',
+        'If you delete this file, you won\\'t be able to recover it. Do you want to delete it?',
       ),
       actions: [
         Button(


### PR DESCRIPTION
This fixes an issue that prevents the content dialog copied code from running. 

## Pre-launch Checklist

<!-- Mark all that applies -->

- [x] I have updated `CHANGELOG.md` with my changes <!-- REQUIRED --> 
- [ ] I have run "dart format ." on the project <!-- REQUIRED --> 
- [x] I have added/updated relevant documentation