### PR TITLE
fix: Let `Button` pass loosen constraints to it's child.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## next
+* fix: A child of `Button` has an unbound height constraint. ([#1039](https://github.com/bdlukaa/fluent_ui/issues/1039))
+
 ## 4.8.6
 
 * fix: Pop the menu flyout before than calling the close callback ([#1009](https://github.com/bdlukaa/fluent_ui/issues/1009))

--- a/lib/src/controls/inputs/buttons/base.dart
+++ b/lib/src/controls/inputs/buttons/base.dart
@@ -214,10 +214,10 @@ class _BaseButtonState extends State<BaseButton> {
                     ),
                 textAlign: TextAlign.center,
                 // used to align the child without expanding the button
-                child: Column(
-                  mainAxisSize: MainAxisSize.min,
-                  mainAxisAlignment: MainAxisAlignment.center,
-                  children: [widget.child],
+                child: Center(
+                  heightFactor: 1,
+                  widthFactor: 1,
+                  child: widget.child,
                 ),
               ),
             ),

--- a/test/button_test.dart
+++ b/test/button_test.dart
@@ -1,0 +1,49 @@
+import 'package:fluent_ui/fluent_ui.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  testWidgets(
+    'Test constraints',
+    (WidgetTester tester) async {
+      await tester.pumpWidget(Directionality(
+        textDirection: TextDirection.ltr,
+        child: FluentTheme(
+          data: FluentThemeData(),
+          child: Center(
+            child: ConstrainedBox(
+              constraints: const BoxConstraints(
+                minWidth: 10,
+                maxWidth: 100,
+                minHeight: 20,
+                maxHeight: 200,
+              ),
+              child: Button(
+                child: const SizedBox.shrink(),
+                onPressed: () {},
+              ),
+            ),
+          ),
+        ),
+      ));
+
+      var buttonBox = tester.firstRenderObject<RenderBox>(find.byType(Button));
+      var innerBox = tester.firstRenderObject<RenderBox>(find.byType(SizedBox));
+
+      expect(
+          buttonBox.constraints,
+          const BoxConstraints(
+            minWidth: 10,
+            maxWidth: 100,
+            minHeight: 20,
+            maxHeight: 200,
+          ));
+      expect(buttonBox.size.width, greaterThanOrEqualTo(10));
+      expect(buttonBox.size.height, greaterThanOrEqualTo(20));
+
+      expect(innerBox.constraints.smallest, Size.zero);
+      expect(innerBox.constraints.maxWidth, lessThanOrEqualTo(100));
+      expect(innerBox.constraints.maxHeight, lessThanOrEqualTo(200));
+      expect(innerBox.size, Size.zero);
+    },
+  );
+}


### PR DESCRIPTION
This PR fixes #1039.

I've replaced the `Column` with a `Center`. By setting the factors to `1`, I've prevented `Center` from expanding.
With this change, `Button` will satisfy the constraints with a minimal size. The constraints passed to the child are loosen. Therefor, the child's size can also be to small. This will result in a centered child.

Close #1039

## Pre-launch Checklist

<!-- Mark all that applies -->

- [x] I have updated `CHANGELOG.md` with my changes <!-- REQUIRED --> 
- [x] I have run "dart format ." on the project <!-- REQUIRED --> 
- [x] I have added/updated relevant documentation