### PR TITLE
feat: [DatePicker] Added `fieldFlex` as prop to control the width.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## NEXT
+* feat: Added `fieldFlex` to the DatePicker to control the width.
+
 ## 4.8.6
 
 * fix: Pop the menu flyout before than calling the close callback ([#1009](https://github.com/bdlukaa/fluent_ui/issues/1009))

--- a/example/lib/screens/forms/date_picker.dart
+++ b/example/lib/screens/forms/date_picker.dart
@@ -12,6 +12,7 @@ class DatePickerPage extends StatefulWidget {
 class _DatePickerPageState extends State<DatePickerPage> with PageMixin {
   DateTime? simpleTime;
   DateTime? hiddenTime;
+  DateTime? flexTime;
 
   bool showYear = true;
   bool showMonth = true;
@@ -102,6 +103,24 @@ DatePicker(
               selected: hiddenTime,
               onChanged: (v) => setState(() => hiddenTime = v),
               showYear: false,
+            ),
+          ),
+        ),
+        subtitle(content: const Text('A DatePicker with flex layout')),
+        CardHighlight(
+          codeSnippet: '''DateTime? selected;
+
+DatePicker(
+  selected: selected,
+  fieldFlex: const [2, 3, 2], // Same order as fieldOrder
+  onChanged: (time) => setState(() => selected = time),
+),''',
+          child: Align(
+            alignment: AlignmentDirectional.centerStart,
+            child: DatePicker(
+              selected: flexTime,
+              fieldFlex: const [2, 3, 2],
+              onChanged: (v) => setState(() => flexTime = v),
             ),
           ),
         ),


### PR DESCRIPTION
Hi, @bdlukaa, long time no see.

## Description 
Perhaps we need to support specifying the layout of date.

I referred to the writing method of fieldOrder and added the prop of fieldFlex in the DatePicker.

When the overall space is relatively limited: 

Before:
![image](https://github.com/bdlukaa/fluent_ui/assets/15630211/c8b11fe8-8d8f-4885-ae66-647cf34261a8)

After:
![image](https://github.com/bdlukaa/fluent_ui/assets/15630211/6ee8b338-bb3d-4cdb-8439-d6fa6582cf08)



## Pre-launch Checklist

- [x] I have updated `CHANGELOG.md` with my changes <!-- REQUIRED --> 
- [x] I have run "dart format ." on the project <!-- REQUIRED --> 
- [x] I have added/updated relevant documentation