### PR TITLE
Fix NumberBox value update with double and check if the result of the math expression is valid

### DIFF
--- a/lib/src/controls/form/number_box.dart
+++ b/lib/src/controls/form/number_box.dart
@@ -466,6 +466,12 @@ class NumberBoxState<T extends num> extends State<NumberBox<T>> {
           value = Parser()
               .parse(controller.text)
               .evaluate(EvaluationType.REAL, ContextModel());
+          // If the value is infinite or not a number, we reset the value with
+          // the previous valid value. For example, if the user tap 1024^200
+          // (the result is too big), the condition value.isInfinite is true.
+          if (value!.isInfinite || value.isNaN) {
+            value = previousValidValue;
+          }
         } catch (_) {
           value = previousValidValue;
         }
@@ -500,8 +506,7 @@ class NumberBoxState<T extends num> extends State<NumberBox<T>> {
       return value.toString();
     }
     final mul = pow(10, widget.precision);
-    return NumberFormat()
-        .format(((value * mul).roundToDouble() / mul).toString());
+    return NumberFormat().format((value * mul).roundToDouble() / mul);
   }
 }
 


### PR DESCRIPTION
- The scroll threw an error on the number box with a double value
- If we entered an expression (like `1024^200`), the value was not updated and threw an exception.