### PR TITLE
Add PasswordBox widget

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 - Add `NumberBox` widget. ([#560](https://github.com/bdlukaa/fluent_ui/issues/560) [#771](https://github.com/bdlukaa/fluent_ui/pull/771) [#789](https://github.com/bdlukaa/fluent_ui/pull/789))
 - Add support for `routerConfig` to `FluentApp.router` ([#781](https://github.com/bdlukaa/fluent_ui/issues/781))
 - Add source code for `Show InfoBar` in example application. ([#785](https://github.com/bdlukaa/fluent_ui/pull/785))
+- Add parameters `onTapDown` and `onTapUp` on all buttons. ([#TODO](https://github.com/bdlukaa/fluent_ui/pull/TODO))
+   - **Breaking: if you use the abstract class `BaseButton`, these two parameters are now required** 
 - Make `color` optional in `FluentApp.router`. ([#782](https://github.com/bdlukaa/fluent_ui/issues/782))
 - Fix `TabView` scroll (the item count was not correctly set) and now the scroll event is not propagated to the parent. ([#772](https://github.com/bdlukaa/fluent_ui/pull/772))
 - Do not calculate the position of the flyout if the `position` parameter is provided. ([#764](https://github.com/bdlukaa/fluent_ui/issues/764))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,8 +3,9 @@
 - Add `NumberBox` widget. ([#560](https://github.com/bdlukaa/fluent_ui/issues/560) [#771](https://github.com/bdlukaa/fluent_ui/pull/771) [#789](https://github.com/bdlukaa/fluent_ui/pull/789))
 - Add support for `routerConfig` to `FluentApp.router` ([#781](https://github.com/bdlukaa/fluent_ui/issues/781))
 - Add source code for `Show InfoBar` in example application. ([#785](https://github.com/bdlukaa/fluent_ui/pull/785))
-- Add parameters `onTapDown` and `onTapUp` on all buttons. ([#TODO](https://github.com/bdlukaa/fluent_ui/pull/TODO))
+- Add parameters `onTapDown` and `onTapUp` on all buttons. ([#795](https://github.com/bdlukaa/fluent_ui/pull/795))
    - **Breaking: if you use the abstract class `BaseButton`, these two parameters are now required** 
+- Add `PasswordBox` widget. ([#795](https://github.com/bdlukaa/fluent_ui/pull/795))
 - Make `color` optional in `FluentApp.router`. ([#782](https://github.com/bdlukaa/fluent_ui/issues/782))
 - Fix `TabView` scroll (the item count was not correctly set) and now the scroll event is not propagated to the parent. ([#772](https://github.com/bdlukaa/fluent_ui/pull/772))
 - Do not calculate the position of the flyout if the `position` parameter is provided. ([#764](https://github.com/bdlukaa/fluent_ui/issues/764))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,14 @@
+## [next]
+
+- Add parameters `onTapDown` and `onTapUp` on all buttons. ([#795](https://github.com/bdlukaa/fluent_ui/pull/795))
+   - **Breaking: if you use the abstract class `BaseButton`, these two parameters are now required** 
+- Add `PasswordBox` widget. ([#795](https://github.com/bdlukaa/fluent_ui/pull/795))
+
 ## 4.4.2
 
 - Add `NumberBox` widget. ([#560](https://github.com/bdlukaa/fluent_ui/issues/560) [#771](https://github.com/bdlukaa/fluent_ui/pull/771) [#789](https://github.com/bdlukaa/fluent_ui/pull/789))
 - Add support for `routerConfig` to `FluentApp.router` ([#781](https://github.com/bdlukaa/fluent_ui/issues/781))
 - Add source code for `Show InfoBar` in example application. ([#785](https://github.com/bdlukaa/fluent_ui/pull/785))
-- Add parameters `onTapDown` and `onTapUp` on all buttons. ([#795](https://github.com/bdlukaa/fluent_ui/pull/795))
-   - **Breaking: if you use the abstract class `BaseButton`, these two parameters are now required** 
-- Add `PasswordBox` widget. ([#795](https://github.com/bdlukaa/fluent_ui/pull/795))
 - Make `color` optional in `FluentApp.router`. ([#782](https://github.com/bdlukaa/fluent_ui/issues/782))
 - Fix `TabView` scroll (the item count was not correctly set) and now the scroll event is not propagated to the parent. ([#772](https://github.com/bdlukaa/fluent_ui/pull/772))
 - Do not calculate the position of the flyout if the `position` parameter is provided. ([#764](https://github.com/bdlukaa/fluent_ui/issues/764))

--- a/example/lib/generated_plugin_registrant.dart
+++ b/example/lib/generated_plugin_registrant.dart
@@ -1,0 +1,21 @@
+//
+// Generated file. Do not edit.
+//
+
+// ignore_for_file: directives_ordering
+// ignore_for_file: lines_longer_than_80_chars
+// ignore_for_file: depend_on_referenced_packages
+
+import 'package:flutter_native_splash/flutter_native_splash_web.dart';
+import 'package:system_theme_web/system_theme_web.dart';
+import 'package:url_launcher_web/url_launcher_web.dart';
+
+import 'package:flutter_web_plugins/flutter_web_plugins.dart';
+
+// ignore: public_member_api_docs
+void registerPlugins(Registrar registrar) {
+  FlutterNativeSplashWeb.registerWith(registrar);
+  SystemThemeWeb.registerWith(registrar);
+  UrlLauncherPlugin.registerWith(registrar);
+  registrar.registerMessageHandler();
+}

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -74,6 +74,7 @@ void main() async {
 
 class MyApp extends StatelessWidget {
   const MyApp({Key? key}) : super(key: key);
+
   // private navigators
 
   @override
@@ -249,6 +250,17 @@ class _MyHomePageState extends State<MyHomePage> with WindowListener {
       onTap: () {
         if (router.location != '/forms/numberbox') {
           router.pushNamed('forms_numberbox');
+        }
+      },
+    ),
+    PaneItem(
+      key: const Key('/forms/passwordbox'),
+      icon: const Icon(FluentIcons.password_field),
+      title: const Text('PasswordBox'),
+      body: const SizedBox.shrink(),
+      onTap: () {
+        if (router.location != '/forms/passwordbox') {
+          router.pushNamed('forms_passwordbox');
         }
       },
     ),
@@ -871,6 +883,15 @@ final router = GoRouter(
           builder: (context, state) => DeferredWidget(
             forms.loadLibrary,
             () => forms.NumberBoxPage(),
+          ),
+        ),
+
+        GoRoute(
+          path: '/forms/passwordbox',
+          name: 'forms_passwordbox',
+          builder: (context, state) => DeferredWidget(
+            forms.loadLibrary,
+            () => forms.PasswordBoxPage(),
           ),
         ),
 

--- a/example/lib/routes/forms.dart
+++ b/example/lib/routes/forms.dart
@@ -1,6 +1,7 @@
 export '../screens/forms/auto_suggest_box.dart';
 export '../screens/forms/combobox.dart';
 export '../screens/forms/number_box.dart';
+export '../screens/forms/password_box.dart';
 export '../screens/forms/date_picker.dart';
 export '../screens/forms/text_box.dart';
 export '../screens/forms/time_picker.dart';

--- a/example/lib/screens/forms/password_box.dart
+++ b/example/lib/screens/forms/password_box.dart
@@ -2,75 +2,119 @@ import 'package:example/widgets/card_highlight.dart';
 import 'package:example/widgets/page.dart';
 import 'package:fluent_ui/fluent_ui.dart';
 
-class PasswordBoxPage extends ScrollablePage {
-  PasswordBoxPage({super.key});
+class PasswordBoxPage extends StatefulWidget {
+  const PasswordBoxPage({super.key});
 
   @override
-  Widget buildHeader(BuildContext context) {
-    return const PageHeader(title: Text('PasswordBox'));
-  }
+  State<PasswordBoxPage> createState() => _PasswordBoxPageState();
+}
+
+class _PasswordBoxPageState extends State<PasswordBoxPage> with PageMixin {
+  bool disabled = false;
+  PasswordRevealMode revealMode = PasswordRevealMode.peek;
 
   @override
-  List<Widget> buildScrollable(BuildContext context) {
-    return [
-      const Text(
-        'The PasswordBox is almost identical to the TextBox. But the character'
-        ' is obfuscated by default and a button in the suffix allow the user to '
-        'show briefly the password in plain text.',
+  Widget build(BuildContext context) {
+    return ScaffoldPage.scrollable(
+      header: PageHeader(
+        title: const Text('NumberBox'),
+        commandBar: ToggleSwitch(
+          checked: disabled,
+          onChanged: (v) {
+            setState(() => disabled = v);
+          },
+          content: const Text('Disabled'),
+        ),
       ),
-      subtitle(
-          content: const Text('A simple PasswordBox in peek mode (default)')),
-      CardHighlight(
-        child: Row(children: const [
-          Expanded(child: PasswordBox()),
-          SizedBox(width: 10.0),
-          Expanded(
-            child: PasswordBox(
-              enabled: false,
-              placeholder: 'Disabled PasswordBox',
-            ),
-          )
-        ]),
-        codeSnippet: '''PasswordBox()''',
-      ),
-      subtitle(content: const Text('A simple PasswordBox in peekAlways mode')),
-      CardHighlight(
-        child: Row(children: const [
-          Expanded(
-              child: PasswordBox(
-            revealMode: PasswordRevealMode.peekAlways,
-          )),
-        ]),
-        codeSnippet: '''PasswordBox(
+      children: [
+        const Text(
+          'The PasswordBox is almost identical to the TextBox. But the character'
+          ' is obfuscated by default and a button in the suffix allow the user to '
+          'show briefly the password in plain text.',
+        ),
+        subtitle(
+            content: const Text('A simple PasswordBox in peek mode (default)')),
+        CardHighlight(
+          child: Row(children: [
+            Expanded(
+                child: PasswordBox(
+              enabled: !disabled,
+            )),
+          ]),
+          codeSnippet: '''PasswordBox()''',
+        ),
+        subtitle(
+            content: const Text('A simple PasswordBox in peekAlways mode')),
+        CardHighlight(
+          child: Row(children: [
+            Expanded(
+                child: PasswordBox(
+              enabled: !disabled,
+              revealMode: PasswordRevealMode.peekAlways,
+            )),
+          ]),
+          codeSnippet: '''PasswordBox(
   revealMode: PasswordRevealMode.peekAlways,
 )''',
-      ),
-      subtitle(
-          content: const Text(
-              'A simple PasswordBox in visible (left) and hidden (right) mode')),
-      CardHighlight(
-        child: Row(children: const [
-          Expanded(
+        ),
+        subtitle(
+            content: const Text(
+                'A simple PasswordBox in visible (left) and hidden (right) mode')),
+        CardHighlight(
+          child: Row(children: [
+            Expanded(
+                child: PasswordBox(
+              enabled: !disabled,
+              revealMode: PasswordRevealMode.visible,
+              placeholder: 'Visible Password',
+            )),
+            const SizedBox(width: 10.0),
+            Expanded(
               child: PasswordBox(
-            revealMode: PasswordRevealMode.visible,
-            placeholder: 'Visible Password',
-          )),
-          SizedBox(width: 10.0),
-          Expanded(
-            child: PasswordBox(
-              revealMode: PasswordRevealMode.hidden,
-              placeholder: 'Hidden Password',
-            ),
-          )
-        ]),
-        codeSnippet: '''PasswordBox(
+                enabled: !disabled,
+                revealMode: PasswordRevealMode.hidden,
+                placeholder: 'Hidden Password',
+              ),
+            )
+          ]),
+          codeSnippet: '''PasswordBox(
   revealMode: PasswordRevealMode.visible,
 );
 
 PasswordBox(
   revealMode: PasswordRevealMode.hidden,
 );''',
-      ),
-    ];
+        ),
+        subtitle(content: const Text('Update programmatically the visibility')),
+        CardHighlight(
+          child: Row(children: [
+            Expanded(
+              child: PasswordBox(
+                enabled: !disabled,
+                revealMode: revealMode,
+              ),
+            ),
+            const SizedBox(width: 10),
+            SizedBox(
+              // width: 50,
+              child: ComboBox<PasswordRevealMode>(
+                onChanged: (e) {
+                  setState(() {
+                    revealMode = e ?? PasswordRevealMode.peek;
+                  });
+                },
+                value: revealMode,
+                items: PasswordRevealMode.values.map((e) {
+                  return ComboBoxItem(child: Text(e.name), value: e);
+                }).toList(),
+              ),
+            ),
+          ]),
+          codeSnippet: '''PasswordBox(
+  revealMode: revealMode,
+)''',
+        ),
+      ],
+    );
   }
 }

--- a/example/lib/screens/forms/password_box.dart
+++ b/example/lib/screens/forms/password_box.dart
@@ -1,0 +1,37 @@
+import 'package:example/widgets/card_highlight.dart';
+import 'package:example/widgets/page.dart';
+import 'package:fluent_ui/fluent_ui.dart';
+
+class PasswordBoxPage extends ScrollablePage {
+  PasswordBoxPage({super.key});
+
+  @override
+  Widget buildHeader(BuildContext context) {
+    return const PageHeader(title: Text('PasswordBox'));
+  }
+
+  @override
+  List<Widget> buildScrollable(BuildContext context) {
+    return [
+      const Text(
+        'The PasswordBox is almost identical to the TextBox. But the character'
+        ' is obfuscated by default and a button in the suffix allow the user to '
+        'show briefly the password in plain text.',
+      ),
+      subtitle(content: const Text('A simple PasswordBox')),
+      CardHighlight(
+        child: Row(children: const [
+          Expanded(child: PasswordBox()),
+          SizedBox(width: 10.0),
+          Expanded(
+            child: PasswordBox(
+              enabled: false,
+              placeholder: 'Disabled PasswordBox',
+            ),
+          )
+        ]),
+        codeSnippet: '''PasswordBox()''',
+      ),
+    ];
+  }
+}

--- a/example/lib/screens/forms/password_box.dart
+++ b/example/lib/screens/forms/password_box.dart
@@ -18,7 +18,8 @@ class PasswordBoxPage extends ScrollablePage {
         ' is obfuscated by default and a button in the suffix allow the user to '
         'show briefly the password in plain text.',
       ),
-      subtitle(content: const Text('A simple PasswordBox')),
+      subtitle(
+          content: const Text('A simple PasswordBox in peek mode (default)')),
       CardHighlight(
         child: Row(children: const [
           Expanded(child: PasswordBox()),
@@ -31,6 +32,44 @@ class PasswordBoxPage extends ScrollablePage {
           )
         ]),
         codeSnippet: '''PasswordBox()''',
+      ),
+      subtitle(content: const Text('A simple PasswordBox in peekAlways mode')),
+      CardHighlight(
+        child: Row(children: const [
+          Expanded(
+              child: PasswordBox(
+            revealMode: PasswordRevealMode.peekAlways,
+          )),
+        ]),
+        codeSnippet: '''PasswordBox(
+  revealMode: PasswordRevealMode.peekAlways,
+)''',
+      ),
+      subtitle(
+          content: const Text(
+              'A simple PasswordBox in visible (left) and hidden (right) mode')),
+      CardHighlight(
+        child: Row(children: const [
+          Expanded(
+              child: PasswordBox(
+            revealMode: PasswordRevealMode.visible,
+            placeholder: 'Visible Password',
+          )),
+          SizedBox(width: 10.0),
+          Expanded(
+            child: PasswordBox(
+              revealMode: PasswordRevealMode.hidden,
+              placeholder: 'Hidden Password',
+            ),
+          )
+        ]),
+        codeSnippet: '''PasswordBox(
+  revealMode: PasswordRevealMode.visible,
+);
+
+PasswordBox(
+  revealMode: PasswordRevealMode.hidden,
+);''',
       ),
     ];
   }

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -587,5 +587,5 @@ packages:
     source: hosted
     version: "3.1.1"
 sdks:
-  dart: ">=2.18.5 <4.0.0"
+  dart: ">=2.18.5 <3.0.0"
   flutter: ">=3.7.0"

--- a/lib/fluent_ui.dart
+++ b/lib/fluent_ui.dart
@@ -47,6 +47,7 @@ export 'src/controls/form/auto_suggest_box.dart';
 export 'src/controls/form/combo_box.dart';
 export 'src/controls/form/form_row.dart';
 export 'src/controls/form/number_box.dart';
+export 'src/controls/form/password_box.dart';
 export 'src/controls/form/pickers/date_picker.dart';
 export 'src/controls/form/pickers/time_picker.dart';
 export 'src/controls/form/selection_controls.dart';

--- a/lib/src/controls/form/password_box.dart
+++ b/lib/src/controls/form/password_box.dart
@@ -178,6 +178,17 @@ class _PasswordBoxState extends State<PasswordBox> {
     super.dispose();
   }
 
+  @override
+  void didUpdateWidget(covariant PasswordBox oldWidget) {
+    if (oldWidget.revealMode == PasswordRevealMode.peekAlways &&
+        widget.revealMode == PasswordRevealMode.peek) {
+      // if the mode change, we consider that the first focus is gone.
+      focusCanPeek = false;
+    }
+
+    super.didUpdateWidget(oldWidget);
+  }
+
   void _handleTextChange() {
     if (controller.text.isEmpty) {
       // If the text box is empty, then we ignore if the focus has been

--- a/lib/src/controls/form/password_box.dart
+++ b/lib/src/controls/form/password_box.dart
@@ -1,0 +1,70 @@
+import 'package:fluent_ui/fluent_ui.dart';
+
+class PasswordBox extends StatefulWidget {
+  final bool? enabled;
+  final String? placeholder;
+  final bool? obscureText;
+
+  const PasswordBox({
+    super.key,
+    this.enabled,
+    this.placeholder,
+    this.obscureText,
+  });
+
+  @override
+  State<PasswordBox> createState() => _PasswordBoxState();
+}
+
+class _PasswordBoxState extends State<PasswordBox> {
+  bool obscureText = true;
+
+  @override
+  void initState() {
+    obscureText = widget.obscureText ?? true;
+    super.initState();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+
+    return TextBox(
+      enabled: widget.enabled,
+      placeholder: widget.placeholder,
+      obscureText: obscureText,
+      suffix: Listener(
+        child: HoverButton(builder: (p0, state) {
+          return Icon(FluentIcons.red_eye);
+        },),
+        onPointerDown: (_){
+          print('DOWN');
+          setState(() {
+            obscureText = false;
+          });
+        },
+        onPointerUp: (_){
+          setState(() {
+            obscureText = widget.obscureText ?? true;
+          });
+        },
+      ),
+
+
+      /*suffix: HoverButton(
+        onTapDown: (){
+          print('DOWN');
+        },
+        onTapUp: (){
+          print('UP');
+        },
+        onTapCancel: (){
+          print('CANCEL');
+        },
+        builder: (p0, state) {
+          return Icon(FluentIcons.red_eye); // todo: half eye icon like WinUI3 ?
+          // return IconButton(icon: Icon(FluentIcons.red_eye), onPressed: null,);
+        },
+      ),*/
+    );
+  }
+}

--- a/lib/src/controls/form/password_box.dart
+++ b/lib/src/controls/form/password_box.dart
@@ -26,18 +26,111 @@ enum PasswordRevealMode {
   visible,
 }
 
+/// A fluent design input form for password.
+///
+/// A PasswordBox lets the user enter a password. There is multiple mode to
+/// indicate if the password must be hidden, visible or if a reveal button is
+/// shown.
+///
+/// See also:
+///
+///  * https://learn.microsoft.com/en-us/windows/apps/design/controls/password-box
 class PasswordBox extends StatefulWidget {
-  final FocusNode? focusNode;
+  /// Controls the text being edited.
+  ///
+  /// If null, this widget will create its own [TextEditingController].
+  final TextEditingController? controller;
+
+  /// Disables the text field when false.
+  ///
+  /// Text fields in disabled states have a light grey background and don't
+  /// respond to touch events including the [prefix], [suffix].
   final bool enabled;
-  final String? placeholder;
+
+  /// {@macro flutter.widgets.editableText.onEditingComplete}
+  final VoidCallback? onEditingComplete;
+
+  /// {@macro flutter.widgets.editableText.onSubmitted}
+  ///
+  /// See also:
+  ///
+  ///  * [TextInputAction.next] and [TextInputAction.previous], which
+  ///    automatically shift the focus to the next/previous focusable item when
+  ///    the user is done editing.
+  final ValueChanged<String>? onSubmitted;
+
+  /// The reveal mode determine how the password is visible or obscured.
   final PasswordRevealMode revealMode;
+
+  /// {@macro flutter.widgets.editableText.autofocus}
+  final bool autofocus;
+
+  /// {@macro flutter.widgets.Focus.focusNode}
+  final FocusNode? focusNode;
+
+  /// A widget displayed at the start of the text box
+  ///
+  /// Usually an [IconButton] or [Icon]
+  final Widget? leadingIcon;
+
+  /// The text shown when the text box is empty
+  ///
+  /// See also:
+  ///
+  ///  * [TextBox.placeholder]
+  final String? placeholder;
+
+  /// The style of [placeholder]
+  ///
+  /// See also:
+  ///
+  ///  * [TextBox.placeholderStyle]
+  final TextStyle? placeholderStyle;
+
+  /// {@macro flutter.widgets.editableText.cursorWidth}
+  final double cursorWidth;
+
+  /// {@macro flutter.widgets.editableText.cursorRadius}
+  final Radius cursorRadius;
+
+  /// {@macro flutter.widgets.editableText.cursorHeight}
+  final double? cursorHeight;
+
+  /// The color of the cursor.
+  ///
+  /// The cursor indicates the current location of text insertion point in
+  /// the field.
+  final Color? cursorColor;
+
+  /// {@macro flutter.widgets.editableText.showCursor}
+  final bool? showCursor;
+
+  /// The highlight color of the text box.
+  ///
+  /// If [foregroundDecoration] is provided, this must not be provided.
+  ///
+  /// See also:
+  ///  * [unfocusedColor], displayed when the field is not focused
+  final Color? highlightColor;
 
   const PasswordBox({
     super.key,
+    this.controller,
+    this.onEditingComplete,
+    this.onSubmitted,
     this.focusNode,
     this.enabled = true,
     this.placeholder,
     this.revealMode = PasswordRevealMode.peek,
+    this.autofocus = false,
+    this.leadingIcon,
+    this.placeholderStyle,
+    this.cursorWidth = 1.5,
+    this.cursorRadius = const Radius.circular(2.0),
+    this.cursorHeight,
+    this.cursorColor,
+    this.showCursor,
+    this.highlightColor,
   });
 
   @override
@@ -49,7 +142,8 @@ class _PasswordBoxState extends State<PasswordBox> {
   bool focusCanPeek = true;
   bool textCanPeek = false;
 
-  final TextEditingController controller = TextEditingController();
+  late final TextEditingController controller =
+      widget.controller ?? TextEditingController();
 
   FocusNode? _internalNode;
 
@@ -57,7 +151,9 @@ class _PasswordBoxState extends State<PasswordBox> {
 
   bool get _isVisible =>
       widget.revealMode == PasswordRevealMode.visible ||
-      (widget.revealMode == PasswordRevealMode.peek && peek);
+      ((widget.revealMode == PasswordRevealMode.peek ||
+              widget.revealMode == PasswordRevealMode.peekAlways) &&
+          peek);
 
   bool get _canPeek =>
       (widget.revealMode == PasswordRevealMode.peekAlways && textCanPeek) ||
@@ -125,6 +221,7 @@ class _PasswordBoxState extends State<PasswordBox> {
       controller: controller,
       enabled: widget.enabled,
       placeholder: widget.placeholder,
+      placeholderStyle: widget.placeholderStyle,
       obscureText: !_isVisible,
       suffix: _canPeek
           ? IconButton(
@@ -147,6 +244,15 @@ class _PasswordBoxState extends State<PasswordBox> {
                   : null,
             )
           : null,
+      onEditingComplete: widget.onEditingComplete,
+      onSubmitted: widget.onSubmitted,
+      autofocus: widget.autofocus,
+      prefix: widget.leadingIcon,
+      cursorWidth: widget.cursorWidth,
+      cursorRadius: widget.cursorRadius,
+      cursorHeight: widget.cursorHeight,
+      cursorColor: widget.cursorColor,
+      highlightColor: widget.highlightColor,
     );
   }
 }

--- a/lib/src/controls/form/password_box.dart
+++ b/lib/src/controls/form/password_box.dart
@@ -173,7 +173,7 @@ class _PasswordBoxState extends State<PasswordBox> {
   @override
   void initState() {
     if (widget.focusNode == null) {
-      _internalNode ??= FocusNode(debugLabel: '${widget.runtimeType}');
+      _internalNode = FocusNode(debugLabel: '${widget.runtimeType}');
     }
     if (widget.controller == null) {
       _internalController = TextEditingController();

--- a/lib/src/controls/form/password_box.dart
+++ b/lib/src/controls/form/password_box.dart
@@ -1,15 +1,43 @@
 import 'package:fluent_ui/fluent_ui.dart';
 
+enum PasswordRevealMode {
+  /// The password reveal button is visible. The password is not obscured while
+  /// the button is pressed.
+  ///
+  /// If the focus is lost, the button will be hidden on next time the focus
+  /// is got until the password box is cleared. (This is a security concern).
+  ///
+  /// If you want to keep the reveal button visible, see [peekAlways].
+  peek,
+
+  /// The password reveal button is visible. The button is not obscured while
+  /// the button is pressed.
+  ///
+  /// The reveal button will always be visible if the password box has the focus
+  /// and it's not empty. Unlike the [peek] mode, if the focus is regained,
+  /// the reveal button will be visible.
+  peekAlways,
+
+  /// The password reveal button is not visible. The password is
+  /// always obscured.
+  hidden,
+
+  /// The password reveal button is not visible. The password is not obscured.
+  visible,
+}
+
 class PasswordBox extends StatefulWidget {
-  final bool? enabled;
+  final FocusNode? focusNode;
+  final bool enabled;
   final String? placeholder;
-  final bool? obscureText;
+  final PasswordRevealMode revealMode;
 
   const PasswordBox({
     super.key,
-    this.enabled,
+    this.focusNode,
+    this.enabled = true,
     this.placeholder,
-    this.obscureText,
+    this.revealMode = PasswordRevealMode.peek,
   });
 
   @override
@@ -17,54 +45,108 @@ class PasswordBox extends StatefulWidget {
 }
 
 class _PasswordBoxState extends State<PasswordBox> {
-  bool obscureText = true;
+  bool peek = false;
+  bool focusCanPeek = true;
+  bool textCanPeek = false;
+
+  final TextEditingController controller = TextEditingController();
+
+  FocusNode? _internalNode;
+
+  FocusNode? get focusNode => widget.focusNode ?? _internalNode;
+
+  bool get _isVisible =>
+      widget.revealMode == PasswordRevealMode.visible ||
+      (widget.revealMode == PasswordRevealMode.peek && peek);
+
+  bool get _canPeek =>
+      (widget.revealMode == PasswordRevealMode.peekAlways && textCanPeek) ||
+      (widget.revealMode == PasswordRevealMode.peek &&
+          focusCanPeek &&
+          textCanPeek);
 
   @override
   void initState() {
-    obscureText = widget.obscureText ?? true;
+    if (widget.focusNode == null) {
+      _internalNode ??= _createFocusNode();
+    }
+    controller.addListener(_handleTextChange);
+    focusNode!.addListener(_handleFocusChange);
     super.initState();
   }
 
   @override
-  Widget build(BuildContext context) {
+  void dispose() {
+    controller.dispose();
+    focusNode!.dispose();
+    super.dispose();
+  }
 
+  void _handleTextChange() {
+    if (controller.text.isEmpty) {
+      // If the text box is empty, then we ignore if the focus has been
+      // lost or not previously.
+      focusCanPeek = true;
+    }
+
+    if (controller.text.isNotEmpty && !textCanPeek) {
+      // If the text box is not empty, the reveal button must be visible
+      // (it will be only if focusCanPeek is true !)
+      setState(() {
+        textCanPeek = true;
+      });
+    } else if (controller.text.isEmpty && textCanPeek) {
+      // If the text box is empty, the reveal button must be hidden.
+      setState(() {
+        textCanPeek = false;
+      });
+    }
+  }
+
+  void _handleFocusChange() {
+    if (!focusNode!.hasFocus && controller.text.isNotEmpty) {
+      // If the focus is lost and the text box is not empty, then the reveal
+      // button must not be hidden.
+      setState(() {
+        focusCanPeek = false;
+      });
+    }
+  }
+
+  // Only used if needed to create _internalNode.
+  FocusNode _createFocusNode() {
+    return FocusNode(debugLabel: '${widget.runtimeType}');
+  }
+
+  @override
+  Widget build(BuildContext context) {
     return TextBox(
+      focusNode: focusNode,
+      controller: controller,
       enabled: widget.enabled,
       placeholder: widget.placeholder,
-      obscureText: obscureText,
-      suffix: Listener(
-        child: HoverButton(builder: (p0, state) {
-          return Icon(FluentIcons.red_eye);
-        },),
-        onPointerDown: (_){
-          print('DOWN');
-          setState(() {
-            obscureText = false;
-          });
-        },
-        onPointerUp: (_){
-          setState(() {
-            obscureText = widget.obscureText ?? true;
-          });
-        },
-      ),
-
-
-      /*suffix: HoverButton(
-        onTapDown: (){
-          print('DOWN');
-        },
-        onTapUp: (){
-          print('UP');
-        },
-        onTapCancel: (){
-          print('CANCEL');
-        },
-        builder: (p0, state) {
-          return Icon(FluentIcons.red_eye); // todo: half eye icon like WinUI3 ?
-          // return IconButton(icon: Icon(FluentIcons.red_eye), onPressed: null,);
-        },
-      ),*/
+      obscureText: !_isVisible,
+      suffix: _canPeek
+          ? IconButton(
+              icon: const Icon(FluentIcons.red_eye),
+              // todo: half eye icon, like WinUI3 ?
+              onPressed: null,
+              onTapDown: widget.enabled
+                  ? () {
+                      setState(() {
+                        peek = true;
+                      });
+                    }
+                  : null,
+              onTapUp: widget.enabled
+                  ? () {
+                      setState(() {
+                        peek = false;
+                      });
+                    }
+                  : null,
+            )
+          : null,
     );
   }
 }

--- a/lib/src/controls/form/password_box.dart
+++ b/lib/src/controls/form/password_box.dart
@@ -113,6 +113,12 @@ class PasswordBox extends StatefulWidget {
   ///  * [unfocusedColor], displayed when the field is not focused
   final Color? highlightColor;
 
+  /// {@macro flutter.widgets.editableText.readOnly}
+  final bool readOnly;
+
+  /// {@macro flutter.widgets.editableText.obscuringCharacter}
+  final String obscuringCharacter;
+
   const PasswordBox({
     super.key,
     this.controller,
@@ -131,6 +137,8 @@ class PasswordBox extends StatefulWidget {
     this.cursorColor,
     this.showCursor,
     this.highlightColor,
+    this.readOnly = false,
+    this.obscuringCharacter = '•',
   });
 
   @override
@@ -264,6 +272,8 @@ class _PasswordBoxState extends State<PasswordBox> {
       cursorHeight: widget.cursorHeight,
       cursorColor: widget.cursorColor,
       highlightColor: widget.highlightColor,
+      readOnly: widget.readOnly,
+      obscuringCharacter: widget.obscuringCharacter,
     );
   }
 }

--- a/lib/src/controls/inputs/buttons/base.dart
+++ b/lib/src/controls/inputs/buttons/base.dart
@@ -19,6 +19,8 @@ abstract class BaseButton extends StatefulWidget {
     Key? key,
     required this.onPressed,
     required this.onLongPress,
+    required this.onTapDown,
+    required this.onTapUp,
     required this.style,
     required this.focusNode,
     required this.autofocus,
@@ -28,16 +30,38 @@ abstract class BaseButton extends StatefulWidget {
 
   /// Called when the button is tapped or otherwise activated.
   ///
-  /// If this callback and [onLongPress] are null, then the button will be disabled.
+  /// If this callback, [onLongPress], [onTapDown], and [onTapUp] are null,
+  /// then the button will be disabled.
   ///
   /// See also:
   ///
   ///  * [enabled], which is true if the button is enabled.
   final VoidCallback? onPressed;
 
+  /// Called when the button is pressed.
+  ///
+  /// If this callback, [onLongPress], [onPressed] and [onTapUp] are null,
+  /// then the button will be disabled.
+  ///
+  /// See also:
+  ///
+  ///  * [enabled], which is true if the button is enabled.
+  final VoidCallback? onTapDown;
+
+  /// Called when the button is released.
+  ///
+  /// If this callback, [onLongPress], [onPressed] and [onTapDown] are null,
+  /// then the button will be disabled.
+  ///
+  /// See also:
+  ///
+  ///  * [enabled], which is true if the button is enabled.
+  final VoidCallback? onTapUp;
+
   /// Called when the button is long-pressed.
   ///
-  /// If this callback and [onPressed] are null, then the button will be disabled.
+  /// If this callback, [onPressed], [onTapDown] and [onTapUp] are null,
+  /// then the button will be disabled.
   ///
   /// See also:
   ///
@@ -68,9 +92,13 @@ abstract class BaseButton extends StatefulWidget {
 
   /// Whether the button is enabled or disabled.
   ///
-  /// Buttons are disabled by default. To enable a button, set its [onPressed]
-  /// or [onLongPress] properties to a non-null value.
-  bool get enabled => onPressed != null || onLongPress != null;
+  /// Buttons are disabled by default. To enable a button, set its [onPressed],
+  /// [onLongPress], [onTapDown] or [onTapUp] properties to a non-null value.
+  bool get enabled =>
+      onPressed != null ||
+      onLongPress != null ||
+      onTapDown != null ||
+      onTapUp != null;
 
   @override
   State<BaseButton> createState() => _BaseButtonState();
@@ -110,6 +138,8 @@ class _BaseButtonState extends State<BaseButton> {
       onPressed: widget.onPressed,
       onLongPress: widget.onLongPress,
       focusEnabled: widget.focusable,
+      onTapDown: widget.onTapDown,
+      onTapUp: widget.onTapUp,
       builder: (context, states) {
         T? resolve<T>(
             ButtonState<T>? Function(ButtonStyle? style) getProperty) {

--- a/lib/src/controls/inputs/buttons/button.dart
+++ b/lib/src/controls/inputs/buttons/button.dart
@@ -17,6 +17,8 @@ class Button extends BaseButton {
     required Widget child,
     required VoidCallback? onPressed,
     VoidCallback? onLongPress,
+    VoidCallback? onTapDown,
+    VoidCallback? onTapUp,
     FocusNode? focusNode,
     bool autofocus = false,
     ButtonStyle? style,
@@ -28,6 +30,8 @@ class Button extends BaseButton {
           autofocus: autofocus,
           onLongPress: onLongPress,
           onPressed: onPressed,
+          onTapDown: onTapDown,
+          onTapUp: onTapUp,
           style: style,
           focusable: focusable,
         );

--- a/lib/src/controls/inputs/buttons/icon_button.dart
+++ b/lib/src/controls/inputs/buttons/icon_button.dart
@@ -8,6 +8,8 @@ class IconButton extends BaseButton {
     required Widget icon,
     required VoidCallback? onPressed,
     VoidCallback? onLongPress,
+    VoidCallback? onTapDown,
+    VoidCallback? onTapUp,
     FocusNode? focusNode,
     bool autofocus = false,
     ButtonStyle? style,
@@ -20,6 +22,8 @@ class IconButton extends BaseButton {
           autofocus: autofocus,
           onLongPress: onLongPress,
           onPressed: onPressed,
+          onTapDown: onTapDown,
+          onTapUp: onTapUp,
           style: style,
           focusable: focusable,
         );

--- a/lib/src/controls/inputs/buttons/outlined_button.dart
+++ b/lib/src/controls/inputs/buttons/outlined_button.dart
@@ -14,6 +14,8 @@ class OutlinedButton extends BaseButton {
     required Widget child,
     required VoidCallback? onPressed,
     VoidCallback? onLongPress,
+    VoidCallback? onTapDown,
+    VoidCallback? onTapUp,
     FocusNode? focusNode,
     bool autofocus = false,
     ButtonStyle? style,
@@ -25,6 +27,8 @@ class OutlinedButton extends BaseButton {
           autofocus: autofocus,
           onLongPress: onLongPress,
           onPressed: onPressed,
+          onTapDown: onTapDown,
+          onTapUp: onTapUp,
           style: style,
           focusable: focusable,
         );

--- a/lib/src/controls/inputs/buttons/text_button.dart
+++ b/lib/src/controls/inputs/buttons/text_button.dart
@@ -15,6 +15,8 @@ class TextButton extends BaseButton {
     required Widget child,
     required VoidCallback? onPressed,
     VoidCallback? onLongPress,
+    VoidCallback? onTapDown,
+    VoidCallback? onTapUp,
     FocusNode? focusNode,
     bool autofocus = false,
     ButtonStyle? style,
@@ -26,6 +28,8 @@ class TextButton extends BaseButton {
           autofocus: autofocus,
           onLongPress: onLongPress,
           onPressed: onPressed,
+          onTapDown: onTapDown,
+          onTapUp: onTapUp,
           style: style,
           focusable: focusable,
         );

--- a/lib/src/controls/utils/hover_button.dart
+++ b/lib/src/controls/utils/hover_button.dart
@@ -238,16 +238,16 @@ class _HoverButtonState extends State<HoverButton> {
         if (mounted) setState(() => _pressing = false);
       },
       onLongPress: enabled ? widget.onLongPress : null,
-      onLongPressStart: (_) {
+      onLongPressStart: widget.onLongPressStart != null ? (_) {
         if (!enabled) return;
         widget.onLongPressStart?.call();
         if (mounted) setState(() => _pressing = true);
-      },
-      onLongPressEnd: (_) {
+      } : null,
+      onLongPressEnd: widget.onLongPressEnd != null ? (_) {
         if (!enabled) return;
         widget.onLongPressEnd?.call();
         if (mounted) setState(() => _pressing = false);
-      },
+      } : null,
       onHorizontalDragStart: widget.onHorizontalDragStart,
       onHorizontalDragUpdate: widget.onHorizontalDragUpdate,
       onHorizontalDragEnd: widget.onHorizontalDragEnd,

--- a/lib/src/controls/utils/hover_button.dart
+++ b/lib/src/controls/utils/hover_button.dart
@@ -238,16 +238,20 @@ class _HoverButtonState extends State<HoverButton> {
         if (mounted) setState(() => _pressing = false);
       },
       onLongPress: enabled ? widget.onLongPress : null,
-      onLongPressStart: widget.onLongPressStart != null ? (_) {
-        if (!enabled) return;
-        widget.onLongPressStart?.call();
-        if (mounted) setState(() => _pressing = true);
-      } : null,
-      onLongPressEnd: widget.onLongPressEnd != null ? (_) {
-        if (!enabled) return;
-        widget.onLongPressEnd?.call();
-        if (mounted) setState(() => _pressing = false);
-      } : null,
+      onLongPressStart: widget.onLongPressStart != null
+          ? (_) {
+              if (!enabled) return;
+              widget.onLongPressStart?.call();
+              if (mounted) setState(() => _pressing = true);
+            }
+          : null,
+      onLongPressEnd: widget.onLongPressEnd != null
+          ? (_) {
+              if (!enabled) return;
+              widget.onLongPressEnd?.call();
+              if (mounted) setState(() => _pressing = false);
+            }
+          : null,
       onHorizontalDragStart: widget.onHorizontalDragStart,
       onHorizontalDragUpdate: widget.onHorizontalDragUpdate,
       onHorizontalDragEnd: widget.onHorizontalDragEnd,

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -366,5 +366,5 @@ packages:
     source: hosted
     version: "3.1.1"
 sdks:
-  dart: ">=2.18.0 <4.0.0"
+  dart: ">=2.18.0 <3.0.0"
   flutter: ">=3.7.0"


### PR DESCRIPTION
<!-- Add a description of what this PR is changing or adding, and why. Consider mentioning issues -->

This PR add a new widget: `PasswordBox` : https://learn.microsoft.com/en-us/windows/apps/design/controls/password-box


This looks like that:

![passwordbox](https://user-images.githubusercontent.com/8223773/228664467-b8e5f720-546a-4a8d-b0b0-c52b46f12689.gif)

There is four modes:

- `peek` : default mode, when the user got the focus (for the first time !) and the text field is not empty, a reveal button is added. If the focus is lost and re-got, the button is not visible (same operation than Microsoft WinUI). The button is visible again only if the text field is cleared.
- `peekAlways`: (not a Microsoft standard mode). The button is visible when the text-field is not empty and doesn't look if it the first focus or not).
- `visible` : the password is always visible (useful for a programmatically change)
- `hidden`: the password is always hidden (useful for a programmatically change)

-----------------

This PR also add parameters `onTapDown` and `onTapUp` on all buttons.


## Pre-launch Checklist

<!-- Mark all that applies -->

- [x] I have updated `CHANGELOG.md` with my changes <!-- REQUIRED --> 
- [x] I have run "dart format ." on the project <!-- REQUIRED --> 
- [x] I have added/updated relevant documentation