### PR TITLE
add example page of Snackbar in /popups/snackbar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## [Next]
 
+- Add example page of `Snackbar` in /popups/snackbar
+
 - Add parameters `onTapDown` and `onTapUp` on all buttons. ([#795](https://github.com/bdlukaa/fluent_ui/pull/795))
    - **Breaking: if you use the abstract class `BaseButton`, these two parameters are now required** 
 - Add `PasswordBox` widget. ([#795](https://github.com/bdlukaa/fluent_ui/pull/795))

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -419,6 +419,17 @@ class _MyHomePageState extends State<MyHomePage> with WindowListener {
         }
       },
     ),
+    PaneItem(
+      key: const Key('/popups/snackbar'),
+      icon: const Icon(FluentIcons.arrange_send_backward),
+      title: const Text('SnackBar'),
+      body: const SizedBox.shrink(),
+      onTap: () {
+        if (router.location != '/popups/snackbar') {
+          router.pushNamed('popups_snackbar');
+        }
+      },
+    ),
     PaneItemHeader(header: const Text('Theming')),
     PaneItem(
       key: const Key('/theming/colors'),
@@ -1033,6 +1044,16 @@ final router = GoRouter(
           builder: (context, state) => DeferredWidget(
             surfaces.loadLibrary,
             () => popups.Flyout2Screen(),
+          ),
+        ),
+
+        /// SnackBar
+        GoRoute(
+          path: '/popups/snackbar',
+          name: 'popups_snackbar',
+          builder: (context, state) => DeferredWidget(
+            surfaces.loadLibrary,
+            () => popups.SnackBarPage(),
           ),
         ),
 

--- a/example/lib/routes/popups.dart
+++ b/example/lib/routes/popups.dart
@@ -1,3 +1,4 @@
 export '../screens/popups/content_dialog.dart';
 export '../screens/popups/flyout.dart';
 export '../screens/popups/tooltip.dart';
+export '../screens/popups/snackbar.dart';

--- a/example/lib/screens/popups/snackbar.dart
+++ b/example/lib/screens/popups/snackbar.dart
@@ -1,0 +1,186 @@
+import 'package:clipboard/clipboard.dart';
+import 'package:example/widgets/card_highlight.dart';
+import 'package:example/widgets/page.dart';
+import 'package:fluent_ui/fluent_ui.dart';
+
+class SnackBarPage extends StatefulWidget {
+  const SnackBarPage({super.key});
+
+  @override
+  State<SnackBarPage> createState() => _SnackBarPageState();
+}
+
+class _SnackBarPageState extends State<SnackBarPage> with PageMixin {
+  var textEditingController = TextEditingController();
+
+  @override
+  void dispose() {
+    textEditingController.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return ScaffoldPage.scrollable(
+      header: const PageHeader(title: Text('SnackBar')),
+      children: [
+        const Text(
+            'A Snackbar is a small message that pops up at the bottom of '
+            'the screen to display a brief message to the user. '
+            'It is often used to provide feedback or to alert the user of a change or an error.'),
+        subtitle(content: const Text('Example of a Simple SnackBar')),
+        CardHighlight(
+            child: Button(
+              child: const Text('Click me'),
+              onPressed: () {
+                showSnackbar(
+                  context,
+                  const Snackbar(
+                    content: Text('A Simple SnackBar'),
+                  ),
+                );
+              },
+            ),
+            codeSnippet: '''
+showSnackbar(
+  context,
+  const Snackbar(
+    content: Text('A Simple SnackBar'),
+  ),
+);
+'''),
+        subtitle(content: const Text('Example of a Featureful SnackBar')),
+        CardHighlight(
+            child: Row(
+              children: [
+                SizedBox(
+                  width: 300,
+                  child: TextBox(
+                    controller: textEditingController,
+                    placeholder: 'Enter Something',
+                  ),
+                ),
+                const SizedBox(width: 10.0),
+                Button(
+                  child: const Text('Copy to clipboard'),
+                  onPressed: () async {
+                    if (textEditingController.text.isEmpty) {
+                      showSnackbarWithText(
+                          context, textEditingController.text, false);
+                      return;
+                    }
+                    await FlutterClipboard.copy(textEditingController.text);
+                    showSnackbarWithText(
+                        context, textEditingController.text, true);
+                  },
+                ),
+                const Spacer(),
+              ],
+            ),
+            codeSnippet: '''
+// Define text editing controller
+var textEditingController = TextEditingController();
+
+// A sample Row which renders TextBox and Button
+Row(
+  children: [
+    SizedBox(
+      width: 300,
+      child: TextBox(
+        controller: textEditingController,
+        placeholder: 'Enter Something',
+      ),
+    ),
+    const SizedBox(width: 10.0),
+    Button(
+      child: const Text('Copy to clipboard'),
+      onPressed: () async {
+        if (textEditingController.text.isEmpty) {
+          showSnackbarWithText(
+              context, textEditingController.text, false);
+          return;
+        }
+        await FlutterClipboard.copy(textEditingController.text);
+        showSnackbarWithText(
+            context, textEditingController.text, true);
+      },
+    ),
+    const Spacer(),
+  ],
+);
+
+// takes String copiedText and bool statusPass
+// statusPass indicates if the entered text can be
+// copied to clipboard
+void showSnackbarWithText(
+    BuildContext context, String copiedText, bool statusPass) {
+  showSnackbar(
+    context,
+    Snackbar(
+      content: RichText(
+        text: TextSpan(
+          text: statusPass ? 'Copied: ' : 'Error: ',
+          style: TextStyle(color: statusPass ? Colors.white : Colors.red),
+          children: [
+            TextSpan(
+              text: statusPass
+                  ? copiedText
+                  : 'Empty string can not be copied to clipboard',
+              style: TextStyle(
+                color: Colors.blue.defaultBrushFor(
+                  FluentTheme.of(context).brightness,
+                ),
+                fontWeight: FontWeight.w500,
+              ),
+            ),
+          ],
+        ),
+      ),
+      extended: true,
+    ),
+  );
+}
+
+// Do not forget to dispose the textEditingController
+@override
+void dispose() {
+  textEditingController.dispose();
+  super.dispose();
+}
+'''),
+      ],
+    );
+  }
+}
+
+// takes String copiedText and bool statusPass
+// statusPass indicates if the entered text can be
+// copied to clipboard
+void showSnackbarWithText(
+    BuildContext context, String copiedText, bool statusPass) {
+  showSnackbar(
+    context,
+    Snackbar(
+      content: RichText(
+        text: TextSpan(
+          text: statusPass ? 'Copied: ' : 'Error: ',
+          style: TextStyle(color: statusPass ? Colors.white : Colors.red),
+          children: [
+            TextSpan(
+              text: statusPass
+                  ? copiedText
+                  : 'Empty string can not be copied to clipboard',
+              style: TextStyle(
+                color: Colors.blue.defaultBrushFor(
+                  FluentTheme.of(context).brightness,
+                ),
+                fontWeight: FontWeight.w500,
+              ),
+            ),
+          ],
+        ),
+      ),
+      extended: true,
+    ),
+  );
+}


### PR DESCRIPTION
<!-- Add a description of what this PR is changing or adding, and why. Consider mentioning issues -->
`Snackbar` was used in the example application in `Theming/Icons`,  but there was no page or example of `Snackbar`. So, I have added a page for `Snackbar` in `popups`. The base implementation of `Snackbar` is taken from `Theming/Icons` in the example application.

 See Image for reference.
![Capture](https://user-images.githubusercontent.com/70003855/230361040-502960e4-fa3a-411f-bfb1-33e337fd5b30.JPG)


## Pre-launch Checklist

<!-- Mark all that applies -->

- [x] I have updated `CHANGELOG.md` with my changes <!-- REQUIRED --> 
- [x] I have run "dart format ." on the project <!-- REQUIRED --> 
- [x] I have added/updated relevant documentation