### PR TITLE
fix: backButtonDispatcher not being null when routerConfig is provided

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## [Next]
 
-- Remove default value of `backButtonDispatcher` using `FluentApp.router`.
+- Remove default value of `backButtonDispatcher` when using `FluentApp.router`.
 - Add parameters `onTapDown` and `onTapUp` on all buttons. ([#795](https://github.com/bdlukaa/fluent_ui/pull/795))
    - **Breaking: if you use the abstract class `BaseButton`, these two parameters are now required** 
 - Add `PasswordBox` widget. ([#795](https://github.com/bdlukaa/fluent_ui/pull/795))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## [Next]
 
+- Fix `backButtonDispatcher` not null when using `routerConfig`.
 - Add parameters `onTapDown` and `onTapUp` on all buttons. ([#795](https://github.com/bdlukaa/fluent_ui/pull/795))
    - **Breaking: if you use the abstract class `BaseButton`, these two parameters are now required** 
 - Add `PasswordBox` widget. ([#795](https://github.com/bdlukaa/fluent_ui/pull/795))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## [Next]
 
-- Fix `backButtonDispatcher` not null when using `routerConfig`.
+- Remove default value of `backButtonDispatcher` using `FluentApp.router`.
 - Add parameters `onTapDown` and `onTapUp` on all buttons. ([#795](https://github.com/bdlukaa/fluent_ui/pull/795))
    - **Breaking: if you use the abstract class `BaseButton`, these two parameters are now required** 
 - Add `PasswordBox` widget. ([#795](https://github.com/bdlukaa/fluent_ui/pull/795))

--- a/lib/src/app.dart
+++ b/lib/src/app.dart
@@ -118,8 +118,26 @@ class FluentApp extends StatefulWidget {
     this.restorationScopeId,
     this.scrollBehavior = const FluentScrollBehavior(),
     this.useInheritedMediaQuery = false,
-  })  : assert(routeInformationParser != null && routerDelegate != null ||
-            routerConfig != null),
+  })  : assert(() {
+          if (routerConfig != null) {
+            assert(
+              (routeInformationProvider ??
+                      routeInformationParser ??
+                      routerDelegate ??
+                      backButtonDispatcher) ==
+                  null,
+              'If the routerConfig is provided, all the other router delegates must not be provided',
+            );
+            return true;
+          }
+          assert(routerDelegate != null,
+              'Either one of routerDelegate or routerConfig must be provided');
+          assert(
+            routeInformationProvider == null || routeInformationParser != null,
+            'If routeInformationProvider is provided, routeInformationParser must also be provided',
+          );
+          return true;
+        }()),
         assert(supportedLocales.isNotEmpty),
         navigatorObservers = null,
         navigatorKey = null,

--- a/lib/src/app.dart
+++ b/lib/src/app.dart
@@ -97,7 +97,7 @@ class FluentApp extends StatefulWidget {
     this.routeInformationProvider,
     this.routeInformationParser,
     this.routerDelegate,
-    BackButtonDispatcher? backButtonDispatcher,
+    this.backButtonDispatcher,
     this.routerConfig,
     this.builder,
     this.title = '',
@@ -122,8 +122,6 @@ class FluentApp extends StatefulWidget {
             routerConfig != null),
         assert(supportedLocales.isNotEmpty),
         navigatorObservers = null,
-        backButtonDispatcher =
-            backButtonDispatcher ?? RootBackButtonDispatcher(),
         navigatorKey = null,
         onGenerateRoute = null,
         home = null,
@@ -468,8 +466,7 @@ class _FluentAppState extends State<FluentApp> {
         routeInformationParser: widget.routeInformationParser,
         routerDelegate: widget.routerDelegate,
         routerConfig: widget.routerConfig,
-        backButtonDispatcher:
-            widget.routerConfig == null ? widget.backButtonDispatcher : null,
+        backButtonDispatcher: widget.backButtonDispatcher,
         builder: _builder,
         title: widget.title,
         onGenerateTitle: widget.onGenerateTitle,

--- a/lib/src/app.dart
+++ b/lib/src/app.dart
@@ -468,7 +468,8 @@ class _FluentAppState extends State<FluentApp> {
         routeInformationParser: widget.routeInformationParser,
         routerDelegate: widget.routerDelegate,
         routerConfig: widget.routerConfig,
-        backButtonDispatcher: widget.backButtonDispatcher,
+        backButtonDispatcher:
+            widget.routerConfig == null ? widget.backButtonDispatcher : null,
         builder: _builder,
         title: widget.title,
         onGenerateTitle: widget.onGenerateTitle,


### PR DESCRIPTION
When using `routerConfig` an assertion fails in `WidgetsApp.router`.
This is caused by `backButtonDispatcher` defaulting to `DefaultBackButtonDispatcher`.

## Pre-launch Checklist

<!-- Mark all that applies -->

- [x] I have updated `CHANGELOG.md` with my changes <!-- REQUIRED --> 
- [x] I have run "dart format ." on the project <!-- REQUIRED --> 
- [x] I have added/updated relevant documentation