### PR TITLE
The EditableComboBox is missing the part that applies the style to the TextBox, so add it.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 4.9.3
+
+- fix : The EditableComboBox is missing the part that applies the style to the TextBox, so add it.
+
 ## 4.9.2
 
 - feat: `NavigationAppBar` `leading` widget is now a minimum of `kCompactNavigationPaneWidth` width instead of being fixed to this width ([#1103](https://github.com/bdlukaa/fluent_ui/pull/1103))

--- a/lib/src/controls/form/editable_combo_box.dart
+++ b/lib/src/controls/form/editable_combo_box.dart
@@ -164,6 +164,7 @@ class _EditableComboboxState<T> extends ComboBoxState<T> {
         return KeyEventResult.ignored;
       },
       child: TextBox(
+        style: widget.style,
         focusNode: focusNode,
         autofocus: widget.autofocus,
         controller: controller,


### PR DESCRIPTION
The EditableComboBox is missing the part that applies the style to the TextBox, so add it.

## Pre-launch Checklist

<!-- Mark all that applies -->

- [x] I have updated `CHANGELOG.md` with my changes <!-- REQUIRED --> 
- [x] I have run "dart format ." on the project <!-- REQUIRED --> 
- [ ] I have added/updated relevant documentation