### PR TITLE
Fix TabView buttons render

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## [next]
 
 * fix: `ProgressRing` and `ProgressBar` now fit correctly the parent bounds ([#942](https://github.com/bdlukaa/fluent_ui/issues/942))
+* fix: `TabView` buttons was only rendered on hover. Now the buttons (add and scroll buttons) are always rendered.
 
 ## 4.7.6
 

--- a/lib/src/controls/navigation/tab_view.dart
+++ b/lib/src/controls/navigation/tab_view.dart
@@ -354,10 +354,10 @@ class _TabViewState extends State<TabView> {
         onPressed: onPressed,
         style: ButtonStyle(
           foregroundColor: ButtonState.resolveWith((states) {
-            if (states.isDisabled || states.isNone) {
+            if (states.isDisabled) {
               return FluentTheme.of(context)
                   .resources
-                  .controlAltFillColorDisabled;
+                  .accentTextFillColorDisabled;
             } else {
               return FluentTheme.of(context).inactiveColor;
             }


### PR DESCRIPTION
<!-- Add a description of what this PR is changing or adding, and why. Consider mentioning issues -->

Now: 

![image](https://github.com/bdlukaa/fluent_ui/assets/8223773/2aca082b-5687-4575-8194-290fab8511eb)

(Note that the scroll button look disabled, because we are at the end), otherwise:


![image](https://github.com/bdlukaa/fluent_ui/assets/8223773/6983f514-6366-4291-adcc-15b9c32177bd)



Before:

![image](https://github.com/bdlukaa/fluent_ui/assets/8223773/ef1dfbeb-fe06-43a1-8719-3a1d2e7d4dd6)

(Was only rendered on hover)

## Pre-launch Checklist

<!-- Mark all that applies -->

- [x] I have updated `CHANGELOG.md` with my changes <!-- REQUIRED --> 
- [x] I have run "dart format ." on the project <!-- REQUIRED --> 
- [x] I have added/updated relevant documentation