### PR TITLE
Change NavigationAppBar leading widget to be min width instead of fix…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 4.9.2
+
+- feat: `NavigationAppBar` `leading` widget is now a minimum of `kCompactNavigationPaneWidth` width instead of being fixed to this width ([#1103](https://github.com/bdlukaa/fluent_ui/pull/1103))
+
 ## 4.9.1
 
 - feat: ¹ `NumberBox` now supports precision greater than 4. ² Add `NumberBox.pattern`, `NumberBox.formatter`, `NumberBox.format` ([#1080](https://github.com/bdlukaa/fluent_ui/pull/1080))

--- a/lib/src/controls/navigation/navigation_view/view.dart
+++ b/lib/src/controls/navigation/navigation_view/view.dart
@@ -933,7 +933,10 @@ class NavigationAppBar with Diagnosticable {
       } else {
         return const SizedBox.shrink();
       }
-      widget = SizedBox(width: kCompactNavigationPaneWidth, child: widget);
+      widget = ConstrainedBox(
+          constraints:
+              const BoxConstraints(minWidth: kCompactNavigationPaneWidth),
+          child: widget);
       return widget;
     });
   }


### PR DESCRIPTION
`NavigationAppBar` `leading` widget is now a minimum of `kCompactNavigationPaneWidth` width instead of being fixed to this width (#1102)

## Pre-launch Checklist

<!-- Mark all that applies -->

- [X] I have updated `CHANGELOG.md` with my changes <!-- REQUIRED --> 
- [X] I have run "dart format ." on the project <!-- REQUIRED --> 
- [ ] I have added/updated relevant documentation