### PR TITLE
Fix: `PaneItem` Behavior in Compact Mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## NEXT
+* fix: Resolved issue where `PaneItem` within `PaneItemExpander` remained accessible in `NavigationPane` compact mode ([#1081](https://github.com/bdlukaa/fluent_ui/issues/1081))
+
 ## 4.9.0
 
 * fix: ¹ `DropDownButton.closeAfterClick` is now correctly applied. ² Added `MenuFlyoutItem.closeAfterClick`, which defaults to `true`. ([#1016](https://github.com/bdlukaa/fluent_ui/issues/1016))

--- a/lib/src/controls/navigation/navigation_view/pane_items.dart
+++ b/lib/src/controls/navigation/navigation_view/pane_items.dart
@@ -937,9 +937,9 @@ class _PaneItemExpanderMenuItem extends MenuFlyoutItemBase {
         forceEnabled: item.enabled,
         builder: (context, states) {
           final textStyle = (isSelected
-              ? navigationTheme.selectedTextStyle?.resolve(states)
-              : navigationTheme.unselectedTextStyle?.resolve(states))
-              ?? const TextStyle();
+                  ? navigationTheme.selectedTextStyle?.resolve(states)
+                  : navigationTheme.unselectedTextStyle?.resolve(states)) ??
+              const TextStyle();
           final iconTheme = IconThemeData(
             color: textStyle.color ??
                 (isSelected

--- a/lib/src/controls/navigation/navigation_view/pane_items.dart
+++ b/lib/src/controls/navigation/navigation_view/pane_items.dart
@@ -927,13 +927,26 @@ class _PaneItemExpanderMenuItem extends MenuFlyoutItemBase {
   Widget build(BuildContext context) {
     assert(debugCheckHasFluentTheme(context));
     final theme = FluentTheme.of(context);
+    final navigationTheme = NavigationPaneTheme.of(context);
     final size = Flyout.of(context).size;
     return Container(
       width: size.isEmpty ? null : size.width,
       padding: MenuFlyout.itemsPadding,
       child: HoverButton(
-        onPressed: onPressed,
+        onPressed: item.enabled ? onPressed : null,
+        forceEnabled: item.enabled,
         builder: (context, states) {
+          final textStyle = (isSelected
+              ? navigationTheme.selectedTextStyle?.resolve(states)
+              : navigationTheme.unselectedTextStyle?.resolve(states))
+              ?? const TextStyle();
+          final iconTheme = IconThemeData(
+            color: textStyle.color ??
+                (isSelected
+                    ? navigationTheme.selectedIconColor?.resolve(states)
+                    : navigationTheme.unselectedIconColor?.resolve(states)),
+            size: textStyle.fontSize ?? 16.0,
+          );
           return Container(
             padding: const EdgeInsets.symmetric(
               horizontal: 10.0,
@@ -951,11 +964,17 @@ class _PaneItemExpanderMenuItem extends MenuFlyoutItemBase {
             child: Row(mainAxisSize: MainAxisSize.min, children: [
               Padding(
                 padding: const EdgeInsetsDirectional.only(end: 12.0),
-                child: item.icon,
+                child: IconTheme.merge(
+                  data: iconTheme,
+                  child: item.icon,
+                ),
               ),
               Flexible(
                 fit: size.isEmpty ? FlexFit.loose : FlexFit.tight,
-                child: item.title ?? const SizedBox.shrink(),
+                child: DefaultTextStyle(
+                  style: textStyle,
+                  child: item.title ?? const SizedBox.shrink(),
+                ),
               ),
               if (item.infoBadge != null)
                 Padding(


### PR DESCRIPTION
Fix: Disabled `PaneItem` Still Accessible in Compact Mode of `NavigationPane`

**Description:**
This Pull Request addresses the issue where `PaneItem` widgets with `enabled: false` are still accessible when the `NavigationPane` is in `PaneDisplayMode.compact` mode.

**Changes Made:**
- Modified `pane_items.dart` to ensure that `onPressed` and `forceEnabled` values are correctly passed based on the `item.enabled` property.
- Updated the `builder` to merge the theme of the icon and title based on the `states`.

**Issue Reference:**
This PR resolves the bug where disabled `PaneItem` widgets can be navigated to when the `NavigationPane` is in compact mode, as described in the related issue: https://github.com/bdlukaa/fluent_ui/issues/1081

<!-- Add a description of what this PR is changing or adding, and why. Consider mentioning issues -->

## Pre-launch Checklist

<!-- Mark all that applies -->

- [x] I have updated `CHANGELOG.md` with my changes <!-- REQUIRED --> 
- [x] I have run "dart format ." on the project <!-- REQUIRED --> 
- [ ] I have added/updated relevant documentation