### PR TITLE
Add support for reserved footer area

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 ## [next]
 
 - fix: Add missing properties (`closeIconSize`, `closeButtonStyle`) in `debugFillProperties` and `InfoBarThemeData.merge` ([#1128](https://github.com/bdlukaa/fluent_ui/issues/1128)
+- Added `reservedStripWidth` to `TabView` to ensure minimum drag area between tabs and footer, 
+  critical for window manipulation when used in title bar scenarios ([@1106](https://github.com/bdlukaa/fluent_ui/issues/1106))
 
 ## 4.9.2
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,7 @@
 ## [next]
 
 - fix: Add missing properties (`closeIconSize`, `closeButtonStyle`) in `debugFillProperties` and `InfoBarThemeData.merge` ([#1128](https://github.com/bdlukaa/fluent_ui/issues/1128)
-- Added `reservedStripWidth` to `TabView` to ensure minimum drag area between tabs and footer, 
-  critical for window manipulation when used in title bar scenarios ([@1106](https://github.com/bdlukaa/fluent_ui/issues/1106))
+- feat: Add `TabView.reservedStripWidth`, which adds a minimum empty area between the tabs and the tab view footer ([#1106](https://github.com/bdlukaa/fluent_ui/issues/1106))
 
 ## 4.9.2
 

--- a/example/lib/screens/navigation/tab_view.dart
+++ b/example/lib/screens/navigation/tab_view.dart
@@ -233,6 +233,7 @@ TabView(
             height: 400,
             child: TabView(
               tabs: tabs!,
+              reservedStripWidth: 100,
               currentIndex: currentIndex,
               onChanged: (index) => setState(() => currentIndex = index),
               tabWidthBehavior: tabWidthBehavior,

--- a/lib/src/controls/navigation/tab_view.dart
+++ b/lib/src/controls/navigation/tab_view.dart
@@ -171,16 +171,17 @@ class TabView extends StatefulWidget {
   /// Usually a [Text] widget.
   final Widget? footer;
 
-  /// Minimum reserved width at the end of tab strip to ensure space for window controls.
-  /// This area will be excluded when laying out tabs.
+  /// The minimum width reserved at the end of the tab strip.
+  ///
+  /// This reserved space ensures a consistent drag area for window manipulation 
+  /// (e.g., dragging, resizing) even when many tabs are present. This is particularly 
+  /// crucial when `TabView` is used in a title bar.
   ///
   /// When using TabView in a title bar, this space ensures minimum drag area even
   /// when many tabs are present. This is critical for window manipulation (dragging, etc)
   /// as it guarantees a consistent drag target regardless of tab count.
   ///
-  /// The reserved space is placed after the new tab button (if present)
-  /// and before the footer (if present). When tabs expand, they will not
-  /// encroach on this reserved area.
+  /// If `null`, no reserved width is enforced.
   final double? reservedStripWidth;
 
   /// The builder for the strip that contains the tabs.

--- a/lib/src/controls/navigation/tab_view.dart
+++ b/lib/src/controls/navigation/tab_view.dart
@@ -73,6 +73,7 @@ class TabView extends StatefulWidget {
     this.tabWidthBehavior = TabWidthBehavior.equal,
     this.header,
     this.footer,
+    this.reservedStripWidth,
     this.stripBuilder,
     this.closeDelayDuration = const Duration(seconds: 1),
   });
@@ -170,6 +171,18 @@ class TabView extends StatefulWidget {
   /// Usually a [Text] widget.
   final Widget? footer;
 
+  /// Minimum reserved width at the end of tab strip to ensure space for window controls.
+  /// This area will be excluded when laying out tabs.
+  ///
+  /// When using TabView in a title bar, this space ensures minimum drag area even
+  /// when many tabs are present. This is critical for window manipulation (dragging, etc)
+  /// as it guarantees a consistent drag target regardless of tab count.
+  ///
+  /// The reserved space is placed after the new tab button (if present)
+  /// and before the footer (if present). When tabs expand, they will not
+  /// encroach on this reserved area.
+  final double? reservedStripWidth;
+
   /// The builder for the strip that contains the tabs.
   final Widget Function(BuildContext context, Widget strip)? stripBuilder;
 
@@ -244,7 +257,8 @@ class TabView extends StatefulWidget {
         defaultValue: const Duration(seconds: 1),
       ))
       ..add(DoubleProperty('minTabWidth', minTabWidth, defaultValue: 80.0))
-      ..add(DoubleProperty('maxTabWidth', maxTabWidth, defaultValue: 240.0));
+      ..add(DoubleProperty('maxTabWidth', maxTabWidth, defaultValue: 240.0))
+      ..add(DoubleProperty('minFooterWidth', reservedStripWidth));
   }
 }
 
@@ -476,10 +490,11 @@ class _TabViewState extends State<TabView> {
                   'You can only create a TabView in a box with defined width',
                 );
 
-                preferredTabWidth =
-                    ((width - (widget.showNewButton ? _kButtonWidth : 0)) /
-                            widget.tabs.length)
-                        .clamp(widget.minTabWidth, widget.maxTabWidth);
+                preferredTabWidth = ((width -
+                            (widget.showNewButton ? _kButtonWidth : 0) -
+                            (widget.reservedStripWidth ?? 0)) /
+                        widget.tabs.length)
+                    .clamp(widget.minTabWidth, widget.maxTabWidth);
 
                 final Widget listView = Listener(
                   onPointerSignal: (PointerSignalEvent e) {
@@ -583,18 +598,22 @@ class _TabViewState extends State<TabView> {
                 }
 
                 final strip = Row(children: [
+                  // scroll buttons if needed
                   if (showScrollButtons)
                     direction == TextDirection.ltr
                         ? backwardButton()
                         : forwardButton(),
+                  // tabs area (flexible/expanded)
                   if (scrollable)
                     Expanded(child: listView)
                   else
                     Flexible(child: listView),
+                  // scroll buttons if needed
                   if (showScrollButtons)
                     direction == TextDirection.ltr
                         ? forwardButton()
                         : backwardButton(),
+                  // new tab button
                   if (widget.showNewButton)
                     Padding(
                       padding: const EdgeInsetsDirectional.only(
@@ -624,6 +643,9 @@ class _TabViewState extends State<TabView> {
                         localizations.newTabLabel,
                       ),
                     ),
+                  // reserved strip width
+                  if (widget.reservedStripWidth != null)
+                    SizedBox(width: widget.reservedStripWidth),
                 ]);
 
                 if (widget.stripBuilder != null) {


### PR DESCRIPTION
This PR resolves #1106 by adding support for **a guaranteed minimum space between tabs and footer** in `TabView`. This is particularly critical when using `TabView` in `TitleBar` to ensure there's always enough space for `DragToMoveArea`, regardless of the number of tabs.

### Changes:
1. Add `reservedStripWidth` property to TabView.
2. Modify tab width calculation to consider reserved space:
```dart
preferredTabWidth = ((width - 
   (widget.showNewButton ? _kButtonWidth : 0) - 
   (widget.reservedStripWidth ?? 0)) / widget.tabs.length)
   .clamp(widget.minTabWidth, widget.maxTabWidth);
````
3. Add reserved space in strip layout after new tab button:
````dart
// In strip children
if (widget.reservedStripWidth != null)
  SizedBox(width: widget.reservedStripWidth),
````

###  Example usage:
````dart
TabView(
  footer: const WindowButtons(),
  reservedStripWidth: 100.0,
  stripBuilder: (context, strip) {
    return DragToMoveArea(child: strip);
  },
  // ... other properties
)
````

### Pre-launch Checklist

<!-- Mark all that applies -->

- [x] I have updated `CHANGELOG.md` with my changes <!-- REQUIRED --> 
- [x] I have run "dart format ." on the project <!-- REQUIRED --> 
- [x] I have added/updated relevant documentation