### PR TITLE
Add source code snippet for Show InfoBar Button.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## [next]
 
+- Add source code for `Show InfoBar` in example application.
 - Do not calculate the position of the flyout if the `position` parameter is provided. ([#764](https://github.com/bdlukaa/fluent_ui/issues/764))
 - Add source code for Surfaces/CommandBar in example application ([#766](https://github.com/bdlukaa/fluent_ui/pull/766))
 - Do not enforce a max height on `PaneItem` ([#762](https://github.com/bdlukaa/fluent_ui/issues/762))

--- a/example/lib/screens/surface/info_bars.dart
+++ b/example/lib/screens/surface/info_bars.dart
@@ -59,7 +59,18 @@ class _InfoBarsPageState extends State<InfoBarsPage> with PageMixin {
               child: const Text('Show InfoBar'),
             ),
           ),
-          codeSnippet: '''''',
+          codeSnippet: '''displayInfoBar(context, builder: (context, close) {
+  return InfoBar(
+    title: const Text('You can not do that :/'),
+    content: const Text(
+        'A proper warning message of why the user can not do that :/'),
+    action: IconButton(
+      icon: const Icon(FluentIcons.clear),
+      onPressed: close,
+    ),
+    severity: InfoBarSeverity.warning,
+  );
+}''',
         ),
         subtitle(
           content: const Text(


### PR DESCRIPTION
There is no corresponding source code under the Show InfoBar button on the InfoBar page, so I added it myself.

## Pre-launch Checklist

<!-- Mark all that applies -->

- [x] I have updated `CHANGELOG.md` with my changes <!-- REQUIRED --> 
- [x] I have run "dart format ." on the project <!-- REQUIRED --> 
- [x] I have added/updated relevant documentation