### PR TITLE
Fix visibility of Tab's close button when onClosed is null

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## [next]
+
+- fix: hide Tab's close button when `onClosed` is null
+
 ## 4.10.0
 
 - fix: Add missing properties (`closeIconSize`, `closeButtonStyle`) in `debugFillProperties` and `InfoBarThemeData.merge` ([#1128](https://github.com/bdlukaa/fluent_ui/issues/1128)

--- a/lib/src/controls/navigation/tab_view/tab.dart
+++ b/lib/src/controls/navigation/tab_view/tab.dart
@@ -185,10 +185,10 @@ class Tab extends StatefulWidget {
   /// Usually an [Icon] widget.
   final Widget? closeIcon;
 
-  /// Called when clicking x-to-close button or when thec`Ctrl + T` or
+  /// Called when clicking x-to-close button or when the `Ctrl + T` or
   /// `Ctrl + F4` is executed
   ///
-  /// If null, the tab is not closeable
+  /// If null, the tab is not closeable and the close button will not be shown.
   final VoidCallback? onClosed;
 
   /// {@macro fluent_ui.controls.inputs.HoverButton.semanticLabel}
@@ -405,7 +405,8 @@ class TabState extends State<Tab>
                             ),
                           ),
                         ),
-                      if (widget.closeIcon != null &&
+                      if (widget.onClosed != null &&
+                          widget.closeIcon != null &&
                           (tab.visibilityMode ==
                                   CloseButtonVisibilityMode.always ||
                               (tab.visibilityMode ==


### PR DESCRIPTION
Added missing `isClosable` property to `Tab` widget to match WinUI 3's [TabViewItem.IsClosable](https://learn.microsoft.com/en-us/windows/winui/api/microsoft.ui.xaml.controls.tabviewitem.isclosable?view=winui-2.8) implementation. 

The property defaults to `true`. When `isClosable` is `false`:
- Close button is not shown
- Keyboard shortcuts (Ctrl+W, Ctrl+F4) are disabled

<!-- Mark all that applies -->

- [x] I have updated `CHANGELOG.md` with my changes <!-- REQUIRED --> 
- [x] I have run "dart format ." on the project <!-- REQUIRED --> 
- [x] I have added/updated relevant documentation