### PR TITLE
update intl & fix textSelection breaking change

### DIFF
--- a/lib/src/controls/form/text_box.dart
+++ b/lib/src/controls/form/text_box.dart
@@ -42,14 +42,14 @@ class _TextBoxSelectionGestureDetectorBuilder
   final _TextBoxState _state;
 
   @override
-  void onSingleTapUp(TapUpDetails details) {
+  void onSingleTapUp(TapDragUpDetails details) {
     super.onSingleTapUp(details);
     _state._requestKeyboard();
     _state.widget.onTap?.call();
   }
 
   @override
-  void onDragSelectionEnd(DragEndDetails details) {
+  void onDragSelectionEnd(TapDragEndDetails details) {
     _state._requestKeyboard();
   }
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -14,7 +14,7 @@ dependencies:
     sdk: flutter
 
   # Used on date and time pickers
-  intl: ^0.17.0
+  intl: ^0.18.0
 
   # Used on TabView
   scroll_pos: ^0.3.0


### PR DESCRIPTION
Update `Intl` package to `0.18.0` & fix `TextSelectionGestureDetectorBuilder` breaking change introduced in https://github.com/flutter/flutter/pull/109573

## Pre-launch Checklist

<!-- Mark all that applies -->

- [ ] I have updated `CHANGELOG.md` with my changes <!-- REQUIRED --> 
- [ ] I have run "dart format ." on the project <!-- REQUIRED --> 
- [ ] I have added/updated relevant documentation