### PR TITLE
Use Fira Code mono width font for example code

### DIFF
--- a/example/lib/widgets/card_highlight.dart
+++ b/example/lib/widgets/card_highlight.dart
@@ -1,6 +1,7 @@
 import 'package:fluent_ui/fluent_ui.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_syntax_view/flutter_syntax_view.dart';
+import 'package:google_fonts/google_fonts.dart';
 
 class CardHighlight extends StatefulWidget {
   const CardHighlight({
@@ -118,10 +119,8 @@ class _CardHighlightState extends State<CardHighlight>
                 bottom: Radius.circular(6.0),
               ),
               child: SyntaxView(
-                code: widget.codeSnippet.replaceAll('  ', '    '),
-                syntaxTheme: theme.brightness.isDark
-                    ? SyntaxTheme.vscodeDark()
-                    : SyntaxTheme.vscodeLight(),
+                code: widget.codeSnippet,
+                syntaxTheme: getSyntaxTheme(theme),
               ),
             ),
           ),
@@ -167,3 +166,15 @@ const fluentHighlightTheme = {
   'strong': TextStyle(fontWeight: FontWeight.bold),
   'emphasis': TextStyle(fontStyle: FontStyle.italic),
 };
+
+SyntaxTheme getSyntaxTheme(FluentThemeData theme) {
+  final syntaxTheme = theme.brightness.isDark
+      ? SyntaxTheme.vscodeDark()
+      : SyntaxTheme.vscodeLight();
+
+  syntaxTheme.baseStyle = GoogleFonts.firaCode(
+    textStyle: syntaxTheme.baseStyle,
+  );
+
+  return syntaxTheme;
+}

--- a/example/macos/Flutter/GeneratedPluginRegistrant.swift
+++ b/example/macos/Flutter/GeneratedPluginRegistrant.swift
@@ -6,6 +6,7 @@ import FlutterMacOS
 import Foundation
 
 import macos_window_utils
+import path_provider_foundation
 import screen_retriever
 import system_theme
 import url_launcher_macos
