### PR TITLE
Do not calculate the position of the flyout if this one is provided as a parameter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## [next]
 
-- Do not calculate the position of the flyout if this one is provided as a parameter. ([#764](https://github.com/bdlukaa/fluent_ui/issues/764))
+- Do not calculate the position of the flyout if the `position` parameter is provided. ([#764](https://github.com/bdlukaa/fluent_ui/issues/764))
 - Add source code for Surfaces/CommandBar in example application ([#766](https://github.com/bdlukaa/fluent_ui/pull/766))
 - Do not enforce a max height on `PaneItem` ([#762](https://github.com/bdlukaa/fluent_ui/issues/762))
 - Add Greek localization ([#761](https://github.com/bdlukaa/fluent_ui/pull/761))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## [next]
 
 - Add Greek localization ([#761](https://github.com/bdlukaa/fluent_ui/pull/761))
+- Do not calculate the position of the flyout if this one is provided as a parameter. ([#764](https://github.com/bdlukaa/fluent_ui/issues/764))
 
 ## 4.4.1
 

--- a/lib/src/controls/flyouts/flyout.dart
+++ b/lib/src/controls/flyouts/flyout.dart
@@ -561,16 +561,25 @@ class FlyoutController with ChangeNotifier {
     transitionDuration ??= theme.fastAnimationDuration;
 
     final navigator = navigatorKey ?? Navigator.of(context);
-    final navigatorBox = navigator.context.findRenderObject() as RenderBox;
 
-    final targetBox = context.findRenderObject() as RenderBox;
-    final targetSize = targetBox.size;
-    final targetOffset =
-        targetBox.localToGlobal(Offset.zero, ancestor: navigatorBox) +
-            Offset(0, targetSize.height);
-    final targetRect =
-        targetBox.localToGlobal(Offset.zero, ancestor: navigatorBox) &
-            targetSize;
+    final Offset targetOffset;
+    final Size targetSize;
+    final Rect targetRect;
+
+    if (position != null) {
+      targetOffset = position;
+      targetSize = Size.zero;
+      targetRect = Rect.zero;
+    } else {
+      final navigatorBox = navigator.context.findRenderObject() as RenderBox;
+
+      final targetBox = context.findRenderObject() as RenderBox;
+      targetSize = targetBox.size;
+      targetOffset = targetBox.localToGlobal(Offset.zero, ancestor: navigatorBox) +
+              Offset(0, targetSize.height);
+      targetRect = targetBox.localToGlobal(Offset.zero, ancestor: navigatorBox) &
+              targetSize;
+    }
 
     _open = true;
     notifyListeners();
@@ -627,7 +636,7 @@ class FlyoutController with ChangeNotifier {
                 child: SafeArea(
                   child: CustomSingleChildLayout(
                     delegate: _FlyoutPositionDelegate(
-                      targetOffset: position ?? targetOffset,
+                      targetOffset: targetOffset,
                       targetSize: position == null ? targetSize : Size.zero,
                       autoModeConfiguration: autoModeConfiguration,
                       placementMode: placementMode,

--- a/lib/src/controls/flyouts/flyout.dart
+++ b/lib/src/controls/flyouts/flyout.dart
@@ -575,9 +575,11 @@ class FlyoutController with ChangeNotifier {
 
       final targetBox = context.findRenderObject() as RenderBox;
       targetSize = targetBox.size;
-      targetOffset = targetBox.localToGlobal(Offset.zero, ancestor: navigatorBox) +
+      targetOffset =
+          targetBox.localToGlobal(Offset.zero, ancestor: navigatorBox) +
               Offset(0, targetSize.height);
-      targetRect = targetBox.localToGlobal(Offset.zero, ancestor: navigatorBox) &
+      targetRect =
+          targetBox.localToGlobal(Offset.zero, ancestor: navigatorBox) &
               targetSize;
     }
 


### PR DESCRIPTION
<!-- Add a description of what this PR is changing or adding, and why. Consider mentioning issues -->

## Pre-launch Checklist

<!-- Mark all that applies -->

- [x] I have updated `CHANGELOG.md` with my changes <!-- REQUIRED --> 
- [x] I have run "dart format ." on the project <!-- REQUIRED --> 
- [x] I have added/updated relevant documentation

This allow to open a flyout from an Widget that is outside the Navigator, by providing manually its position, like that:

![image](https://user-images.githubusercontent.com/8223773/224969245-2f52a88c-c9cf-4f0e-8719-e6924a162ad4.png)

And this continue to work normally in example app: 

![image](https://user-images.githubusercontent.com/8223773/224970037-542da9fa-f329-4779-b275-213aa795d500.png)
