### PR TITLE
Fixes leading/trailing widgets not centered in listTile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,8 @@
 ## [next]
 
 * fix: items not aligned centered in listtile ([#939](https://github.com/bdlukaa/fluent_ui/issues/939))
-  + added `itemsAlignment` to listTile constructor (defaults to `CrossAxisAlignment.center`)
-* add: added `itemsPadding` to listTile constructor (defaults to `kDefaultListTilePadding`)
+  + added `contentAlignment` to `ListTile`
+* Added `contentPadding` to `ListTile`
 
 ## 4.7.5
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## [next]
+
+* fix: items not aligned centered in listtile ([#939](https://github.com/bdlukaa/fluent_ui/issues/939))
+  + added `itemsAlignment` to listTile constructor (defaults to `CrossAxisAlignment.center`)
+* add: added `itemsPadding` to listTile constructor (defaults to `kDefaultListTilePadding`)
+
 ## 4.7.5
 
 * fix: do not enforce a tree view item on `TreeView` ([#934](https://github.com/bdlukaa/fluent_ui/issues/934))

--- a/lib/src/controls/surfaces/list_tile.dart
+++ b/lib/src/controls/surfaces/list_tile.dart
@@ -42,6 +42,8 @@ class ListTile extends StatelessWidget {
     this.autofocus = false,
     this.semanticLabel,
     this.cursor,
+    this.itemsAlignment = CrossAxisAlignment.center,
+    this.itemsPadding = kDefaultListTilePadding,
   })  : assert(
           subtitle != null ? title != null : true,
           'To have a subtitle, there must be a title',
@@ -67,6 +69,8 @@ class ListTile extends StatelessWidget {
     this.onSelectionChange,
     this.semanticLabel,
     this.cursor,
+    this.itemsAlignment = CrossAxisAlignment.center,
+    this.itemsPadding = kDefaultListTilePadding,
   }) : assert(
           subtitle != null ? title != null : true,
           'To have a subtitle, there must be a title',
@@ -154,6 +158,16 @@ class ListTile extends StatelessWidget {
   ///  * [SystemMouseCursors.click], which turns the mouse cursor to click
   final MouseCursor? cursor;
 
+  /// Whether to cemter the leading & trailing widgets along the cross-axis
+  ///
+  /// Defaults to CrossAxisAlignment.center
+  final CrossAxisAlignment itemsAlignment;
+
+  /// Padding applied to list tile content
+  ///
+  /// Defaults to [kDefaultListTilePadding]
+  final EdgeInsetsGeometry itemsPadding;
+
   @override
   void debugFillProperties(DiagnosticPropertiesBuilder properties) {
     super.debugFillProperties(properties);
@@ -217,7 +231,7 @@ class ListTile extends StatelessWidget {
         const placeholder = SizedBox(width: 12.0);
 
         final tile = Row(
-          crossAxisAlignment: CrossAxisAlignment.start,
+          crossAxisAlignment: itemsAlignment,
           children: [
             if (leading != null)
               Padding(
@@ -299,7 +313,7 @@ class ListTile extends StatelessWidget {
                         builder: (context, height, child) => Center(
                           child: Padding(
                             padding: EdgeInsets.symmetric(
-                              vertical: kDefaultListTilePadding.vertical,
+                              vertical: itemsPadding.vertical,
                             ),
                             child: Container(
                               height: height * 0.7,
@@ -322,7 +336,7 @@ class ListTile extends StatelessWidget {
                     placeholder,
                   Expanded(
                     child: Padding(
-                      padding: kDefaultListTilePadding,
+                      padding: itemsPadding,
                       child: tile,
                     ),
                   ),

--- a/lib/src/controls/surfaces/list_tile.dart
+++ b/lib/src/controls/surfaces/list_tile.dart
@@ -42,8 +42,8 @@ class ListTile extends StatelessWidget {
     this.autofocus = false,
     this.semanticLabel,
     this.cursor,
-    this.itemsAlignment = CrossAxisAlignment.center,
-    this.itemsPadding = kDefaultListTilePadding,
+    this.contentAlignment = CrossAxisAlignment.center,
+    this.contentPadding = kDefaultListTilePadding,
   })  : assert(
           subtitle != null ? title != null : true,
           'To have a subtitle, there must be a title',
@@ -69,8 +69,8 @@ class ListTile extends StatelessWidget {
     this.onSelectionChange,
     this.semanticLabel,
     this.cursor,
-    this.itemsAlignment = CrossAxisAlignment.center,
-    this.itemsPadding = kDefaultListTilePadding,
+    this.contentAlignment = CrossAxisAlignment.center,
+    this.contentPadding = kDefaultListTilePadding,
   }) : assert(
           subtitle != null ? title != null : true,
           'To have a subtitle, there must be a title',
@@ -158,15 +158,15 @@ class ListTile extends StatelessWidget {
   ///  * [SystemMouseCursors.click], which turns the mouse cursor to click
   final MouseCursor? cursor;
 
-  /// Whether to cemter the leading & trailing widgets along the cross-axis
+  /// How the children should be placed along the cross axis in a flex layout.
   ///
   /// Defaults to CrossAxisAlignment.center
-  final CrossAxisAlignment itemsAlignment;
+  final CrossAxisAlignment contentAlignment;
 
   /// Padding applied to list tile content
   ///
   /// Defaults to [kDefaultListTilePadding]
-  final EdgeInsetsGeometry itemsPadding;
+  final EdgeInsetsGeometry contentPadding;
 
   @override
   void debugFillProperties(DiagnosticPropertiesBuilder properties) {
@@ -231,7 +231,7 @@ class ListTile extends StatelessWidget {
         const placeholder = SizedBox(width: 12.0);
 
         final tile = Row(
-          crossAxisAlignment: itemsAlignment,
+          crossAxisAlignment: contentAlignment,
           children: [
             if (leading != null)
               Padding(
@@ -313,7 +313,7 @@ class ListTile extends StatelessWidget {
                         builder: (context, height, child) => Center(
                           child: Padding(
                             padding: EdgeInsets.symmetric(
-                              vertical: itemsPadding.vertical,
+                              vertical: contentPadding.vertical,
                             ),
                             child: Container(
                               height: height * 0.7,
@@ -336,7 +336,7 @@ class ListTile extends StatelessWidget {
                     placeholder,
                   Expanded(
                     child: Padding(
-                      padding: itemsPadding,
+                      padding: contentPadding,
                       child: tile,
                     ),
                   ),


### PR DESCRIPTION
<!-- Add a description of what this PR is changing or adding, and why. Consider mentioning issues -->
This PR fixes the leading/trailing widgets alignment on cross axis. As of now, it was aligning items on `CrossAxisAlignment.start`. Hence, the PR addresses that and introduces 2 new parameters named `itemsAlignment` & `itemsPadding`. The first defaults to `CrossAxisAlignment.center` and second defaults to `kDefaultListTilePadding`.

Closes https://github.com/bdlukaa/fluent_ui/issues/939

## Pre-launch Checklist

<!-- Mark all that applies -->

- [X] I have updated `CHANGELOG.md` with my changes <!-- REQUIRED --> 
- [X] I have run "dart format ." on the project <!-- REQUIRED --> 
- [X] I have added/updated relevant documentation