### PR TITLE
fix: Slider thumb is correctly rendered

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
-## NEXT
-* feat: Added `fieldFlex` to the DatePicker to control the width.
+## next
+
+* feat: Added `DatePicker.fieldFlex` to control the width proportion of each field.
+* fix: `Slider` thumb is correct rendered when it's on the edges.
 
 ## 4.8.6
 

--- a/lib/src/controls/inputs/slider.dart
+++ b/lib/src/controls/inputs/slider.dart
@@ -382,6 +382,8 @@ class _SliderState extends State<Slider> {
 
 /// This is used to remove the padding the Material Slider adds automatically
 class _CustomTrackShape extends m.RoundedRectSliderTrackShape {
+  static const double _trackSidePadding = 10.0;
+
   @override
   Rect getPreferredRect({
     required RenderBox parentBox,
@@ -391,9 +393,9 @@ class _CustomTrackShape extends m.RoundedRectSliderTrackShape {
     bool isDiscrete = false,
   }) {
     final trackHeight = sliderTheme.trackHeight!;
-    final trackLeft = offset.dx;
+    final trackLeft = offset.dx + _trackSidePadding;
     final trackTop = offset.dy + (parentBox.size.height - trackHeight) / 2;
-    final trackWidth = parentBox.size.width;
+    final trackWidth = parentBox.size.width - (2 * _trackSidePadding);
     return Rect.fromLTWH(trackLeft, trackTop, trackWidth, trackHeight);
   }
 


### PR DESCRIPTION
fix #1038
The slider handle overflows or gets cut off 

## Pre-launch Checklist

<!-- Mark all that applies -->

- [x] I have updated `CHANGELOG.md` with my changes <!-- REQUIRED --> 
- [x] I have run "dart format ." on the project <!-- REQUIRED --> 
- [x] I have added/updated relevant documentation