### PR TITLE
feat: [CommandBar] supports setting directions if needed.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## [next]
 
+- Add vertical support to `CommandBar`. ([#872](https://github.com/bdlukaa/fluent_ui/pull/872))
 - **BREAKING** Removed `SplitButtonBar` and its related widget. Use `SplitButton` or `SplitButton.toggle` instead ([#882](https://github.com/bdlukaa/fluent_ui/pull/882), [#411](https://github.com/bdlukaa/fluent_ui/issues/411))
 
 ## 4.7.0
@@ -7,7 +8,6 @@
 - Add Slovak localization ([#850](https://github.com/bdlukaa/fluent_ui/issues/850))
 - Add `AutoSuggestBox.itemBuilder` callback builder, which builds the items inside the overlay ([#869](https://github.com/bdlukaa/fluent_ui/issues/869))
 - Add `AutoSuggestBoxItem.semanticsLabel` ([#869](https://github.com/bdlukaa/fluent_ui/issues/869))
-- Add vertical support to `CommandBar`. ([#872](https://github.com/bdlukaa/fluent_ui/pull/872))
 - Add `ButtonState.forStates`, a helper function to quickly resolve values for each button state ([#875](https://github.com/bdlukaa/fluent_ui/pull/875))
 - Slider label color is solid ([#847](https://github.com/bdlukaa/fluent_ui/issues/847))
 - **BREAKING** Removed `.disabledColor`, `uncheckedColor`, `.checkedColor` and `.borderInputColor` from `FluentThemeData`. Use the values from theme resources instead ([`1295b6`](https://github.com/bdlukaa/fluent_ui/pull/875/commits/a195b58f4440c3c0febc595ba6f0b730a950a0d5))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## [next]
 
 - Add Slovak localization
+- Add direction to CommandBar to support verticality.
 
 ## 4.6.2
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 - Add Slovak localization
 - Add direction to CommandBar to support verticality.
+- Add direction to CommandBarSeparator to support horizontally.
+- Add direction to HorizontalScrollView to support verticality.
 
 ## 4.6.2
 

--- a/example/lib/screens/surface/commandbars.dart
+++ b/example/lib/screens/surface/commandbars.dart
@@ -195,6 +195,30 @@ CommandBar(
 ''',
         ),
         subtitle(
+            content: const Text('Simple command bar (no wrapping) (vertical)')),
+        CardHighlight(
+          child: CommandBar(
+            direction: Axis.vertical,
+            overflowBehavior: CommandBarOverflowBehavior.noWrap,
+            primaryItems: [
+              ...simpleCommandBarItems,
+            ],
+          ),
+          codeSnippet: '''
+/// Lists of CommandBarItem named as simpleCommandBarItems and moreCommandBarItems
+/// Used as following
+
+/// Generate CommandBar with different properties like overflowBehavior
+CommandBar(
+  direction: Axis.vertical,
+  overflowBehavior: CommandBarOverflowBehavior.noWrap,
+  primaryItems: [
+    ...simpleCommandBarItems,
+  ],
+);
+''',
+        ),
+        subtitle(
           content: const Text(
             'Command bar with many items (wrapping, auto-compact < 600px)',
           ),
@@ -226,6 +250,44 @@ CommandBar(
         ),
         subtitle(
           content: const Text(
+            'Command bar with many items (wrapping, auto-compact < 600px) (vertical)',
+          ),
+        ),
+        CardHighlight(
+          child: ConstrainedBox(
+            constraints: const BoxConstraints(maxHeight: 230),
+            child: CommandBar(
+              direction: Axis.vertical,
+              overflowBehavior: CommandBarOverflowBehavior.wrap,
+              compactBreakpointWidth: 600,
+              primaryItems: [
+                ...simpleCommandBarItems,
+                const CommandBarSeparator(direction: Axis.horizontal),
+                ...moreCommandBarItems,
+              ],
+            ),
+          ),
+          codeSnippet: '''
+/// Lists of CommandBarItem named as simpleCommandBarItems and moreCommandBarItems
+/// Used as following
+
+ConstrainedBox(
+  constraints: const BoxConstraints(maxHeight: 230),
+  child: CommandBar(
+    direction: Axis.vertical,
+    overflowBehavior: CommandBarOverflowBehavior.wrap,
+    compactBreakpointWidth: 600,
+    primaryItems: [
+      ...simpleCommandBarItems,
+      const CommandBarSeparator(direction: Axis.horizontal),
+      ...moreCommandBarItems,
+    ],
+  ),
+);
+''',
+        ),
+        subtitle(
+          content: const Text(
             'Carded compact command bar with many items (clipped)',
           ),
         ),
@@ -252,6 +314,48 @@ ConstrainedBox(
   constraints: const BoxConstraints(maxWidth: 230),
   child: CommandBarCard(
     child: CommandBar(
+      overflowBehavior: CommandBarOverflowBehavior.clip,
+      isCompact: true,
+      primaryItems: [
+        ...simpleCommandBarItems,
+        const CommandBarSeparator(),
+        ...moreCommandBarItems,
+      ],
+    ),
+  ),
+);
+''',
+        ),
+        subtitle(
+          content: const Text(
+            'Carded compact command bar with many items (clipped) (vertical)',
+          ),
+        ),
+        CardHighlight(
+          child: ConstrainedBox(
+            constraints: const BoxConstraints(maxHeight: 230),
+            child: CommandBarCard(
+              child: CommandBar(
+                direction: Axis.vertical,
+                overflowBehavior: CommandBarOverflowBehavior.clip,
+                isCompact: true,
+                primaryItems: [
+                  ...simpleCommandBarItems,
+                  const CommandBarSeparator(),
+                  ...moreCommandBarItems,
+                ],
+              ),
+            ),
+          ),
+          codeSnippet: '''
+/// Lists of CommandBarItem named as simpleCommandBarItems and moreCommandBarItems
+/// Used as following
+
+ConstrainedBox(
+  constraints: const BoxConstraints(maxHeight: 230),
+  child: CommandBarCard(
+    child: CommandBar(
+      direction: Axis.vertical,
       overflowBehavior: CommandBarOverflowBehavior.clip,
       isCompact: true,
       primaryItems: [
@@ -302,6 +406,50 @@ CommandBarCard(
         ),
         subtitle(
           content: const Text(
+            'Carded compact command bar with many items (dynamic overflow) (vertical)',
+          ),
+        ),
+        CardHighlight(
+          child: ConstrainedBox(
+            constraints: const BoxConstraints(maxHeight: 230),
+            child: CommandBarCard(
+              child: CommandBar(
+                direction: Axis.vertical,
+                overflowBehavior: CommandBarOverflowBehavior.dynamicOverflow,
+                primaryItems: [
+                  ...simpleCommandBarItems,
+                  const CommandBarSeparator(),
+                  ...moreCommandBarItems,
+                  const CommandBarSeparator(),
+                  ...evenMoreCommandBarItems,
+                ],
+              ),
+            ),
+          ),
+          codeSnippet: '''
+/// Create different lists of CommandBarItem
+/// named simpleCommandBarItems, moreCommandBarItems, evenMoreCommandBarItems
+/// These lists can be used as primaryItems as shown
+ConstrainedBox(
+  constraints: const BoxConstraints(maxHeight: 230),
+  child: CommandBarCard(
+    child: CommandBar(
+      direction: Axis.vertical,
+      overflowBehavior: CommandBarOverflowBehavior.dynamicOverflow,
+      primaryItems: [
+        ...simpleCommandBarItems,
+        const CommandBarSeparator(),
+        ...moreCommandBarItems,
+        const CommandBarSeparator(),
+        ...evenMoreCommandBarItems,
+      ],
+    ),
+  ),
+);
+''',
+        ),
+        subtitle(
+          content: const Text(
             'End-aligned command bar with many items (dynamic overflow, auto-compact < 900px)',
           ),
         ),
@@ -339,6 +487,51 @@ CommandBar(
         ),
         subtitle(
           content: const Text(
+            'End-aligned command bar with many items (dynamic overflow, auto-compact < 900px) (vertical)',
+          ),
+        ),
+        CardHighlight(
+          child: ConstrainedBox(
+            constraints: const BoxConstraints(maxHeight: 230),
+            child: CommandBar(
+              direction: Axis.vertical,
+              mainAxisAlignment: MainAxisAlignment.end,
+              overflowBehavior: CommandBarOverflowBehavior.dynamicOverflow,
+              compactBreakpointWidth: 900,
+              primaryItems: [
+                ...simpleCommandBarItems,
+                const CommandBarSeparator(),
+                ...moreCommandBarItems,
+                const CommandBarSeparator(),
+                ...evenMoreCommandBarItems,
+              ],
+            ),
+          ),
+          codeSnippet: '''
+/// Create different lists of CommandBarItem
+/// named simpleCommandBarItems, moreCommandBarItems, evenMoreCommandBarItems
+/// These lists can be used as primaryItems as shown
+
+ConstrainedBox(
+  constraints: const BoxConstraints(maxHeight: 230),
+  child: CommandBar(
+    direction: Axis.vertical,
+    mainAxisAlignment: MainAxisAlignment.end,
+    overflowBehavior: CommandBarOverflowBehavior.dynamicOverflow,
+    compactBreakpointWidth: 900,
+    primaryItems: [
+      ...simpleCommandBarItems,
+      const CommandBarSeparator(),
+      ...moreCommandBarItems,
+      const CommandBarSeparator(),
+      ...evenMoreCommandBarItems,
+    ],
+  ),
+);
+''',
+        ),
+        subtitle(
+          content: const Text(
             'End-aligned command bar with permanent secondary items (dynamic overflow)',
           ),
         ),
@@ -371,6 +564,46 @@ CommandBar(
         ),
         subtitle(
           content: const Text(
+            'End-aligned command bar with permanent secondary items (dynamic overflow) (vertical)',
+          ),
+        ),
+        CardHighlight(
+          child: ConstrainedBox(
+            constraints: const BoxConstraints(maxHeight: 230),
+            child: CommandBar(
+              direction: Axis.vertical,
+              mainAxisAlignment: MainAxisAlignment.end,
+              overflowBehavior: CommandBarOverflowBehavior.dynamicOverflow,
+              primaryItems: [
+                ...simpleCommandBarItems,
+                const CommandBarSeparator(),
+                ...moreCommandBarItems,
+              ],
+              secondaryItems: evenMoreCommandBarItems,
+            ),
+          ),
+          codeSnippet: '''
+/// Lists of CommandBarItem named as simpleCommandBarItems and moreCommandBarItems
+/// Used as following
+
+ConstrainedBox(
+  constraints: const BoxConstraints(maxHeight: 230),
+  child: CommandBar(
+    direction: Axis.vertical,
+    mainAxisAlignment: MainAxisAlignment.end,
+    overflowBehavior: CommandBarOverflowBehavior.dynamicOverflow,
+    primaryItems: [
+      ...simpleCommandBarItems,
+      const CommandBarSeparator(),
+      ...moreCommandBarItems,
+    ],
+    secondaryItems: evenMoreCommandBarItems,
+  ),
+);
+''',
+        ),
+        subtitle(
+          content: const Text(
             'Command bar with secondary items (wrapping)',
           ),
         ),
@@ -388,6 +621,36 @@ CommandBar(
   overflowBehavior: CommandBarOverflowBehavior.wrap,
   primaryItems: simpleCommandBarItems,
   secondaryItems: moreCommandBarItems,
+);
+''',
+        ),
+        subtitle(
+          content: const Text(
+            'Command bar with secondary items (wrapping) (vertical)',
+          ),
+        ),
+        CardHighlight(
+          child: ConstrainedBox(
+            constraints: const BoxConstraints(maxHeight: 230),
+            child: CommandBar(
+              direction: Axis.vertical,
+              overflowBehavior: CommandBarOverflowBehavior.wrap,
+              primaryItems: simpleCommandBarItems,
+              secondaryItems: moreCommandBarItems,
+            ),
+          ),
+          codeSnippet: '''
+/// Lists of CommandBarItem named as simpleCommandBarItems and moreCommandBarItems
+/// Used as following
+
+ConstrainedBox(
+  constraints: const BoxConstraints(maxHeight: 230),
+  child: CommandBar(
+    direction: Axis.vertical,
+    overflowBehavior: CommandBarOverflowBehavior.wrap,
+    primaryItems: simpleCommandBarItems,
+    secondaryItems: moreCommandBarItems,
+  ),
 );
 ''',
         ),
@@ -447,6 +710,77 @@ CommandBarCard(
         ],
       ),
     ],
+  ),
+);
+''',
+        ),
+        subtitle(
+          content: const Text(
+            'Carded complex command bar with many items (vertical scrolling) (vertical)',
+          ),
+        ),
+        CardHighlight(
+          child: ConstrainedBox(
+            constraints: const BoxConstraints(maxHeight: 230, maxWidth: 48),
+            child: CommandBarCard(
+              child: Column(
+                children: [
+                  Expanded(
+                    child: CommandBar(
+                      direction: Axis.vertical,
+                      overflowBehavior: CommandBarOverflowBehavior.scrolling,
+                      primaryItems: [
+                        ...simpleCommandBarItems,
+                        const CommandBarSeparator(direction: Axis.horizontal),
+                        ...moreCommandBarItems,
+                      ],
+                    ),
+                  ),
+                  // End-aligned button(s)
+                  CommandBar(
+                    direction: Axis.vertical,
+                    overflowBehavior: CommandBarOverflowBehavior.noWrap,
+                    primaryItems: [
+                      CommandBarButton(
+                        icon: const Icon(FluentIcons.refresh),
+                        onPressed: () {},
+                      ),
+                    ],
+                  ),
+                ],
+              ),
+            ),
+          ),
+          codeSnippet: '''
+ConstrainedBox(
+  constraints: const BoxConstraints(maxHeight: 230, maxWidth: 48),
+  child: CommandBarCard(
+    child: Column(
+      children: [
+        Expanded(
+          child: CommandBar(
+            direction: Axis.vertical,
+            overflowBehavior: CommandBarOverflowBehavior.scrolling,
+            primaryItems: [
+              ...simpleCommandBarItems,
+              const CommandBarSeparator(direction: Axis.horizontal),
+              ...moreCommandBarItems,
+            ],
+          ),
+        ),
+        // End-aligned button(s)
+        CommandBar(
+          direction: Axis.vertical,
+          overflowBehavior: CommandBarOverflowBehavior.noWrap,
+          primaryItems: [
+            CommandBarButton(
+              icon: const Icon(FluentIcons.refresh),
+              onPressed: () {},
+            ),
+          ],
+        ),
+      ],
+    ),
   ),
 );
 ''',
@@ -513,6 +847,83 @@ CommandBarCard(
         ],
       ),
     ],
+  ),
+);
+''',
+        ),
+        subtitle(
+          content: const Text(
+            'Carded complex command bar with many items (dynamic overflow) (vertical)',
+          ),
+        ),
+        CardHighlight(
+          child: ConstrainedBox(
+            constraints: const BoxConstraints(maxHeight: 330),
+            child: CommandBarCard(
+              child: Column(
+                children: [
+                  Expanded(
+                    child: CommandBar(
+                      direction: Axis.vertical,
+                      overflowBehavior:
+                          CommandBarOverflowBehavior.dynamicOverflow,
+                      overflowItemAlignment: MainAxisAlignment.end,
+                      primaryItems: [
+                        ...simpleCommandBarItems,
+                        const CommandBarSeparator(direction: Axis.horizontal),
+                        ...moreCommandBarItems,
+                      ],
+                      secondaryItems: evenMoreCommandBarItems,
+                    ),
+                  ),
+                  // End-aligned button(s)
+                  CommandBar(
+                    direction: Axis.vertical,
+                    overflowBehavior: CommandBarOverflowBehavior.noWrap,
+                    primaryItems: [
+                      CommandBarButton(
+                        icon: const Icon(FluentIcons.refresh),
+                        onPressed: () {},
+                      ),
+                    ],
+                  ),
+                ],
+              ),
+            ),
+          ),
+          codeSnippet: '''
+ConstrainedBox(
+  constraints: const BoxConstraints(maxHeight: 330),
+  child: CommandBarCard(
+    child: Column(
+      children: [
+        Expanded(
+          child: CommandBar(
+            direction: Axis.vertical,
+            overflowBehavior:
+                CommandBarOverflowBehavior.dynamicOverflow,
+            overflowItemAlignment: MainAxisAlignment.end,
+            primaryItems: [
+              ...simpleCommandBarItems,
+              const CommandBarSeparator(direction: Axis.horizontal),
+              ...moreCommandBarItems,
+            ],
+            secondaryItems: evenMoreCommandBarItems,
+          ),
+        ),
+        // End-aligned button(s)
+        CommandBar(
+          direction: Axis.vertical,
+          overflowBehavior: CommandBarOverflowBehavior.noWrap,
+          primaryItems: [
+            CommandBarButton(
+              icon: const Icon(FluentIcons.refresh),
+              onPressed: () {},
+            ),
+          ],
+        ),
+      ],
+    ),
   ),
 );
 ''',

--- a/lib/src/controls/surfaces/commandbar.dart
+++ b/lib/src/controls/surfaces/commandbar.dart
@@ -157,7 +157,8 @@ class CommandBar extends StatefulWidget {
   final bool _isExpanded;
 
   /// The direction of the command bar. The default is [Axis.horizontal].
-  /// If [direction] is [Axis.vertical], we recomment setting [isCompact] to true.
+  /// If [direction] is [Axis.vertical], we recomment setting [isCompact] to true,
+  /// and [crossAxisAlignment] to [CrossAxisAlignment.start].
   final Axis direction;
 
   /// Creates a command bar.
@@ -170,11 +171,15 @@ class CommandBar extends StatefulWidget {
     this.compactBreakpointWidth,
     bool? isCompact,
     this.mainAxisAlignment = MainAxisAlignment.start,
-    this.crossAxisAlignment = CrossAxisAlignment.center,
+    CrossAxisAlignment? crossAxisAlignment,
     this.overflowItemAlignment = MainAxisAlignment.end,
     this.direction = Axis.horizontal,
   })  : _isExpanded = overflowBehavior != CommandBarOverflowBehavior.noWrap,
-        isCompact = isCompact ?? direction == Axis.vertical;
+        isCompact = isCompact ?? direction == Axis.vertical,
+        crossAxisAlignment = crossAxisAlignment ??
+            (direction == Axis.vertical
+                ? CrossAxisAlignment.start
+                : CrossAxisAlignment.center);
 
   @override
   State<CommandBar> createState() => _CommandBarState();

--- a/lib/src/controls/surfaces/commandbar.dart
+++ b/lib/src/controls/surfaces/commandbar.dart
@@ -156,6 +156,10 @@ class CommandBar extends StatefulWidget {
 
   final bool _isExpanded;
 
+  /// The direction of the command bar. The default is [Axis.horizontal].
+  /// If [direction] is [Axis.vertical], we recomment setting [isCompact] to true.
+  final Axis direction;
+
   /// Creates a command bar.
   const CommandBar({
     super.key,
@@ -164,11 +168,13 @@ class CommandBar extends StatefulWidget {
     this.overflowItemBuilder,
     this.overflowBehavior = CommandBarOverflowBehavior.dynamicOverflow,
     this.compactBreakpointWidth,
-    this.isCompact,
+    bool? isCompact,
     this.mainAxisAlignment = MainAxisAlignment.start,
     this.crossAxisAlignment = CrossAxisAlignment.center,
     this.overflowItemAlignment = MainAxisAlignment.end,
-  }) : _isExpanded = overflowBehavior != CommandBarOverflowBehavior.noWrap;
+    this.direction = Axis.horizontal,
+  })  : _isExpanded = overflowBehavior != CommandBarOverflowBehavior.noWrap,
+        isCompact = isCompact ?? direction == Axis.vertical;
 
   @override
   State<CommandBar> createState() => _CommandBarState();
@@ -277,11 +283,14 @@ class _CommandBarState extends State<CommandBar> {
       );
     }
 
+    var listBuilder =
+        widget.direction == Axis.horizontal ? Row.new : Column.new;
+
     late Widget w;
     switch (widget.overflowBehavior) {
       case CommandBarOverflowBehavior.scrolling:
         w = HorizontalScrollView(
-          child: Row(
+          child: listBuilder.call(
             mainAxisAlignment: widget.mainAxisAlignment,
             crossAxisAlignment: widget.crossAxisAlignment,
             children: [
@@ -292,7 +301,7 @@ class _CommandBarState extends State<CommandBar> {
         );
         break;
       case CommandBarOverflowBehavior.noWrap:
-        w = Row(
+        w = listBuilder.call(
           mainAxisAlignment: widget.mainAxisAlignment,
           crossAxisAlignment: widget.crossAxisAlignment,
           children: [
@@ -303,6 +312,7 @@ class _CommandBarState extends State<CommandBar> {
         break;
       case CommandBarOverflowBehavior.wrap:
         w = Wrap(
+          direction: widget.direction,
           alignment: _getWrapAlignment(),
           crossAxisAlignment: _getWrapCrossAlignment(),
           children: [
@@ -341,7 +351,7 @@ class _CommandBarState extends State<CommandBar> {
         w = SingleChildScrollView(
           scrollDirection: Axis.horizontal,
           physics: const NeverScrollableScrollPhysics(),
-          child: Row(
+          child: listBuilder.call(
             mainAxisAlignment: widget.mainAxisAlignment,
             crossAxisAlignment: widget.crossAxisAlignment,
             children: [
@@ -353,7 +363,7 @@ class _CommandBarState extends State<CommandBar> {
         break;
     }
     if (widget._isExpanded) {
-      w = Row(children: [Expanded(child: w)]);
+      w = listBuilder.call(children: [Expanded(child: w)]);
     }
     return w;
   }

--- a/lib/src/controls/surfaces/commandbar.dart
+++ b/lib/src/controls/surfaces/commandbar.dart
@@ -289,7 +289,10 @@ class _CommandBarState extends State<CommandBar> {
     late Widget w;
     switch (widget.overflowBehavior) {
       case CommandBarOverflowBehavior.scrolling:
+        // Take care of the widget is not only scrolls horizontally,
+        // it depends on the direction of the command bar
         w = HorizontalScrollView(
+          scrollDirection: widget.direction,
           child: listBuilder.call(
             mainAxisAlignment: widget.mainAxisAlignment,
             crossAxisAlignment: widget.crossAxisAlignment,
@@ -324,6 +327,7 @@ class _CommandBarState extends State<CommandBar> {
       case CommandBarOverflowBehavior.dynamicOverflow:
         assert(overflowWidget != null);
         w = DynamicOverflow(
+          direction: widget.direction,
           alignment: widget.mainAxisAlignment,
           crossAxisAlignment: widget.crossAxisAlignment,
           alwaysDisplayOverflowWidget: widget.secondaryItems.isNotEmpty,
@@ -349,7 +353,7 @@ class _CommandBarState extends State<CommandBar> {
         break;
       case CommandBarOverflowBehavior.clip:
         w = SingleChildScrollView(
-          scrollDirection: Axis.horizontal,
+          scrollDirection: widget.direction,
           physics: const NeverScrollableScrollPhysics(),
           child: listBuilder.call(
             mainAxisAlignment: widget.mainAxisAlignment,
@@ -587,6 +591,7 @@ class CommandBarSeparator extends CommandBarItem {
     super.key,
     this.color,
     this.thickness,
+    this.direction = Axis.vertical,
   });
 
   /// Override the color used by the [Divider].
@@ -595,6 +600,10 @@ class CommandBarSeparator extends CommandBarItem {
   /// Override the separator thickness.
   final double? thickness;
 
+  /// The direction of the separator. Defaults to [Axis.vertical].
+  /// This attribute is opposite to [CommandBar. direction].
+  final Axis direction;
+
   @override
   Widget build(BuildContext context, CommandBarItemDisplayMode displayMode) {
     switch (displayMode) {
@@ -602,9 +611,12 @@ class CommandBarSeparator extends CommandBarItem {
       case CommandBarItemDisplayMode.inPrimaryCompact:
         return CommandBarItemInPrimary(
           child: ConstrainedBox(
-            constraints: const BoxConstraints(minHeight: 28),
+            constraints: BoxConstraints(
+              minHeight: direction == Axis.vertical ? 28 : 0,
+              minWidth: direction == Axis.horizontal ? 28 : 0,
+            ),
             child: Divider(
-              direction: Axis.vertical,
+              direction: direction,
               style: DividerThemeData(
                 thickness: thickness,
                 decoration: color != null ? BoxDecoration(color: color) : null,

--- a/lib/src/controls/surfaces/commandbar.dart
+++ b/lib/src/controls/surfaces/commandbar.dart
@@ -368,7 +368,7 @@ class _CommandBarState extends State<CommandBar> {
               if (overflowWidget != null) overflowWidget,
             ],
           ),
-        );
+        ).hideVerticalScrollbar(context);
         break;
     }
     if (widget._isExpanded) {

--- a/lib/src/controls/utils/scrollbar.dart
+++ b/lib/src/controls/utils/scrollbar.dart
@@ -529,3 +529,20 @@ class ScrollbarThemeData with Diagnosticable {
       ));
   }
 }
+
+/// Provider an extension method to hide vertical scrollbar.
+/// May this can help [SingleChildScrollView] looks better.
+extension ScrollViewExtension on SingleChildScrollView {
+  /// Use [ScrollConfiguration] as wrapper to hide vertical scrollbar.
+  Widget hideVerticalScrollbar(
+    BuildContext context, {
+    ScrollBehavior? behavior,
+  }) {
+    behavior ??= ScrollConfiguration.of(context);
+    var showScrollbar = scrollDirection != Axis.vertical;
+    return ScrollConfiguration(
+      behavior: behavior.copyWith(scrollbars: showScrollbar),
+      child: this,
+    );
+  }
+}

--- a/lib/src/utils/horizontal_scroll_view.dart
+++ b/lib/src/utils/horizontal_scroll_view.dart
@@ -79,7 +79,7 @@ class _HorizontalScrollViewState extends State<HorizontalScrollView> {
         physics: widget.scrollPhysics ?? const ClampingScrollPhysics(),
         controller: _controller,
         child: widget.child,
-      ),
+      ).hideVerticalScrollbar(context),
     );
   }
 }

--- a/lib/src/utils/horizontal_scroll_view.dart
+++ b/lib/src/utils/horizontal_scroll_view.dart
@@ -3,6 +3,8 @@ import 'package:flutter/gestures.dart';
 
 /// A specialized kind of [SingleChildScrollView] that only scrolls
 /// horizontally, and allows the mouse wheel to control scrolling.
+/// If vertical scrolling is indeed necessary, can set [scrollDirection]
+/// to [Axis.vertical] also.
 class HorizontalScrollView extends StatefulWidget {
   final Widget child;
   final ScrollPhysics? scrollPhysics;
@@ -13,11 +15,17 @@ class HorizontalScrollView extends StatefulWidget {
   /// unless the user has a trackpad.
   final bool mouseWheelScrolls;
 
+  /// The default is [Axis.horizontal], just like the file name.
+  /// However, as the demand develops, expanding this attribute
+  /// that does not match the file name.
+  final Axis scrollDirection;
+
   const HorizontalScrollView({
     super.key,
     required this.child,
     this.scrollPhysics,
     this.mouseWheelScrolls = true,
+    this.scrollDirection = Axis.horizontal,
   });
 
   @override
@@ -67,7 +75,7 @@ class _HorizontalScrollViewState extends State<HorizontalScrollView> {
             }
           : null,
       child: SingleChildScrollView(
-        scrollDirection: Axis.horizontal,
+        scrollDirection: widget.scrollDirection,
         physics: widget.scrollPhysics ?? const ClampingScrollPhysics(),
         controller: _controller,
         child: widget.child,


### PR DESCRIPTION
<!-- Add a description of what this PR is changing or adding, and why. Consider mentioning issues -->
Add direction to CommandBar to support verticality.
Sometimes, we need to place the command bar on the side. 
Just like this:
![image](https://github.com/bdlukaa/fluent_ui/assets/15630211/a287a6e5-5842-43d1-8515-34b4158de7ed)

When we set `direction` to `Axis.vertical`, the `isCompact` will default to true, if it is not set.

## Pre-launch Checklist

<!-- Mark all that applies -->

- [x] I have updated `CHANGELOG.md` with my changes <!-- REQUIRED --> 
- [x] I have run "dart format ." on the project <!-- REQUIRED --> 
- [x] I have added/updated relevant documentation