### PR TITLE
Load the example app with a bigger size for have a open navigation pane and do not center the window

### DIFF
--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -51,9 +51,8 @@ void main() async {
         TitleBarStyle.hidden,
         windowButtonVisibility: false,
       );
-      await windowManager.setSize(const Size(755, 545));
+      await windowManager.setSize(const Size(1050, 545));
       await windowManager.setMinimumSize(const Size(350, 600));
-      await windowManager.center();
       await windowManager.show();
       await windowManager.setPreventClose(true);
       await windowManager.setSkipTaskbar(false);

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -51,7 +51,7 @@ void main() async {
         TitleBarStyle.hidden,
         windowButtonVisibility: false,
       );
-      await windowManager.setMinimumSize(const Size(350, 600));
+      await windowManager.setMinimumSize(const Size(500, 600));
       await windowManager.show();
       await windowManager.setPreventClose(true);
       await windowManager.setSkipTaskbar(false);

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -51,7 +51,6 @@ void main() async {
         TitleBarStyle.hidden,
         windowButtonVisibility: false,
       );
-      await windowManager.setSize(const Size(1050, 545));
       await windowManager.setMinimumSize(const Size(350, 600));
       await windowManager.show();
       await windowManager.setPreventClose(true);


### PR DESCRIPTION
I find it really annoying that the default Window size as a navigation pane is compact mode.

And each time a do a hot restart, I must change window size.

And at each hot restart, the window is replaced on the center. If we do not enable the center, with an hot restart, the window keep it's position.

---------------

@bdlukaa I know that you work on a laptop. Do you think these settings are good for you ? (For my part, I work on a 39" curved screen, so...)

--------------

Before:
![image](https://user-images.githubusercontent.com/8223773/228346426-3c798a91-6132-4375-a806-c6dcdf122769.png)

After:
![image](https://user-images.githubusercontent.com/8223773/228346469-574c73f0-52b2-4543-82bc-72dbd88fff80.png)


<!-- Add a description of what this PR is changing or adding, and why. Consider mentioning issues -->

## Pre-launch Checklist

<!-- Mark all that applies -->

- [x] I have run "dart format ." on the project <!-- REQUIRED --> 