### PR TITLE
inherit text style for form row error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Added `PasswordFormBox` ([#811](https://github.com/bdlukaa/fluent_ui/issues/811))
 - `DateTime.startYear` and `DateTime.endYear` are now deprecated. Use `DateTime.startDate` and `DateTime.endDate` instead. ([#687](https://github.com/bdlukaa/fluent_ui/issues/687))
 - Added `.decoration`, `.foregroundDecoration`, `.highlightColor`, `.unfocusedColor`, `.keyboardAppearance`, `.textAlign`, `.textAlignVertical` to `PasswordBox` ([#820](https://github.com/bdlukaa/fluent_ui/issues/820))
+- Do not block text style inheritance in widgets ([#823](https://github.com/bdlukaa/fluent_ui/pull/823))
 
 ## 4.5.0
 

--- a/lib/src/controls/flyouts/content.dart
+++ b/lib/src/controls/flyouts/content.dart
@@ -83,8 +83,8 @@ class FlyoutContent extends StatelessWidget {
             shape: resolvedShape,
           ),
           padding: padding,
-          child: DefaultTextStyle(
-            style: theme.typography.body ?? const TextStyle(),
+          child: DefaultTextStyle.merge(
+            style: theme.typography.body,
             child: child,
           ),
         ),

--- a/lib/src/controls/form/auto_suggest_box.dart
+++ b/lib/src/controls/form/auto_suggest_box.dart
@@ -934,8 +934,8 @@ class __AutoSuggestBoxOverlayTileState extends State<_AutoSuggestBoxOverlayTile>
           parent: controller,
           curve: Curves.easeOut,
         )),
-        child: DefaultTextStyle(
-          style: theme.typography.body ?? const TextStyle(),
+        child: DefaultTextStyle.merge(
+          style: theme.typography.body,
           child: widget.text,
         ),
       ),

--- a/lib/src/controls/form/combo_box.dart
+++ b/lib/src/controls/form/combo_box.dart
@@ -314,7 +314,7 @@ class _ComboBoxMenuState<T> extends State<_ComboBoxMenu<T>> {
                 namesRoute: true,
                 explicitChildNodes: true,
                 label: FluentLocalizations.of(context).dialogLabel,
-                child: DefaultTextStyle(
+                child: DefaultTextStyle.merge(
                   style: route.style,
                   child: ScrollConfiguration(
                     behavior: const _ComboBoxScrollBehavior(),
@@ -1221,7 +1221,7 @@ class ComboBoxState<T> extends State<ComboBox<T>> {
       }
 
       placeholderIndex = items.length;
-      items.add(DefaultTextStyle(
+      items.add(DefaultTextStyle.merge(
         style: textStyle!.copyWith(color: theme.disabledColor),
         child: IgnorePointer(
           ignoringSemantics: false,
@@ -1251,7 +1251,7 @@ class ComboBoxState<T> extends State<ComboBox<T>> {
     }
 
     Widget result = Builder(builder: (context) {
-      return DefaultTextStyle(
+      return DefaultTextStyle.merge(
         style: isEnabled
             ? textStyle!
             : textStyle!.copyWith(color: theme.disabledColor),

--- a/lib/src/controls/form/form_row.dart
+++ b/lib/src/controls/form/form_row.dart
@@ -47,7 +47,7 @@ class FormRow extends StatelessWidget {
           Container(
             margin: const EdgeInsetsDirectional.only(top: 2.0),
             alignment: AlignmentDirectional.centerStart,
-            child: DefaultTextStyle(
+            child: DefaultTextStyle.merge(
               style: TextStyle(
                 color: Colors.red.defaultBrushFor(theme.brightness),
                 fontWeight: FontWeight.w500,

--- a/lib/src/controls/form/form_row.dart
+++ b/lib/src/controls/form/form_row.dart
@@ -38,7 +38,7 @@ class FormRow extends StatelessWidget {
         if (helper != null)
           Align(
             alignment: AlignmentDirectional.centerStart,
-            child: DefaultTextStyle(
+            child: DefaultTextStyle.merge(
               style: textStyle!,
               child: helper!,
             ),

--- a/lib/src/controls/inputs/buttons/base.dart
+++ b/lib/src/controls/inputs/buttons/base.dart
@@ -199,8 +199,10 @@ class _BaseButtonState extends State<BaseButton> {
               child: AnimatedDefaultTextStyle(
                 duration: FluentTheme.of(context).fastAnimationDuration,
                 curve: FluentTheme.of(context).animationCurve,
-                style: (resolvedTextStyle ?? const TextStyle())
-                    .copyWith(color: resolvedForegroundColor),
+                style: DefaultTextStyle.of(context).style.merge(
+                      (resolvedTextStyle ?? const TextStyle())
+                          .copyWith(color: resolvedForegroundColor),
+                    ),
                 textAlign: TextAlign.center,
                 child: widget.child,
               ),

--- a/lib/src/controls/inputs/pill_button_bar.dart
+++ b/lib/src/controls/inputs/pill_button_bar.dart
@@ -130,7 +130,7 @@ class _PillButtonBarItem extends StatelessWidget {
               horizontal: _kButtonsSpacing + visualDensity.horizontal,
               vertical: _kButtonsSpacing + visualDensity.vertical,
             ),
-            child: DefaultTextStyle(
+            child: DefaultTextStyle.merge(
               style: (selected
                       ? theme.selectedTextStyle
                       : theme.unselectedTextStyle) ??

--- a/lib/src/controls/navigation/bottom_navigation.dart
+++ b/lib/src/controls/navigation/bottom_navigation.dart
@@ -149,7 +149,7 @@ class _BottomNavigationItem extends StatelessWidget {
             if (item.title != null)
               Padding(
                 padding: const EdgeInsetsDirectional.only(top: 1.0),
-                child: DefaultTextStyle(
+                child: DefaultTextStyle.merge(
                   style: FluentTheme.of(context).typography.caption!.copyWith(
                         color: selected
                             ? style.selectedColor

--- a/lib/src/controls/navigation/navigation_view/pane.dart
+++ b/lib/src/controls/navigation/navigation_view/pane.dart
@@ -1272,9 +1272,8 @@ class _OpenNavigationPaneState extends State<_OpenNavigationPane>
                             padding: const EdgeInsetsDirectional.only(
                               start: 8.0,
                             ),
-                            child: DefaultTextStyle(
-                              style: theme.itemHeaderTextStyle ??
-                                  const TextStyle(),
+                            child: DefaultTextStyle.merge(
+                              style: theme.itemHeaderTextStyle,
                               child: widget.pane.header!,
                             ),
                           ),

--- a/lib/src/controls/navigation/navigation_view/pane_items.dart
+++ b/lib/src/controls/navigation/navigation_view/pane_items.dart
@@ -490,8 +490,8 @@ class PaneItemHeader extends NavigationPaneItem {
               ? EdgeInsets.zero
               : theme.headerPadding ?? EdgeInsets.zero,
         ),
-        child: DefaultTextStyle(
-          style: theme.itemHeaderTextStyle ?? const TextStyle(),
+        child: DefaultTextStyle.merge(
+          style: theme.itemHeaderTextStyle,
           softWrap: false,
           maxLines: 1,
           overflow: TextOverflow.fade,
@@ -749,9 +749,8 @@ class __PaneItemExpanderState extends State<_PaneItemExpander>
                         vertical: 8.0,
                       ),
                       margin: const EdgeInsetsDirectional.only(bottom: 4.0),
-                      child: DefaultTextStyle(
-                        style: navigationTheme.itemHeaderTextStyle ??
-                            const TextStyle(),
+                      child: DefaultTextStyle.merge(
+                        style: navigationTheme.itemHeaderTextStyle,
                         softWrap: false,
                         maxLines: 1,
                         overflow: TextOverflow.fade,

--- a/lib/src/controls/navigation/navigation_view/view.dart
+++ b/lib/src/controls/navigation/navigation_view/view.dart
@@ -893,9 +893,8 @@ class _NavigationAppBar extends StatelessWidget {
           padding: (theme.iconPadding ?? EdgeInsets.zero).add(
             const EdgeInsetsDirectional.only(start: 6.0),
           ),
-          child: DefaultTextStyle(
-            style:
-                FluentTheme.of(context).typography.caption ?? const TextStyle(),
+          child: DefaultTextStyle.merge(
+            style: FluentTheme.of(context).typography.caption,
             maxLines: 1,
             softWrap: false,
             child: appBar.title!,

--- a/lib/src/controls/navigation/tab_view.dart
+++ b/lib/src/controls/navigation/tab_view.dart
@@ -423,7 +423,7 @@ class _TabViewState extends State<TabView> {
             if (widget.header != null)
               Padding(
                 padding: const EdgeInsetsDirectional.only(end: 12.0),
-                child: DefaultTextStyle(
+                child: DefaultTextStyle.merge(
                   style: headerFooterTextStyle,
                   child: widget.header!,
                 ),
@@ -573,7 +573,7 @@ class _TabViewState extends State<TabView> {
             if (widget.footer != null)
               Padding(
                 padding: const EdgeInsetsDirectional.only(start: 12.0),
-                child: DefaultTextStyle(
+                child: DefaultTextStyle.merge(
                   style: headerFooterTextStyle,
                   child: widget.footer!,
                 ),
@@ -905,7 +905,7 @@ class __TabState extends State<_Tab>
             ),
             child: () {
               final result = ClipRect(
-                child: DefaultTextStyle(
+                child: DefaultTextStyle.merge(
                   style: (theme.typography.body ?? const TextStyle()).copyWith(
                     fontSize: 12.0,
                     fontWeight: widget.selected ? FontWeight.w600 : null,

--- a/lib/src/controls/navigation/tree_view.dart
+++ b/lib/src/controls/navigation/tree_view.dart
@@ -1020,7 +1020,7 @@ class _TreeViewItem extends StatelessWidget {
 
                     // Item content
                     Expanded(
-                      child: DefaultTextStyle(
+                      child: DefaultTextStyle.merge(
                         style: TextStyle(
                           fontSize: 12.0,
                           color: itemForegroundColor,

--- a/lib/src/controls/surfaces/bottom_sheet.dart
+++ b/lib/src/controls/surfaces/bottom_sheet.dart
@@ -718,8 +718,8 @@ class BottomSheet extends StatelessWidget {
                     horizontal: 16.0,
                     vertical: 12.0,
                   ),
-                  child: DefaultTextStyle(
-                    style: FluentTheme.of(context).typography.caption!,
+                  child: DefaultTextStyle.merge(
+                    style: FluentTheme.of(context).typography.caption,
                     textAlign: TextAlign.center,
                     child: description!,
                   ),

--- a/lib/src/controls/surfaces/dialog.dart
+++ b/lib/src/controls/surfaces/dialog.dart
@@ -103,8 +103,8 @@ class ContentDialog extends StatelessWidget {
                     if (title != null)
                       Padding(
                         padding: style.titlePadding ?? EdgeInsets.zero,
-                        child: DefaultTextStyle(
-                          style: style.titleStyle ?? const TextStyle(),
+                        child: DefaultTextStyle.merge(
+                          style: style.titleStyle,
                           child: title!,
                         ),
                       ),
@@ -112,8 +112,8 @@ class ContentDialog extends StatelessWidget {
                       Flexible(
                         child: Padding(
                           padding: style.bodyPadding ?? EdgeInsets.zero,
-                          child: DefaultTextStyle(
-                            style: style.bodyStyle ?? const TextStyle(),
+                          child: DefaultTextStyle.merge(
+                            style: style.bodyStyle,
                             child: content!,
                           ),
                         ),

--- a/lib/src/controls/surfaces/info_bar.dart
+++ b/lib/src/controls/surfaces/info_bar.dart
@@ -180,14 +180,14 @@ class InfoBar extends StatelessWidget {
     final closeIcon = style.closeIcon;
     final title = Padding(
       padding: const EdgeInsetsDirectional.only(end: 6.0),
-      child: DefaultTextStyle(
+      child: DefaultTextStyle.merge(
         style: theme.typography.bodyStrong ?? const TextStyle(),
         child: this.title,
       ),
     );
     final content = () {
       if (this.content == null) return null;
-      return DefaultTextStyle(
+      return DefaultTextStyle.merge(
         style: theme.typography.body ?? const TextStyle(),
         child: this.content!,
       );

--- a/lib/src/controls/surfaces/list_tile.dart
+++ b/lib/src/controls/surfaces/list_tile.dart
@@ -212,13 +212,13 @@ class ListTile extends StatelessWidget {
                 crossAxisAlignment: CrossAxisAlignment.start,
                 children: [
                   if (title != null)
-                    DefaultTextStyle(
+                    DefaultTextStyle.merge(
                       style: (theme.typography.body ?? const TextStyle())
                           .copyWith(fontSize: 16),
                       child: title!,
                     ),
                   if (subtitle != null)
-                    DefaultTextStyle(
+                    DefaultTextStyle.merge(
                       style: theme.typography.caption ?? const TextStyle(),
                       child: subtitle!,
                     ),

--- a/lib/src/controls/surfaces/snackbar.dart
+++ b/lib/src/controls/surfaces/snackbar.dart
@@ -139,7 +139,7 @@ class SnackbarState extends State<Snackbar>
         constraints: const BoxConstraints(maxWidth: 300.0, minWidth: 32.0),
         decoration: theme.decoration,
         padding: theme.padding,
-        child: DefaultTextStyle(
+        child: DefaultTextStyle.merge(
           style: TextStyle(color: theme.decoration?.color?.basedOnLuminance()),
           child: Flex(
             direction: widget.extended ? Axis.vertical : Axis.horizontal,

--- a/lib/src/controls/surfaces/tooltip.dart
+++ b/lib/src/controls/surfaces/tooltip.dart
@@ -874,7 +874,7 @@ class _TooltipOverlay extends StatelessWidget {
         opacity: animation,
         child: ConstrainedBox(
           constraints: BoxConstraints(minHeight: height),
-          child: DefaultTextStyle(
+          child: DefaultTextStyle.merge(
             style: FluentTheme.of(context).typography.body!,
             child: Container(
               decoration: decoration,

--- a/lib/src/controls/utils/info_badge.dart
+++ b/lib/src/controls/utils/info_badge.dart
@@ -74,7 +74,7 @@ class InfoBadge extends StatelessWidget {
       ),
       child: source == null
           ? null
-          : DefaultTextStyle(
+          : DefaultTextStyle.merge(
               textAlign: TextAlign.center,
               style: TextStyle(
                 color: foregroundColor,

--- a/lib/src/layout/page.dart
+++ b/lib/src/layout/page.dart
@@ -227,7 +227,7 @@ class PageHeader extends StatelessWidget {
       child: Row(children: [
         if (leading != null) leading!,
         Expanded(
-          child: DefaultTextStyle(
+          child: DefaultTextStyle.merge(
             style: theme.typography.title!,
             child: title ?? const SizedBox(),
           ),


### PR DESCRIPTION
Inherit text style for `FormRow` error widget. Otherwise error text doesn't inherit font family from theme.

## Pre-launch Checklist

<!-- Mark all that applies -->

- [x] I have updated `CHANGELOG.md` with my changes <!-- REQUIRED --> 
- [x] I have run "dart format ." on the project <!-- REQUIRED --> 
- [ ] I have added/updated relevant documentation