### PR TITLE
fixes issue #744, and example application WindowsIcons bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 ## [next]
-
+- Dynamically adding/removing items in NavigationPane ([#744](https://github.com/bdlukaa/fluent_ui/issues/744))
+  ```dart
+  if (_itemKeys.length != widget.pane?.effectiveItems.length) {
+    if (widget.pane?.effectiveItems.length != null) {
+      _generateKeys();
+    }
+  }
+  ```
+- Fix example application was showing 2 WindowsIcons on changing transparency and maximizing
 - Add `TextFormBox.initialValue` ([#749](https://github.com/bdlukaa/fluent_ui/issues/749))
 - Add `PaneItem.enabled` ([#748](https://github.com/bdlukaa/fluent_ui/discussions/748))
 - Add Thai localization ([#750](https://github.com/bdlukaa/fluent_ui/pull/750))

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -47,6 +47,7 @@ void main() async {
 
   if (isDesktop) {
     await flutter_acrylic.Window.initialize();
+    await flutter_acrylic.Window.hideWindowControls();
     await WindowManager.instance.ensureInitialized();
     windowManager.waitUntilReadyToShow().then((_) async {
       await windowManager.setTitleBarStyle(

--- a/lib/src/controls/navigation/navigation_view/view.dart
+++ b/lib/src/controls/navigation/navigation_view/view.dart
@@ -244,6 +244,12 @@ class NavigationViewState extends State<NavigationView> {
         _generateKeys();
       }
     }
+
+    if (_itemKeys.length != widget.pane?.effectiveItems.length) {
+      if (widget.pane?.effectiveItems.length != null) {
+        _generateKeys();
+      }
+    }
   }
 
   void _generateKeys() {


### PR DESCRIPTION
<!-- Add a description of what this PR is changing or adding, and why. Consider mentioning issues -->
The following changes have been made.
- fix: example application was showing 2 WindowsIcons on changing transparency and maximizing. See image below
![bug_fluent_ui](https://user-images.githubusercontent.com/70003855/222903417-178ecd12-1d2f-4106-9e90-f7a1b2ba9dec.png)

- Fixes issue #744, One could not add and remove items dynamically from NavigationPane due to the PaneItemKeys issue, which has been fixed and tested. Special thanks to [@ACking-you](https://github.com/ACking-you) for the amazing suggestion. 

## Pre-launch Checklist

<!-- Mark all that applies -->

- [x] I have updated `CHANGELOG.md` with my changes <!-- REQUIRED --> 
- [x] I have run "dart format ." on the project <!-- REQUIRED --> 
- [x] I have added/updated relevant documentation