### PR TITLE
fix: remove top padding from `NavigationView` when `appBar` is provided

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - Tooltips are dismissed as soon as the mouse leaves ([#898](https://github.com/bdlukaa/fluent_ui/issues/898))
 - Added `FluentThemeData.selectionColor`, which defaults to the accent color normal shade ([#897](https://github.com/bdlukaa/fluent_ui/issues/897))
 - Flyout reverse transition duration is properly set ([#893](https://github.com/bdlukaa/fluent_ui/issues/893))
+- Remove view padding when app bar is provided ([#884](https://github.com/bdlukaa/fluent_ui/issues/884))
 
 ## 4.7.0
 

--- a/lib/src/controls/navigation/navigation_view/view.dart
+++ b/lib/src/controls/navigation/navigation_view/view.dart
@@ -306,6 +306,11 @@ class NavigationViewState extends State<NavigationView> {
     assert(debugCheckHasFluentLocalizations(context));
     assert(debugCheckHasMediaQuery(context));
     assert(debugCheckHasDirectionality(context));
+    assert(
+      widget.content != null || widget.pane != null,
+      'Either pane or '
+      'content must be provided',
+    );
 
     final brightness = FluentTheme.of(context).brightness;
     final theme = NavigationPaneTheme.of(context);
@@ -711,8 +716,9 @@ class NavigationViewState extends State<NavigationView> {
           Expanded(child: widget.content!),
         ]);
       } else {
-        throw 'Either pane or content must be provided';
+        return const SizedBox.shrink();
       }
+
       return Mica(
         backgroundColor: theme.backgroundColor,
         child: InheritedNavigationView(
@@ -734,7 +740,11 @@ class NavigationViewState extends State<NavigationView> {
         child: ScrollConfiguration(
           behavior: widget.pane?.scrollBehavior ??
               const NavigationViewScrollBehavior(),
-          child: child,
+          child: MediaQuery.removePadding(
+            context: context,
+            removeTop: widget.appBar != null,
+            child: child,
+          ),
         ),
       );
     });
@@ -856,10 +866,12 @@ class NavigationAppBar with Diagnosticable {
     });
   }
 
+  /// Determines the height of this app bar based on its height and the top
+  /// padding from the system.
+  @visibleForTesting
   double finalHeight(BuildContext context) {
     assert(debugCheckHasMediaQuery(context));
-    final topPadding = MediaQuery.viewPaddingOf(context).top;
-
+    final topPadding = MediaQuery.paddingOf(context).top;
     return height + topPadding;
   }
 }
@@ -941,7 +953,7 @@ class _NavigationAppBar extends StatelessWidget {
       default:
         return const SizedBox.shrink();
     }
-    final topPadding = MediaQuery.viewPaddingOf(context).top;
+    final topPadding = MediaQuery.paddingOf(context).top;
 
     return Container(
       color: appBar.backgroundColor,


### PR DESCRIPTION
<!-- Add a description of what this PR is changing or adding, and why. Consider mentioning issues -->

Fixes #884

_fake padding of `EdgeInsets.only(top: 43.0)`_
Before:
![image](https://github.com/bdlukaa/fluent_ui/assets/45696119/1c71d4c4-2689-46a8-8c53-52d293930638)

After:
![image](https://github.com/bdlukaa/fluent_ui/assets/45696119/d07a000f-69d2-40be-9136-cc78c982ad16)



## Pre-launch Checklist

<!-- Mark all that applies -->

- [x] I have updated `CHANGELOG.md` with my changes <!-- REQUIRED --> 
- [x] I have run "dart format ." on the project <!-- REQUIRED --> 
- [x] I have added/updated relevant documentation