@@ -13,6 +14,7 @@ import window_manager
 
 func RegisterGeneratedPlugins(registry: FlutterPluginRegistry) {
   MacOSWindowUtilsPlugin.register(with: registry.registrar(forPlugin: "MacOSWindowUtilsPlugin"))
+  PathProviderPlugin.register(with: registry.registrar(forPlugin: "PathProviderPlugin"))
   ScreenRetrieverPlugin.register(with: registry.registrar(forPlugin: "ScreenRetrieverPlugin"))
   SystemThemePlugin.register(with: registry.registrar(forPlugin: "SystemThemePlugin"))
   UrlLauncherPlugin.register(with: registry.registrar(forPlugin: "UrlLauncherPlugin"))

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -129,13 +129,21 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.3.1"
+  ffi:
+    dependency: transitive
+    description:
+      name: ffi
+      sha256: "7bf0adc28a23d395f19f3f1eb21dd7cfd1dd9f8e1c50051c069122e6853bc878"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.1.0"
   fluent_ui:
     dependency: "direct main"
     description:
       path: ".."
       relative: true
     source: path
-    version: "4.8.0"
+    version: "4.8.1"
   flutter:
     dependency: "direct main"
     description: flutter
@@ -213,6 +221,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "10.2.0"
+  google_fonts:
+    dependency: "direct main"
+    description:
+      name: google_fonts
+      sha256: f0b8d115a13ecf827013ec9fc883390ccc0e87a96ed5347a3114cac177ef18e8
+      url: "https://pub.dev"
+    source: hosted
+    version: "6.1.0"
   html:
     dependency: transitive
     description:
@@ -349,6 +365,54 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.8.3"
+  path_provider:
+    dependency: transitive
+    description:
+      name: path_provider
+      sha256: a1aa8aaa2542a6bc57e381f132af822420216c80d4781f7aa085ca3229208aaa
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.1.1"
+  path_provider_android:
+    dependency: transitive
+    description:
+      name: path_provider_android
+      sha256: e595b98692943b4881b219f0a9e3945118d3c16bd7e2813f98ec6e532d905f72
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.2.1"
+  path_provider_foundation:
+    dependency: transitive
+    description:
+      name: path_provider_foundation
+      sha256: "19314d595120f82aca0ba62787d58dde2cc6b5df7d2f0daf72489e38d1b57f2d"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.3.1"
+  path_provider_linux:
+    dependency: transitive
+    description:
+      name: path_provider_linux
+      sha256: f7a1fe3a634fe7734c8d3f2766ad746ae2a2884abe22e241a8b301bf5cac3279
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.2.1"
+  path_provider_platform_interface:
+    dependency: transitive
+    description:
+      name: path_provider_platform_interface
+      sha256: "94b1e0dd80970c1ce43d5d4e050a9918fce4f4a775e6142424c30a29a363265c"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.1.1"
+  path_provider_windows:
+    dependency: transitive
+    description:
+      name: path_provider_windows
+      sha256: "8bc9f22eee8690981c22aa7fc602f5c85b497a6fb2ceb35ee5a5e5ed85ad8170"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.2.1"
   petitparser:
     dependency: transitive
     description:
@@ -357,6 +421,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "6.0.1"
+  platform:
+    dependency: transitive
+    description:
+      name: platform
+      sha256: "0a279f0707af40c890e80b1e9df8bb761694c074ba7e1d4ab1bc4b728e200b59"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.1.3"
   plugin_platform_interface:
     dependency: transitive
     description:
@@ -578,6 +650,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.3.0"
+  win32:
+    dependency: transitive
+    description:
+      name: win32
+      sha256: "7c99c0e1e2fa190b48d25c81ca5e42036d5cac81430ef249027d97b0935c553f"
+      url: "https://pub.dev"
+    source: hosted
+    version: "5.1.0"
   window_manager:
     dependency: "direct main"
     description:
@@ -586,6 +666,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.3.7"
+  xdg_directories:
+    dependency: transitive
+    description:
+      name: xdg_directories
+      sha256: "589ada45ba9e39405c198fe34eb0f607cddb2108527e658136120892beac46d2"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.0.3"
   xml:
     dependency: transitive
     description:

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -28,6 +28,7 @@ dependencies:
       url: https://github.com/YehudaKremer/flutter_syntax_view.git
   go_router: ^10.0.0
   intl: ^0.18.0
+  google_fonts: ^6.1.0
 
 dev_dependencies:
   flutter_test:

--- a/example/windows/flutter/CMakeLists.txt
+++ b/example/windows/flutter/CMakeLists.txt
@@ -10,6 +10,11 @@ include(${EPHEMERAL_DIR}/generated_config.cmake)
 # https://github.com/flutter/flutter/issues/57146.
 set(WRAPPER_ROOT "${EPHEMERAL_DIR}/cpp_client_wrapper")
 
+# Set fallback configurations for older versions of the flutter tool.
+if (NOT DEFINED FLUTTER_TARGET_PLATFORM)
+  set(FLUTTER_TARGET_PLATFORM "windows-x64")
+endif()
+
 # === Flutter Library ===
 set(FLUTTER_LIBRARY "${EPHEMERAL_DIR}/flutter_windows.dll")
 
@@ -92,7 +97,7 @@ add_custom_command(
   COMMAND ${CMAKE_COMMAND} -E env
     ${FLUTTER_TOOL_ENVIRONMENT}
     "${FLUTTER_ROOT}/packages/flutter_tools/bin/tool_backend.bat"
-      windows-x64 $<CONFIG>
+      ${FLUTTER_TARGET_PLATFORM} $<CONFIG>
   VERBATIM
 )
 add_custom_target(flutter_assemble DEPENDS


### PR DESCRIPTION
<!-- Add a description of what this PR is changing or adding, and why. Consider mentioning issues -->

As a programmer I would prefer pre-formatted sample code to use a text style similar to most IDEs.

As such, this PR changes the current font (which is variable width) to Fira Code by loading it using the `google_fonts` package. Fira Code's ligatures have been automatically enabled as it seems, but I think it looks nice (of course there is no impact on copied code).

![image](https://github.com/bdlukaa/fluent_ui/assets/2611894/d3b1f79a-9f4a-42db-a10b-718995385179)

Tested on Windows 11 and web (Chrome) currently.

<!-- Mark all that applies -->

- [ ] I have updated `CHANGELOG.md` with my changes <!-- REQUIRED --> 
- [X] I have run "dart format ." on the project <!-- REQUIRED --> 
- [ ] I have added/updated relevant documentation