### PR TITLE
feat: [Picker] add `autoOpen` allow open panel auto when the widget is built

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 - feat: `NavigationAppBar` `leading` widget is now a minimum of `kCompactNavigationPaneWidth` width instead of being fixed to this width ([#1103](https://github.com/bdlukaa/fluent_ui/pull/1103))
 - feat: Add `TabView.stripBuilder` ([#1106](https://github.com/bdlukaa/fluent_ui/issues/1106))
+- feat: [Picker] add `autoOpen` allow open panel auto when the widget is built. ([#1112](https://github.com/bdlukaa/fluent_ui/pull/1112))
 
 ## 4.9.1
 

--- a/example/lib/screens/forms/date_picker.dart
+++ b/example/lib/screens/forms/date_picker.dart
@@ -13,6 +13,7 @@ class _DatePickerPageState extends State<DatePickerPage> with PageMixin {
   DateTime? simpleTime;
   DateTime? hiddenTime;
   DateTime? flexTime;
+  DateTime? autoOpenTime;
 
   bool showYear = true;
   bool showMonth = true;
@@ -121,6 +122,24 @@ DatePicker(
               selected: flexTime,
               fieldFlex: const [2, 3, 2],
               onChanged: (v) => setState(() => flexTime = v),
+            ),
+          ),
+        ),
+        subtitle(content: const Text('A DatePicker with panel auto open.')),
+        CardHighlight(
+          codeSnippet: '''DateTime? selected;
+
+DatePicker(
+  selected: selected,
+  onChanged: (time) => setState(() => selected = time),
+  autoOpen: true,
+),''',
+          child: Align(
+            alignment: AlignmentDirectional.centerStart,
+            child: DatePicker(
+              selected: autoOpenTime,
+              onChanged: (v) => setState(() => autoOpenTime = v),
+              autoOpen: true,
             ),
           ),
         ),

--- a/example/lib/screens/forms/time_picker.dart
+++ b/example/lib/screens/forms/time_picker.dart
@@ -13,6 +13,7 @@ class _TimePickerPageState extends State<TimePickerPage> with PageMixin {
   DateTime? simpleTime;
   DateTime? arrivalTime;
   DateTime? hhTime;
+  DateTime? autoOpenTime;
 
   @override
   Widget build(BuildContext context) {
@@ -90,6 +91,28 @@ TimePicker(
               selected: hhTime,
               onChanged: (v) => setState(() => hhTime = v),
               hourFormat: HourFormat.HH,
+            ),
+          ),
+        ),
+        subtitle(
+          content: const Text(
+            'A TimePicker with panel auto open.',
+          ),
+        ),
+        CardHighlight(
+          codeSnippet: '''DateTime? selected;
+        
+TimePicker(
+  selected: selected,
+  onChanged: (time) => setState(() => selected = time),
+  autoOpen: true,
+),''',
+          child: Align(
+            alignment: AlignmentDirectional.centerStart,
+            child: TimePicker(
+              selected: autoOpenTime,
+              onChanged: (v) => setState(() => autoOpenTime = v),
+              autoOpen: true,
             ),
           ),
         ),

--- a/lib/src/controls/form/pickers/date_picker.dart
+++ b/lib/src/controls/form/pickers/date_picker.dart
@@ -69,6 +69,7 @@ class DatePicker extends StatefulWidget {
     this.locale,
     this.fieldOrder,
     this.fieldFlex,
+    this.autoOpen = false,
   })  : startDate = startDate ?? DateTime.now().subtract(kYearDuration * 100),
         endDate = endDate ?? DateTime.now().add(kYearDuration * 25),
         assert(
@@ -167,6 +168,11 @@ class DatePicker extends StatefulWidget {
   /// * [getDateFlexFromLocale], which returns the flex of the fields based
   ///   on the current locale
   final List<int>? fieldFlex;
+
+  /// When first loaded, automatically open the panel.
+  ///
+  /// Defaults to false
+  final bool autoOpen;
 
   @override
   State<DatePicker> createState() => _DatePickerState();
@@ -317,6 +323,7 @@ class _DatePickerState extends State<DatePicker> {
           fieldFlex: fieldFlex,
         );
       },
+      autoOpen: widget.autoOpen,
       pickerHeight: widget.popupHeight,
       child: (context, open) => HoverButton(
         autofocus: widget.autofocus,

--- a/lib/src/controls/form/pickers/pickers.dart
+++ b/lib/src/controls/form/pickers/pickers.dart
@@ -311,11 +311,13 @@ class Picker extends StatefulWidget {
     required this.child,
     required this.pickerContent,
     required this.pickerHeight,
+    this.autoOpen = false,
   });
 
   final PickerBuilder child;
   final WidgetBuilder pickerContent;
   final double pickerHeight;
+  final bool autoOpen;
 
   @override
   State<Picker> createState() => _PickerState();
@@ -323,6 +325,16 @@ class Picker extends StatefulWidget {
 
 class _PickerState extends State<Picker> {
   late final GlobalKey _childKey = GlobalKey(debugLabel: '${widget.child} key');
+
+  @override
+  void initState() {
+    super.initState();
+    if (widget.autoOpen) {
+      WidgetsBinding.instance.addPostFrameCallback((_) {
+        open();
+      });
+    }
+  }
 
   Future<void> open() {
     assert(

--- a/lib/src/controls/form/pickers/time_picker.dart
+++ b/lib/src/controls/form/pickers/time_picker.dart
@@ -50,6 +50,7 @@ class TimePicker extends StatefulWidget {
     this.autofocus = false,
     this.minuteIncrement = 1,
     this.locale,
+    this.autoOpen = false,
   });
 
   /// The current date selected date.
@@ -101,6 +102,11 @@ class TimePicker extends StatefulWidget {
   ///
   /// If null, the system locale will be used.
   final Locale? locale;
+
+  /// When first loaded, automatically open the panel.
+  ///
+  /// Defaults to false
+  final bool autoOpen;
 
   bool get use24Format => [HourFormat.HH, HourFormat.H].contains(hourFormat);
 
@@ -227,6 +233,7 @@ class _TimePickerState extends State<TimePicker>
           locale: locale,
         );
       },
+      autoOpen: widget.autoOpen,
       child: (context, open) => HoverButton(
         focusNode: widget.focusNode,
         autofocus: widget.autofocus,


### PR DESCRIPTION
In some scenarios, we hope that time related forms will automatically pop up a panel when loaded to save the need for clicking again.

This PR affects `DatePicker`, `TimePicker`, and `Picker`

## Pre-launch Checklist

<!-- Mark all that applies -->

- [x] I have updated `CHANGELOG.md` with my changes <!-- REQUIRED --> 
- [x] I have run "dart format ." on the project <!-- REQUIRED --> 
- [x] I have added/updated relevant documentation