### PR TITLE
feat: Added `NavigationView.onItemPressed` callback, called when item is on tap.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,12 +1,13 @@
 ## NEXT
 * fix: Scroll issue in `DatePicker`. ([#1054](https://github.com/bdlukaa/fluent_ui/issues/1054))
 * feat: Add `NumberBox.textInputAction` and `NumberBox.onEditingComplete` ([#1063](https://github.com/bdlukaa/fluent_ui/pull/1063))
+* feat: Added `NavigationView.onItemPressed` callback, called when the item is on tap.
 
 ## 4.8.7
 
 * fix: A child of `Button` has an unbound height constraint. ([#1039](https://github.com/bdlukaa/fluent_ui/issues/1039))
 * feat: Added `DatePicker.fieldFlex` to control the width proportion of each field. ([#1053](https://github.com/bdlukaa/fluent_ui/pull/1053))
-* fix: `Slider` thumb is correct rendered when it's on the edges. ([#1046](https://github.com/bdlukaa/fluent_ui/pull/1046)
+* fix: `Slider` thumb is correct rendered when it's on the edges. ([#1046](https://github.com/bdlukaa/fluent_ui/pull/1046))
 * feat: Added `TabView.addIconBuilder` ([#1047](https://github.com/bdlukaa/fluent_ui/pull/1047))
 
 ## 4.8.6

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 ## NEXT
 * fix: Scroll issue in `DatePicker`. ([#1054](https://github.com/bdlukaa/fluent_ui/issues/1054))
 * feat: Add `NumberBox.textInputAction` and `NumberBox.onEditingComplete` ([#1063](https://github.com/bdlukaa/fluent_ui/pull/1063))
-* feat: Added `NavigationView.onItemPressed` callback, called when the item is on tap.
+* feat: Added `NavigationView.onItemPressed` callback, called when the item is on tap ([#1067](https://github.com/bdlukaa/fluent_ui/pull/1067))
 
 ## 4.8.7
 

--- a/example/lib/screens/navigation/navigation_view.dart
+++ b/example/lib/screens/navigation/navigation_view.dart
@@ -287,6 +287,16 @@ NavigationView(
   ),
   pane: NavigationPane(
     selected: topIndex,
+    onItemPressed: (index) {
+      // Do anything you want to do, such as:
+      if (index == topIndex) {
+        if (displayMode == PaneDisplayMode.open) {
+          setState(() => this.displayMode = PaneDisplayMode.compact);
+        } else if (displayMode == PaneDisplayMode.compact) {
+          setState(() => this.displayMode = PaneDisplayMode.open);
+        }
+      }
+    },
     onChanged: (index) => setState(() => topIndex = index),
     displayMode: displayMode,
     items: items,
@@ -329,6 +339,16 @@ NavigationView(
             },
             pane: NavigationPane(
               selected: topIndex,
+              onItemPressed: (index) {
+                // Do anything you want to do, such as:
+                if (index == topIndex) {
+                  if (displayMode == PaneDisplayMode.open) {
+                    setState(() => this.displayMode = PaneDisplayMode.compact);
+                  } else if (displayMode == PaneDisplayMode.compact) {
+                    setState(() => this.displayMode = PaneDisplayMode.open);
+                  }
+                }
+              },
               onChanged: (index) => setState(() => topIndex = index),
               displayMode: displayMode,
               indicator: indicators[indicator],

--- a/lib/src/controls/navigation/navigation_view/pane.dart
+++ b/lib/src/controls/navigation/navigation_view/pane.dart
@@ -184,7 +184,7 @@ class NavigationPane with Diagnosticable {
   /// Called when the current index changes.
   final ValueChanged<int>? onChanged;
 
-  /// Called when the item is clicked.
+  /// Called when an item is pressed.
   final ValueChanged<int>? onItemPressed;
 
   /// The scroll controller used by the pane when [displayMode] is

--- a/lib/src/controls/navigation/navigation_view/pane.dart
+++ b/lib/src/controls/navigation/navigation_view/pane.dart
@@ -78,6 +78,7 @@ class NavigationPane with Diagnosticable {
     this.key,
     this.selected,
     this.onChanged,
+    this.onItemPressed,
     this.size,
     this.header,
     this.items = const [],
@@ -183,6 +184,9 @@ class NavigationPane with Diagnosticable {
   /// Called when the current index changes.
   final ValueChanged<int>? onChanged;
 
+  /// Called when the item is clicked.
+  final ValueChanged<int>? onItemPressed;
+
   /// The scroll controller used by the pane when [displayMode] is
   /// [PaneDisplayMode.compact] and [PaneDisplayMode.open].
   ///
@@ -223,6 +227,8 @@ class NavigationPane with Diagnosticable {
       ))
       ..add(IntProperty('selected', selected, ifNull: 'none'))
       ..add(ObjectFlagProperty('onChanged', onChanged, ifNull: 'disabled'))
+      ..add(ObjectFlagProperty('onItemPressed', onItemPressed,
+          ifNull: 'disabled'))
       ..add(DiagnosticsProperty<ScrollController>(
           'scrollController', scrollController))
       ..add(DiagnosticsProperty<NavigationPaneSize>('size', size))
@@ -232,6 +238,7 @@ class NavigationPane with Diagnosticable {
   /// Changes the selected item to [item].
   void changeTo(NavigationPaneItem item) {
     final index = effectiveIndexOf(item);
+    if (!index.isNegative) onItemPressed?.call(index);
     if (selected != index && !index.isNegative) onChanged?.call(index);
   }
 
@@ -333,6 +340,7 @@ class NavigationPane with Diagnosticable {
         other.autoSuggestBoxReplacement == autoSuggestBoxReplacement &&
         other.selected == selected &&
         other.onChanged == onChanged &&
+        other.onItemPressed == onItemPressed &&
         other.scrollController == scrollController &&
         other.indicator == indicator;
   }
@@ -351,6 +359,7 @@ class NavigationPane with Diagnosticable {
         autoSuggestBoxReplacement.hashCode ^
         selected.hashCode ^
         onChanged.hashCode ^
+        onItemPressed.hashCode ^
         scrollController.hashCode ^
         indicator.hashCode;
   }


### PR DESCRIPTION
## NavigationView.onItemPressed

When the same index is clicked, we hope to have a response event.
So I extended the `onItemPressed` method on the basis of `onChanged`.

As shown in the example, it is possible to control whether to open or compact the effects.


## Pre-launch Checklist

<!-- Mark all that applies -->

- [x] I have updated `CHANGELOG.md` with my changes <!-- REQUIRED --> 
- [x] I have run "dart format ." on the project <!-- REQUIRED --> 
- [x] I have added/updated relevant documentation