### PR TITLE
run example in linux

### DIFF
--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -44,7 +44,9 @@ void main() async {
 
   if (isDesktop) {
     await flutter_acrylic.Window.initialize();
-    await flutter_acrylic.Window.hideWindowControls();
+    if (defaultTargetPlatform == TargetPlatform.windows) {
+      await flutter_acrylic.Window.hideWindowControls();
+    }
     await WindowManager.instance.ensureInitialized();
     windowManager.waitUntilReadyToShow().then((_) async {
       await windowManager.setTitleBarStyle(


### PR DESCRIPTION
When running the example in Linux I got:

gdk_window_get_state: assertion 'GDK_IS_WINDOW (window)' failed

![image](https://github.com/bdlukaa/fluent_ui/assets/4116353/daabff9d-1e2f-4a89-bc78-a0a2130d6c64)

<!-- Add a description of what this PR is changing or adding, and why. Consider mentioning issues -->

## Pre-launch Checklist

<!-- Mark all that applies -->

- [ ] I have updated `CHANGELOG.md` with my changes <!-- REQUIRED --> 
- [x] I have run "dart format ." on the project <!-- REQUIRED --> 
- [ ] I have added/updated relevant documentation