### PR TITLE
Add source code for Surfaces/CommandBar in example application.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## [next]
 
+- Add source code for Surfaces/CommandBar in example application
 - Add Greek localization ([#761](https://github.com/bdlukaa/fluent_ui/pull/761))
 
 ## 4.4.1

--- a/example/lib/screens/surface/commandbars.dart
+++ b/example/lib/screens/surface/commandbars.dart
@@ -1,3 +1,4 @@
+import 'package:example/widgets/card_highlight.dart';
 import 'package:fluent_ui/fluent_ui.dart';
 
 import '../../widgets/page.dart';
@@ -135,53 +136,180 @@ class _CommandBarsPageState extends State<CommandBarsPage> with PageMixin {
           'page-specific commands and can be used with any navigation pattern.',
         ),
         subtitle(content: const Text('Simple command bar (no wrapping)')),
-        CommandBar(
-          overflowBehavior: CommandBarOverflowBehavior.noWrap,
-          primaryItems: [
-            ...simpleCommandBarItems,
-          ],
+        CardHighlight(
+          child: CommandBar(
+            overflowBehavior: CommandBarOverflowBehavior.noWrap,
+            primaryItems: [
+              ...simpleCommandBarItems,
+            ],
+          ),
+          codeSnippet: '''
+/// Define list of CommandBarItem
+final simpleCommandBarItems = <CommandBarItem>[
+  CommandBarBuilderItem(
+    builder: (context, mode, w) => Tooltip(
+      message: "Create something new!",
+      child: w,
+    ),
+    wrappedItem: CommandBarButton(
+      icon: const Icon(FluentIcons.add),
+      label: const Text('New'),
+      onPressed: () {},
+    ),
+  ),
+  CommandBarBuilderItem(
+    builder: (context, mode, w) => Tooltip(
+      message: "Delete what is currently selected!",
+      child: w,
+    ),
+    wrappedItem: CommandBarButton(
+      icon: const Icon(FluentIcons.delete),
+      label: const Text('Delete'),
+      onPressed: () {},
+    ),
+  ),
+  CommandBarButton(
+    icon: const Icon(FluentIcons.archive),
+    label: const Text('Archive'),
+    onPressed: () {},
+  ),
+  CommandBarButton(
+    icon: const Icon(FluentIcons.move),
+    label: const Text('Move'),
+    onPressed: () {},
+  ),
+  const CommandBarButton(
+    icon: Icon(FluentIcons.cancel),
+    label: Text('Disabled'),
+    onPressed: null,
+  ),
+];
+
+/// Generate CommandBar with different properties like overflowBehavior
+CommandBar(
+  overflowBehavior: CommandBarOverflowBehavior.noWrap,
+  primaryItems: [
+    ...simpleCommandBarItems,
+  ],
+);
+''',
         ),
         subtitle(
           content: const Text(
             'Command bar with many items (wrapping, auto-compact < 600px)',
           ),
         ),
-        CommandBar(
-          overflowBehavior: CommandBarOverflowBehavior.wrap,
-          compactBreakpointWidth: 600,
-          primaryItems: [
-            ...simpleCommandBarItems,
-            const CommandBarSeparator(),
-            ...moreCommandBarItems,
-          ],
+        CardHighlight(
+          child: CommandBar(
+            overflowBehavior: CommandBarOverflowBehavior.wrap,
+            compactBreakpointWidth: 600,
+            primaryItems: [
+              ...simpleCommandBarItems,
+              const CommandBarSeparator(),
+              ...moreCommandBarItems,
+            ],
+          ),
+          codeSnippet: '''
+/// Lists of CommandBarItem named as simpleCommandBarItems and moreCommandBarItems
+/// Used as following
+
+CommandBar(
+  overflowBehavior: CommandBarOverflowBehavior.wrap,
+  compactBreakpointWidth: 600,
+  primaryItems: [
+    ...simpleCommandBarItems,
+    const CommandBarSeparator(),
+    ...moreCommandBarItems,
+  ],
+);
+''',
         ),
         subtitle(
           content: const Text(
             'Carded compact command bar with many items (clipped)',
           ),
         ),
-        ConstrainedBox(
-          constraints: const BoxConstraints(maxWidth: 230),
-          child: CommandBarCard(
-            child: CommandBar(
-              overflowBehavior: CommandBarOverflowBehavior.clip,
-              isCompact: true,
-              primaryItems: [
-                ...simpleCommandBarItems,
-                const CommandBarSeparator(),
-                ...moreCommandBarItems,
-              ],
+        CardHighlight(
+          child: ConstrainedBox(
+            constraints: const BoxConstraints(maxWidth: 230),
+            child: CommandBarCard(
+              child: CommandBar(
+                overflowBehavior: CommandBarOverflowBehavior.clip,
+                isCompact: true,
+                primaryItems: [
+                  ...simpleCommandBarItems,
+                  const CommandBarSeparator(),
+                  ...moreCommandBarItems,
+                ],
+              ),
             ),
           ),
+          codeSnippet: '''
+/// Lists of CommandBarItem named as simpleCommandBarItems and moreCommandBarItems
+/// Used as following
+
+ConstrainedBox(
+  constraints: const BoxConstraints(maxWidth: 230),
+  child: CommandBarCard(
+    child: CommandBar(
+      overflowBehavior: CommandBarOverflowBehavior.clip,
+      isCompact: true,
+      primaryItems: [
+        ...simpleCommandBarItems,
+        const CommandBarSeparator(),
+        ...moreCommandBarItems,
+      ],
+    ),
+  ),
+);
+''',
         ),
         subtitle(
           content: const Text(
             'Carded compact command bar with many items (dynamic overflow)',
           ),
         ),
-        CommandBarCard(
+        CardHighlight(
+          child: CommandBarCard(
+            child: CommandBar(
+              overflowBehavior: CommandBarOverflowBehavior.dynamicOverflow,
+              primaryItems: [
+                ...simpleCommandBarItems,
+                const CommandBarSeparator(),
+                ...moreCommandBarItems,
+                const CommandBarSeparator(),
+                ...evenMoreCommandBarItems,
+              ],
+            ),
+          ),
+          codeSnippet: '''
+/// Create different lists of CommandBarItem
+/// named simpleCommandBarItems, moreCommandBarItems, evenMoreCommandBarItems
+/// These lists can be used as primaryItems as shown
+CommandBarCard(
+  child: CommandBar(
+    overflowBehavior: CommandBarOverflowBehavior.dynamicOverflow,
+    primaryItems: [
+      ...simpleCommandBarItems,
+      const CommandBarSeparator(),
+      ...moreCommandBarItems,
+      const CommandBarSeparator(),
+      ...evenMoreCommandBarItems,
+    ],
+  ),
+);
+''',
+        ),
+        subtitle(
+          content: const Text(
+            'End-aligned command bar with many items (dynamic overflow, auto-compact < 900px)',
+          ),
+        ),
+        CardHighlight(
           child: CommandBar(
+            mainAxisAlignment: MainAxisAlignment.end,
             overflowBehavior: CommandBarOverflowBehavior.dynamicOverflow,
+            compactBreakpointWidth: 900,
             primaryItems: [
               ...simpleCommandBarItems,
               const CommandBarSeparator(),
@@ -190,32 +318,182 @@ class _CommandBarsPageState extends State<CommandBarsPage> with PageMixin {
               ...evenMoreCommandBarItems,
             ],
           ),
-        ),
-        subtitle(
-          content: const Text(
-            'End-aligned command bar with many items (dynamic overflow, auto-compact < 900px)',
-          ),
-        ),
-        CommandBar(
-          mainAxisAlignment: MainAxisAlignment.end,
-          overflowBehavior: CommandBarOverflowBehavior.dynamicOverflow,
-          compactBreakpointWidth: 900,
-          primaryItems: [
-            ...simpleCommandBarItems,
-            const CommandBarSeparator(),
-            ...moreCommandBarItems,
-            const CommandBarSeparator(),
-            ...evenMoreCommandBarItems,
-          ],
+          codeSnippet: '''
+/// Create different lists of CommandBarItem
+/// named simpleCommandBarItems, moreCommandBarItems, evenMoreCommandBarItems
+/// These lists can be used as primaryItems as shown
+
+CommandBar(
+  mainAxisAlignment: MainAxisAlignment.end,
+  overflowBehavior: CommandBarOverflowBehavior.dynamicOverflow,
+  compactBreakpointWidth: 900,
+  primaryItems: [
+    ...simpleCommandBarItems,
+    const CommandBarSeparator(),
+    ...moreCommandBarItems,
+    const CommandBarSeparator(),
+    ...evenMoreCommandBarItems,
+  ],
+);
+''',
         ),
         subtitle(
           content: const Text(
             'End-aligned command bar with permanent secondary items (dynamic overflow)',
           ),
         ),
-        CommandBar(
-          mainAxisAlignment: MainAxisAlignment.end,
+        CardHighlight(
+          child: CommandBar(
+            mainAxisAlignment: MainAxisAlignment.end,
+            overflowBehavior: CommandBarOverflowBehavior.dynamicOverflow,
+            primaryItems: [
+              ...simpleCommandBarItems,
+              const CommandBarSeparator(),
+              ...moreCommandBarItems,
+            ],
+            secondaryItems: evenMoreCommandBarItems,
+          ),
+          codeSnippet: '''
+/// Lists of CommandBarItem named as simpleCommandBarItems and moreCommandBarItems
+/// Used as following
+
+CommandBar(
+  mainAxisAlignment: MainAxisAlignment.end,
+  overflowBehavior: CommandBarOverflowBehavior.dynamicOverflow,
+  primaryItems: [
+    ...simpleCommandBarItems,
+    const CommandBarSeparator(),
+    ...moreCommandBarItems,
+  ],
+  secondaryItems: evenMoreCommandBarItems,
+);
+''',
+        ),
+        subtitle(
+          content: const Text(
+            'Command bar with secondary items (wrapping)',
+          ),
+        ),
+        CardHighlight(
+          child: CommandBar(
+            overflowBehavior: CommandBarOverflowBehavior.wrap,
+            primaryItems: simpleCommandBarItems,
+            secondaryItems: moreCommandBarItems,
+          ),
+          codeSnippet: '''
+/// Lists of CommandBarItem named as simpleCommandBarItems and moreCommandBarItems
+/// Used as following
+
+CommandBar(
+  overflowBehavior: CommandBarOverflowBehavior.wrap,
+  primaryItems: simpleCommandBarItems,
+  secondaryItems: moreCommandBarItems,
+);
+''',
+        ),
+        subtitle(
+          content: const Text(
+            'Carded complex command bar with many items (horizontal scrolling)',
+          ),
+        ),
+        CardHighlight(
+          child: CommandBarCard(
+            child: Row(
+              children: [
+                Expanded(
+                  child: CommandBar(
+                    overflowBehavior: CommandBarOverflowBehavior.scrolling,
+                    primaryItems: [
+                      ...simpleCommandBarItems,
+                      const CommandBarSeparator(),
+                      ...moreCommandBarItems,
+                    ],
+                  ),
+                ),
+                // End-aligned button(s)
+                CommandBar(
+                  overflowBehavior: CommandBarOverflowBehavior.noWrap,
+                  primaryItems: [
+                    CommandBarButton(
+                      icon: const Icon(FluentIcons.refresh),
+                      onPressed: () {},
+                    ),
+                  ],
+                ),
+              ],
+            ),
+          ),
+          codeSnippet: '''
+CommandBarCard(
+    child: Row(children: [
+      Expanded(
+        child: CommandBar(
+          overflowBehavior: CommandBarOverflowBehavior.scrolling,
+          primaryItems: [
+            ...simpleCommandBarItems,
+            const CommandBarSeparator(),
+            ...moreCommandBarItems,
+          ],
+        ),
+      ),
+      // End-aligned button(s)
+      CommandBar(
+        overflowBehavior: CommandBarOverflowBehavior.noWrap,
+        primaryItems: [
+          CommandBarButton(
+            icon: const Icon(FluentIcons.refresh),
+            onPressed: () {},
+          ),
+        ],
+      ),
+    ],
+  ),
+);
+''',
+        ),
+        subtitle(
+          content: const Text(
+            'Carded complex command bar with many items (dynamic overflow)',
+          ),
+        ),
+        CardHighlight(
+          child: CommandBarCard(
+            child: Row(
+              children: [
+                Expanded(
+                  child: CommandBar(
+                    overflowBehavior:
+                        CommandBarOverflowBehavior.dynamicOverflow,
+                    overflowItemAlignment: MainAxisAlignment.end,
+                    primaryItems: [
+                      ...simpleCommandBarItems,
+                      const CommandBarSeparator(),
+                      ...moreCommandBarItems,
+                    ],
+                    secondaryItems: evenMoreCommandBarItems,
+                  ),
+                ),
+                // End-aligned button(s)
+                CommandBar(
+                  overflowBehavior: CommandBarOverflowBehavior.noWrap,
+                  primaryItems: [
+                    CommandBarButton(
+                      icon: const Icon(FluentIcons.refresh),
+                      onPressed: () {},
+                    ),
+                  ],
+                ),
+              ],
+            ),
+          ),
+          codeSnippet: '''
+CommandBarCard(
+  child: Row(
+    children: [
+      Expanded(
+        child: CommandBar(
           overflowBehavior: CommandBarOverflowBehavior.dynamicOverflow,
+          overflowItemAlignment: MainAxisAlignment.end,
           primaryItems: [
             ...simpleCommandBarItems,
             const CommandBarSeparator(),
@@ -223,75 +501,21 @@ class _CommandBarsPageState extends State<CommandBarsPage> with PageMixin {
           ],
           secondaryItems: evenMoreCommandBarItems,
         ),
-        subtitle(
-          content: const Text(
-            'Command bar with secondary items (wrapping)',
+      ),
+      // End-aligned button(s)
+      CommandBar(
+        overflowBehavior: CommandBarOverflowBehavior.noWrap,
+        primaryItems: [
+          CommandBarButton(
+            icon: const Icon(FluentIcons.refresh),
+            onPressed: () {},
           ),
-        ),
-        CommandBar(
-          overflowBehavior: CommandBarOverflowBehavior.wrap,
-          primaryItems: simpleCommandBarItems,
-          secondaryItems: moreCommandBarItems,
-        ),
-        subtitle(
-          content: const Text(
-            'Carded complex command bar with many items (horizontal scrolling)',
-          ),
-        ),
-        CommandBarCard(
-          child: Row(children: [
-            Expanded(
-              child: CommandBar(
-                overflowBehavior: CommandBarOverflowBehavior.scrolling,
-                primaryItems: [
-                  ...simpleCommandBarItems,
-                  const CommandBarSeparator(),
-                  ...moreCommandBarItems,
-                ],
-              ),
-            ),
-            // End-aligned button(s)
-            CommandBar(
-              overflowBehavior: CommandBarOverflowBehavior.noWrap,
-              primaryItems: [
-                CommandBarButton(
-                  icon: const Icon(FluentIcons.refresh),
-                  onPressed: () {},
-                ),
-              ],
-            ),
-          ]),
-        ),
-        subtitle(
-          content: const Text(
-            'Carded complex command bar with many items (dynamic overflow)',
-          ),
-        ),
-        CommandBarCard(
-          child: Row(children: [
-            Expanded(
-              child: CommandBar(
-                overflowBehavior: CommandBarOverflowBehavior.dynamicOverflow,
-                overflowItemAlignment: MainAxisAlignment.end,
-                primaryItems: [
-                  ...simpleCommandBarItems,
-                  const CommandBarSeparator(),
-                  ...moreCommandBarItems,
-                ],
-                secondaryItems: evenMoreCommandBarItems,
-              ),
-            ),
-            // End-aligned button(s)
-            CommandBar(
-              overflowBehavior: CommandBarOverflowBehavior.noWrap,
-              primaryItems: [
-                CommandBarButton(
-                  icon: const Icon(FluentIcons.refresh),
-                  onPressed: () {},
-                ),
-              ],
-            ),
-          ]),
+        ],
+      ),
+    ],
+  ),
+);
+''',
         ),
       ],
     );


### PR DESCRIPTION
When I was working on my personal application using `fluent_ui`, I found it strange that there is no source code (or example code) available for Surfaces/CommandBar and I had to look into the example application's source code itself.

So, I have added important source code in Surfaces/CommandBar so that one can use it right away.

## Pre-launch Checklist

- [x] I have updated `CHANGELOG.md` with my changes <!-- REQUIRED --> 
- [x] I have run "dart format ." on the project <!-- REQUIRED --> 
- [x] I have added/updated relevant documentation