### PR TITLE
Command Bar Updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,23 @@
 - feat: Add `TextBox.cursorOpacityAnimates` (defaults to `FluentThemeData.cursorOpacityAnimates`, which defaults to `false`); default setting improves CPU/GPU efficiency while TextBox has focus ([#1164](https://github.com/bdlukaa/fluent_ui/issues/1164))
 - fix: `DatePicker` selectable range matches the one between `startDate` and `endDate`. [#1170](https://github.com/bdlukaa/fluent_ui/issues/1170)
 - fix: `ScaffoldPage` has a built-in color if no parent `NavigationView` is found. ([#1168](https://github.com/bdlukaa/fluent_ui/issues/1168))
+- feat: Added `CommandBarButton.closeAfterClick` ([#1149](https://github.com/bdlukaa/fluent_ui/issues/1149))
+- feat: Added `FlyoutController.showFlyout.buildTarget` ([#1173](https://github.com/bdlukaa/fluent_ui/issues/1173))
+  Primary items of the command bar are now accessible through the secondary flyout.
+- fix: `CommandBar` secondary menu preferred placement mode ([#1174](https://github.com/bdlukaa/fluent_ui/pull/1174))
+- feat: Added `FlyoutController.close` ([#1174](https://github.com/bdlukaa/fluent_ui/pull/1174))
+- feat: `CommandBarState` is now accessible, making it possible to open/close the secondary flyout programmatically ([#1174](https://github.com/bdlukaa/fluent_ui/pull/1174))
+  ```dart
+  final commandBarKey = GlobalKey<CommandBarState>();
+
+  CommandBar(
+    key: commandBarKey, 
+    ...,
+  ),
+  
+  commandBarKey.currentState?.toggleSecondaryMenu();
+  commandBarKey.currentState?.secondaryFlyoutController.close();
+  ```
 
 ## 4.10.0
 

--- a/example/lib/screens/surface/commandbars.dart
+++ b/example/lib/screens/surface/commandbars.dart
@@ -134,12 +134,13 @@ class _CommandBarsPageState extends State<CommandBarsPage> with PageMixin {
                 child: InfoLabel(
                   label: 'Compact breakpoint width',
                   child: NumberBox<double>(
-                      value: compactBreakpointWidth,
-                      onChanged: (value) {
-                        setState(() {
-                          compactBreakpointWidth = value;
-                        });
-                      }),
+                    value: compactBreakpointWidth,
+                    onChanged: (value) {
+                      setState(() {
+                        compactBreakpointWidth = value;
+                      });
+                    },
+                  ),
                 ),
               ),
               InfoLabel(
@@ -219,18 +220,21 @@ CommandBar(${compactBreakpointWidth != null ? '\n  compactBreakpointWidth: compa
 ''',
           child: SizedBox(
             height: _vertical ? 400.0 : null,
-            child: CommandBar(
-              compactBreakpointWidth: compactBreakpointWidth,
-              direction: _vertical ? Axis.vertical : Axis.horizontal,
-              isCompact: _compact,
-              overflowBehavior: overflowBehavior,
-              primaryItems: [
-                ...simpleCommandBarItems,
-                const CommandBarSeparator(),
-                ...moreCommandBarItems,
-                const CommandBarSeparator(),
-                ...evenMoreCommandBarItems,
-              ],
+            child: Align(
+              alignment: AlignmentDirectional.topStart,
+              child: CommandBar(
+                compactBreakpointWidth: compactBreakpointWidth,
+                direction: _vertical ? Axis.vertical : Axis.horizontal,
+                isCompact: _compact,
+                overflowBehavior: overflowBehavior,
+                primaryItems: [
+                  ...simpleCommandBarItems,
+                  const CommandBarSeparator(),
+                  ...moreCommandBarItems,
+                  const CommandBarSeparator(),
+                  ...evenMoreCommandBarItems,
+                ],
+              ),
             ),
           ),
         ),

--- a/example/lib/screens/surface/commandbars.dart
+++ b/example/lib/screens/surface/commandbars.dart
@@ -11,6 +11,8 @@ class CommandBarsPage extends StatefulWidget {
 }
 
 class _CommandBarsPageState extends State<CommandBarsPage> with PageMixin {
+  final key = GlobalKey<CommandBarState>();
+
   final simpleCommandBarItems = <CommandBarItem>[
     CommandBarButton(
       icon: const Icon(FluentIcons.add),
@@ -185,6 +187,12 @@ class _CommandBarsPageState extends State<CommandBarsPage> with PageMixin {
                 },
                 content: const Text('Compact'),
               ),
+              Button(
+                onPressed: () {
+                  key.currentState?.toggleSecondaryMenu();
+                },
+                child: const Text('Toggle secondary menu'),
+              ),
             ],
           ),
         ),
@@ -194,8 +202,10 @@ class _CommandBarsPageState extends State<CommandBarsPage> with PageMixin {
           ),
         ),
         CardHighlight(
-          codeSnippet: '''
-CommandBar(${compactBreakpointWidth != null ? '\n  compactBreakpointWidth: compactBreakpointWidth,' : ''}${_vertical ? '\n  direction: Axis.vertical,' : ''}${_compact ? '\n  isCompact: true,' : ''}
+          codeSnippet: '''final commandBarKey = GlobalKey<CommandBarState>();
+
+CommandBar(
+  key: commandBarKey, ${compactBreakpointWidth != null ? '\n  compactBreakpointWidth: compactBreakpointWidth,' : ''}${_vertical ? '\n  direction: Axis.vertical,' : ''}${_compact ? '\n  isCompact: true,' : ''}
   overflowBehavior: $overflowBehavior,
   primaryItems: [
     CommandBarButton(
@@ -216,13 +226,17 @@ CommandBar(${compactBreakpointWidth != null ? '\n  compactBreakpointWidth: compa
       },
     ),
   ],
-),
+);
+
+// To toggle the secondary menu
+commandBarKey.currentState?.toggleSecondaryMenu();
 ''',
           child: SizedBox(
             height: _vertical ? 400.0 : null,
             child: Align(
               alignment: AlignmentDirectional.topStart,
               child: CommandBar(
+                key: key,
                 compactBreakpointWidth: compactBreakpointWidth,
                 direction: _vertical ? Axis.vertical : Axis.horizontal,
                 isCompact: _compact,

--- a/example/lib/screens/surface/commandbars.dart
+++ b/example/lib/screens/surface/commandbars.dart
@@ -107,273 +107,122 @@ class _CommandBarsPageState extends State<CommandBarsPage> with PageMixin {
     ),
   ];
 
+  double? compactBreakpointWidth;
+  bool _vertical = false;
+  bool _compact = false;
+  var overflowBehavior = CommandBarOverflowBehavior.dynamicOverflow;
+
   @override
   Widget build(BuildContext context) {
     return ScaffoldPage.scrollable(
-      header: PageHeader(
-        title: const Text('CommandBar'),
-        commandBar: CommandBar(
-          mainAxisAlignment: MainAxisAlignment.end,
-          primaryItems: [
-            ...simpleCommandBarItems,
-          ],
-        ),
-      ),
+      header: const PageHeader(title: Text('CommandBar')),
       children: [
         const Text(
           'Command bars provide users with easy access to your app\'s most '
           'common tasks. Command bars can provide access to app-level or '
           'page-specific commands and can be used with any navigation pattern.',
         ),
-        subtitle(content: const Text('Simple command bar (no wrapping)')),
-        CardHighlight(
-          codeSnippet: '''
-/// Define list of CommandBarItem
-final simpleCommandBarItems = <CommandBarItem>[
-  CommandBarButton(
-    icon: const Icon(FluentIcons.add),
-    label: const Text('New'),
-    tooltip: 'Create something new!',
-    onPressed: () {},
-  ),
-  CommandBarButton(
-    icon: const Icon(FluentIcons.delete),
-    label: const Text('Delete'),
-    tooltip: 'Delete what is currently selected!',
-    onPressed: () {},
-  ),
-  CommandBarButton(
-    icon: const Icon(FluentIcons.archive),
-    label: const Text('Archive'),
-    onPressed: () {},
-  ),
-  CommandBarButton(
-    icon: const Icon(FluentIcons.move),
-    label: const Text('Move'),
-    onPressed: () {},
-  ),
-  const CommandBarButton(
-    icon: Icon(FluentIcons.cancel),
-    label: Text('Disabled'),
-    onPressed: null,
-  ),
-];
-
-/// Generate CommandBar with different properties like overflowBehavior
-CommandBar(
-  overflowBehavior: CommandBarOverflowBehavior.noWrap,
-  primaryItems: [
-    ...simpleCommandBarItems,
-  ],
-);
-''',
-          child: CommandBar(
-            overflowBehavior: CommandBarOverflowBehavior.noWrap,
-            primaryItems: [
-              ...simpleCommandBarItems,
-            ],
-          ),
-        ),
-        subtitle(
-            content: const Text('Simple command bar (no wrapping) (vertical)')),
-        CardHighlight(
-          codeSnippet: '''
-/// Lists of CommandBarItem named as simpleCommandBarItems and moreCommandBarItems
-/// Used as following
-
-/// Generate CommandBar with different properties like overflowBehavior
-CommandBar(
-  direction: Axis.vertical,
-  overflowBehavior: CommandBarOverflowBehavior.noWrap,
-  primaryItems: [
-    ...simpleCommandBarItems,
-  ],
-);
-''',
-          child: CommandBar(
-            direction: Axis.vertical,
-            overflowBehavior: CommandBarOverflowBehavior.noWrap,
-            primaryItems: [
-              ...simpleCommandBarItems,
+        const SizedBox(height: 8.0),
+        Card(
+          child: Wrap(
+            spacing: 12.0,
+            crossAxisAlignment: WrapCrossAlignment.end,
+            children: [
+              SizedBox(
+                width: 200.0,
+                child: InfoLabel(
+                  label: 'Compact breakpoint width',
+                  child: NumberBox<double>(
+                      value: compactBreakpointWidth,
+                      onChanged: (value) {
+                        setState(() {
+                          compactBreakpointWidth = value;
+                        });
+                      }),
+                ),
+              ),
+              InfoLabel(
+                label: 'Overflow behavior',
+                child: ComboBox<CommandBarOverflowBehavior>(
+                  value: overflowBehavior,
+                  items: CommandBarOverflowBehavior.values.map((behavior) {
+                    return ComboBoxItem<CommandBarOverflowBehavior>(
+                      value: behavior,
+                      child: Text(
+                        behavior.name
+                            .replaceAllMapped(
+                              RegExp(r'([a-z])([A-Z])'),
+                              (match) => '${match.group(1)} ${match.group(2)}',
+                            )
+                            .uppercaseFirst(),
+                      ),
+                    );
+                  }).toList(),
+                  onChanged: (value) {
+                    setState(() {
+                      overflowBehavior = value!;
+                    });
+                  },
+                ),
+              ),
+              Checkbox(
+                checked: _vertical,
+                onChanged: (value) {
+                  setState(() {
+                    _vertical = value!;
+                  });
+                },
+                content: const Text('Vertical'),
+              ),
+              Checkbox(
+                checked: _compact,
+                onChanged: (value) {
+                  setState(() {
+                    _compact = value!;
+                  });
+                },
+                content: const Text('Compact'),
+              ),
             ],
           ),
         ),
         subtitle(
           content: const Text(
-            'Command bar with many items (wrapping, auto-compact < 600px)',
+            'Command bar with many items (dynamic overflow)',
           ),
         ),
         CardHighlight(
           codeSnippet: '''
-/// Lists of CommandBarItem named as simpleCommandBarItems and moreCommandBarItems
-/// Used as following
-
-CommandBar(
-  overflowBehavior: CommandBarOverflowBehavior.wrap,
-  compactBreakpointWidth: 600,
+CommandBar(${compactBreakpointWidth != null ? '\n  compactBreakpointWidth: compactBreakpointWidth,' : ''}${_vertical ? '\n  direction: Axis.vertical,' : ''}${_compact ? '\n  isCompact: true,' : ''}
+  overflowBehavior: $overflowBehavior,
   primaryItems: [
-    ...simpleCommandBarItems,
+    CommandBarButton(
+      icon: const Icon(FluentIcons.add),
+      label: const Text('New'),
+      tooltip: 'Create something new!',
+      onPressed: () {
+        // Create something new!
+      },
+    ),
     const CommandBarSeparator(),
-    ...moreCommandBarItems,
+    CommandBarButton(
+      icon: const Icon(FluentIcons.delete),
+      label: const Text('Delete'),
+      tooltip: 'Delete what is currently selected!',
+      onPressed: () {
+        // Delete what is currently selected!
+      },
+    ),
   ],
-);
+),
 ''',
-          child: CommandBar(
-            overflowBehavior: CommandBarOverflowBehavior.wrap,
-            compactBreakpointWidth: 600,
-            primaryItems: [
-              ...simpleCommandBarItems,
-              const CommandBarSeparator(),
-              ...moreCommandBarItems,
-            ],
-          ),
-        ),
-        subtitle(
-          content: const Text(
-            'Command bar with many items (wrapping, auto-compact < 600px) (vertical)',
-          ),
-        ),
-        CardHighlight(
-          codeSnippet: '''
-/// Lists of CommandBarItem named as simpleCommandBarItems and moreCommandBarItems
-/// Used as following
-
-ConstrainedBox(
-  constraints: const BoxConstraints(maxHeight: 230),
-  child: CommandBar(
-    direction: Axis.vertical,
-    overflowBehavior: CommandBarOverflowBehavior.wrap,
-    compactBreakpointWidth: 600,
-    primaryItems: [
-      ...simpleCommandBarItems,
-      const CommandBarSeparator(direction: Axis.horizontal),
-      ...moreCommandBarItems,
-    ],
-  ),
-);
-''',
-          child: ConstrainedBox(
-            constraints: const BoxConstraints(maxHeight: 230),
+          child: SizedBox(
+            height: _vertical ? 400.0 : null,
             child: CommandBar(
-              direction: Axis.vertical,
-              overflowBehavior: CommandBarOverflowBehavior.wrap,
-              compactBreakpointWidth: 600,
-              primaryItems: [
-                ...simpleCommandBarItems,
-                const CommandBarSeparator(direction: Axis.horizontal),
-                ...moreCommandBarItems,
-              ],
-            ),
-          ),
-        ),
-        subtitle(
-          content: const Text(
-            'Carded compact command bar with many items (clipped)',
-          ),
-        ),
-        CardHighlight(
-          codeSnippet: '''
-/// Lists of CommandBarItem named as simpleCommandBarItems and moreCommandBarItems
-/// Used as following
-
-ConstrainedBox(
-  constraints: const BoxConstraints(maxWidth: 230),
-  child: CommandBarCard(
-    child: CommandBar(
-      overflowBehavior: CommandBarOverflowBehavior.clip,
-      isCompact: true,
-      primaryItems: [
-        ...simpleCommandBarItems,
-        const CommandBarSeparator(),
-        ...moreCommandBarItems,
-      ],
-    ),
-  ),
-);
-''',
-          child: ConstrainedBox(
-            constraints: const BoxConstraints(maxWidth: 230),
-            child: CommandBarCard(
-              child: CommandBar(
-                overflowBehavior: CommandBarOverflowBehavior.clip,
-                isCompact: true,
-                primaryItems: [
-                  ...simpleCommandBarItems,
-                  const CommandBarSeparator(),
-                  ...moreCommandBarItems,
-                ],
-              ),
-            ),
-          ),
-        ),
-        subtitle(
-          content: const Text(
-            'Carded compact command bar with many items (clipped) (vertical)',
-          ),
-        ),
-        CardHighlight(
-          codeSnippet: '''
-/// Lists of CommandBarItem named as simpleCommandBarItems and moreCommandBarItems
-/// Used as following
-
-ConstrainedBox(
-  constraints: const BoxConstraints(maxHeight: 230),
-  child: CommandBarCard(
-    child: CommandBar(
-      direction: Axis.vertical,
-      overflowBehavior: CommandBarOverflowBehavior.clip,
-      isCompact: true,
-      primaryItems: [
-        ...simpleCommandBarItems,
-        const CommandBarSeparator(),
-        ...moreCommandBarItems,
-      ],
-    ),
-  ),
-);
-''',
-          child: ConstrainedBox(
-            constraints: const BoxConstraints(maxHeight: 230),
-            child: CommandBarCard(
-              child: CommandBar(
-                direction: Axis.vertical,
-                overflowBehavior: CommandBarOverflowBehavior.clip,
-                isCompact: true,
-                primaryItems: [
-                  ...simpleCommandBarItems,
-                  const CommandBarSeparator(),
-                  ...moreCommandBarItems,
-                ],
-              ),
-            ),
-          ),
-        ),
-        subtitle(
-          content: const Text(
-            'Carded compact command bar with many items (dynamic overflow)',
-          ),
-        ),
-        CardHighlight(
-          codeSnippet: '''
-/// Create different lists of CommandBarItem
-/// named simpleCommandBarItems, moreCommandBarItems, evenMoreCommandBarItems
-/// These lists can be used as primaryItems as shown
-CommandBarCard(
-  child: CommandBar(
-    overflowBehavior: CommandBarOverflowBehavior.dynamicOverflow,
-    primaryItems: [
-      ...simpleCommandBarItems,
-      const CommandBarSeparator(),
-      ...moreCommandBarItems,
-      const CommandBarSeparator(),
-      ...evenMoreCommandBarItems,
-    ],
-  ),
-);
-''',
-          child: CommandBarCard(
-            child: CommandBar(
-              overflowBehavior: CommandBarOverflowBehavior.dynamicOverflow,
+              compactBreakpointWidth: compactBreakpointWidth,
+              direction: _vertical ? Axis.vertical : Axis.horizontal,
+              isCompact: _compact,
+              overflowBehavior: overflowBehavior,
               primaryItems: [
                 ...simpleCommandBarItems,
                 const CommandBarSeparator(),
@@ -381,530 +230,6 @@ CommandBarCard(
                 const CommandBarSeparator(),
                 ...evenMoreCommandBarItems,
               ],
-            ),
-          ),
-        ),
-        subtitle(
-          content: const Text(
-            'Carded compact command bar with many items (dynamic overflow) (vertical)',
-          ),
-        ),
-        CardHighlight(
-          codeSnippet: '''
-/// Create different lists of CommandBarItem
-/// named simpleCommandBarItems, moreCommandBarItems, evenMoreCommandBarItems
-/// These lists can be used as primaryItems as shown
-ConstrainedBox(
-  constraints: const BoxConstraints(maxHeight: 230),
-  child: CommandBarCard(
-    child: CommandBar(
-      direction: Axis.vertical,
-      overflowBehavior: CommandBarOverflowBehavior.dynamicOverflow,
-      primaryItems: [
-        ...simpleCommandBarItems,
-        const CommandBarSeparator(),
-        ...moreCommandBarItems,
-        const CommandBarSeparator(),
-        ...evenMoreCommandBarItems,
-      ],
-    ),
-  ),
-);
-''',
-          child: ConstrainedBox(
-            constraints: const BoxConstraints(maxHeight: 230),
-            child: CommandBarCard(
-              child: CommandBar(
-                direction: Axis.vertical,
-                overflowBehavior: CommandBarOverflowBehavior.dynamicOverflow,
-                primaryItems: [
-                  ...simpleCommandBarItems,
-                  const CommandBarSeparator(),
-                  ...moreCommandBarItems,
-                  const CommandBarSeparator(),
-                  ...evenMoreCommandBarItems,
-                ],
-              ),
-            ),
-          ),
-        ),
-        subtitle(
-          content: const Text(
-            'End-aligned command bar with many items (dynamic overflow, auto-compact < 900px)',
-          ),
-        ),
-        CardHighlight(
-          codeSnippet: '''
-/// Create different lists of CommandBarItem
-/// named simpleCommandBarItems, moreCommandBarItems, evenMoreCommandBarItems
-/// These lists can be used as primaryItems as shown
-
-CommandBar(
-  mainAxisAlignment: MainAxisAlignment.end,
-  overflowBehavior: CommandBarOverflowBehavior.dynamicOverflow,
-  compactBreakpointWidth: 900,
-  primaryItems: [
-    ...simpleCommandBarItems,
-    const CommandBarSeparator(),
-    ...moreCommandBarItems,
-    const CommandBarSeparator(),
-    ...evenMoreCommandBarItems,
-  ],
-);
-''',
-          child: CommandBar(
-            mainAxisAlignment: MainAxisAlignment.end,
-            overflowBehavior: CommandBarOverflowBehavior.dynamicOverflow,
-            compactBreakpointWidth: 900,
-            primaryItems: [
-              ...simpleCommandBarItems,
-              const CommandBarSeparator(),
-              ...moreCommandBarItems,
-              const CommandBarSeparator(),
-              ...evenMoreCommandBarItems,
-            ],
-          ),
-        ),
-        subtitle(
-          content: const Text(
-            'End-aligned command bar with many items (dynamic overflow, auto-compact < 900px) (vertical)',
-          ),
-        ),
-        CardHighlight(
-          codeSnippet: '''
-/// Create different lists of CommandBarItem
-/// named simpleCommandBarItems, moreCommandBarItems, evenMoreCommandBarItems
-/// These lists can be used as primaryItems as shown
-
-ConstrainedBox(
-  constraints: const BoxConstraints(maxHeight: 230),
-  child: CommandBar(
-    direction: Axis.vertical,
-    mainAxisAlignment: MainAxisAlignment.end,
-    overflowBehavior: CommandBarOverflowBehavior.dynamicOverflow,
-    compactBreakpointWidth: 900,
-    primaryItems: [
-      ...simpleCommandBarItems,
-      const CommandBarSeparator(),
-      ...moreCommandBarItems,
-      const CommandBarSeparator(),
-      ...evenMoreCommandBarItems,
-    ],
-  ),
-);
-''',
-          child: ConstrainedBox(
-            constraints: const BoxConstraints(maxHeight: 230),
-            child: CommandBar(
-              direction: Axis.vertical,
-              mainAxisAlignment: MainAxisAlignment.end,
-              overflowBehavior: CommandBarOverflowBehavior.dynamicOverflow,
-              compactBreakpointWidth: 900,
-              primaryItems: [
-                ...simpleCommandBarItems,
-                const CommandBarSeparator(),
-                ...moreCommandBarItems,
-                const CommandBarSeparator(),
-                ...evenMoreCommandBarItems,
-              ],
-            ),
-          ),
-        ),
-        subtitle(
-          content: const Text(
-            'End-aligned command bar with permanent secondary items (dynamic overflow)',
-          ),
-        ),
-        CardHighlight(
-          codeSnippet: '''
-/// Lists of CommandBarItem named as simpleCommandBarItems and moreCommandBarItems
-/// Used as following
-
-CommandBar(
-  mainAxisAlignment: MainAxisAlignment.end,
-  overflowBehavior: CommandBarOverflowBehavior.dynamicOverflow,
-  primaryItems: [
-    ...simpleCommandBarItems,
-    const CommandBarSeparator(),
-    ...moreCommandBarItems,
-  ],
-  secondaryItems: evenMoreCommandBarItems,
-);
-''',
-          child: CommandBar(
-            mainAxisAlignment: MainAxisAlignment.end,
-            overflowBehavior: CommandBarOverflowBehavior.dynamicOverflow,
-            primaryItems: [
-              ...simpleCommandBarItems,
-              const CommandBarSeparator(),
-              ...moreCommandBarItems,
-            ],
-            secondaryItems: evenMoreCommandBarItems,
-          ),
-        ),
-        subtitle(
-          content: const Text(
-            'End-aligned command bar with permanent secondary items (dynamic overflow) (vertical)',
-          ),
-        ),
-        CardHighlight(
-          codeSnippet: '''
-/// Lists of CommandBarItem named as simpleCommandBarItems and moreCommandBarItems
-/// Used as following
-
-ConstrainedBox(
-  constraints: const BoxConstraints(maxHeight: 230),
-  child: CommandBar(
-    direction: Axis.vertical,
-    mainAxisAlignment: MainAxisAlignment.end,
-    overflowBehavior: CommandBarOverflowBehavior.dynamicOverflow,
-    primaryItems: [
-      ...simpleCommandBarItems,
-      const CommandBarSeparator(),
-      ...moreCommandBarItems,
-    ],
-    secondaryItems: evenMoreCommandBarItems,
-  ),
-);
-''',
-          child: ConstrainedBox(
-            constraints: const BoxConstraints(maxHeight: 230),
-            child: CommandBar(
-              direction: Axis.vertical,
-              mainAxisAlignment: MainAxisAlignment.end,
-              overflowBehavior: CommandBarOverflowBehavior.dynamicOverflow,
-              primaryItems: [
-                ...simpleCommandBarItems,
-                const CommandBarSeparator(),
-                ...moreCommandBarItems,
-              ],
-              secondaryItems: evenMoreCommandBarItems,
-            ),
-          ),
-        ),
-        subtitle(
-          content: const Text(
-            'Command bar with secondary items (wrapping)',
-          ),
-        ),
-        CardHighlight(
-          codeSnippet: '''
-/// Lists of CommandBarItem named as simpleCommandBarItems and moreCommandBarItems
-/// Used as following
-
-CommandBar(
-  overflowBehavior: CommandBarOverflowBehavior.wrap,
-  primaryItems: simpleCommandBarItems,
-  secondaryItems: moreCommandBarItems,
-);
-''',
-          child: CommandBar(
-            overflowBehavior: CommandBarOverflowBehavior.wrap,
-            primaryItems: simpleCommandBarItems,
-            secondaryItems: moreCommandBarItems,
-          ),
-        ),
-        subtitle(
-          content: const Text(
-            'Command bar with secondary items (wrapping) (vertical)',
-          ),
-        ),
-        CardHighlight(
-          codeSnippet: '''
-/// Lists of CommandBarItem named as simpleCommandBarItems and moreCommandBarItems
-/// Used as following
-
-ConstrainedBox(
-  constraints: const BoxConstraints(maxHeight: 230),
-  child: CommandBar(
-    direction: Axis.vertical,
-    overflowBehavior: CommandBarOverflowBehavior.wrap,
-    primaryItems: simpleCommandBarItems,
-    secondaryItems: moreCommandBarItems,
-  ),
-);
-''',
-          child: ConstrainedBox(
-            constraints: const BoxConstraints(maxHeight: 230),
-            child: CommandBar(
-              direction: Axis.vertical,
-              overflowBehavior: CommandBarOverflowBehavior.wrap,
-              primaryItems: simpleCommandBarItems,
-              secondaryItems: moreCommandBarItems,
-            ),
-          ),
-        ),
-        subtitle(
-          content: const Text(
-            'Carded complex command bar with many items (horizontal scrolling)',
-          ),
-        ),
-        CardHighlight(
-          codeSnippet: '''
-CommandBarCard(
-    child: Row(children: [
-      Expanded(
-        child: CommandBar(
-          overflowBehavior: CommandBarOverflowBehavior.scrolling,
-          primaryItems: [
-            ...simpleCommandBarItems,
-            const CommandBarSeparator(),
-            ...moreCommandBarItems,
-          ],
-        ),
-      ),
-      // End-aligned button(s)
-      CommandBar(
-        overflowBehavior: CommandBarOverflowBehavior.noWrap,
-        primaryItems: [
-          CommandBarButton(
-            icon: const Icon(FluentIcons.refresh),
-            onPressed: () {},
-          ),
-        ],
-      ),
-    ],
-  ),
-);
-''',
-          child: CommandBarCard(
-            child: Row(
-              children: [
-                Expanded(
-                  child: CommandBar(
-                    overflowBehavior: CommandBarOverflowBehavior.scrolling,
-                    primaryItems: [
-                      ...simpleCommandBarItems,
-                      const CommandBarSeparator(),
-                      ...moreCommandBarItems,
-                    ],
-                  ),
-                ),
-                // End-aligned button(s)
-                CommandBar(
-                  overflowBehavior: CommandBarOverflowBehavior.noWrap,
-                  primaryItems: [
-                    CommandBarButton(
-                      icon: const Icon(FluentIcons.refresh),
-                      onPressed: () {},
-                    ),
-                  ],
-                ),
-              ],
-            ),
-          ),
-        ),
-        subtitle(
-          content: const Text(
-            'Carded complex command bar with many items (vertical scrolling) (vertical)',
-          ),
-        ),
-        CardHighlight(
-          codeSnippet: '''
-ConstrainedBox(
-  constraints: const BoxConstraints(maxHeight: 230, maxWidth: 48),
-  child: CommandBarCard(
-    child: Column(
-      children: [
-        Expanded(
-          child: CommandBar(
-            direction: Axis.vertical,
-            overflowBehavior: CommandBarOverflowBehavior.scrolling,
-            primaryItems: [
-              ...simpleCommandBarItems,
-              const CommandBarSeparator(direction: Axis.horizontal),
-              ...moreCommandBarItems,
-            ],
-          ),
-        ),
-        // End-aligned button(s)
-        CommandBar(
-          direction: Axis.vertical,
-          overflowBehavior: CommandBarOverflowBehavior.noWrap,
-          primaryItems: [
-            CommandBarButton(
-              icon: const Icon(FluentIcons.refresh),
-              onPressed: () {},
-            ),
-          ],
-        ),
-      ],
-    ),
-  ),
-);
-''',
-          child: ConstrainedBox(
-            constraints: const BoxConstraints(maxHeight: 230, maxWidth: 48),
-            child: CommandBarCard(
-              child: Column(
-                children: [
-                  Expanded(
-                    child: CommandBar(
-                      direction: Axis.vertical,
-                      overflowBehavior: CommandBarOverflowBehavior.scrolling,
-                      primaryItems: [
-                        ...simpleCommandBarItems,
-                        const CommandBarSeparator(direction: Axis.horizontal),
-                        ...moreCommandBarItems,
-                      ],
-                    ),
-                  ),
-                  // End-aligned button(s)
-                  CommandBar(
-                    direction: Axis.vertical,
-                    overflowBehavior: CommandBarOverflowBehavior.noWrap,
-                    primaryItems: [
-                      CommandBarButton(
-                        icon: const Icon(FluentIcons.refresh),
-                        onPressed: () {},
-                      ),
-                    ],
-                  ),
-                ],
-              ),
-            ),
-          ),
-        ),
-        subtitle(
-          content: const Text(
-            'Carded complex command bar with many items (dynamic overflow)',
-          ),
-        ),
-        CardHighlight(
-          codeSnippet: '''
-CommandBarCard(
-  child: Row(
-    children: [
-      Expanded(
-        child: CommandBar(
-          overflowBehavior: CommandBarOverflowBehavior.dynamicOverflow,
-          overflowItemAlignment: MainAxisAlignment.end,
-          primaryItems: [
-            ...simpleCommandBarItems,
-            const CommandBarSeparator(),
-            ...moreCommandBarItems,
-          ],
-          secondaryItems: evenMoreCommandBarItems,
-        ),
-      ),
-      // End-aligned button(s)
-      CommandBar(
-        overflowBehavior: CommandBarOverflowBehavior.noWrap,
-        primaryItems: [
-          CommandBarButton(
-            icon: const Icon(FluentIcons.refresh),
-            onPressed: () {},
-          ),
-        ],
-      ),
-    ],
-  ),
-);
-''',
-          child: CommandBarCard(
-            child: Row(
-              children: [
-                Expanded(
-                  child: CommandBar(
-                    overflowBehavior:
-                        CommandBarOverflowBehavior.dynamicOverflow,
-                    overflowItemAlignment: MainAxisAlignment.end,
-                    primaryItems: [
-                      ...simpleCommandBarItems,
-                      const CommandBarSeparator(),
-                      ...moreCommandBarItems,
-                    ],
-                    secondaryItems: evenMoreCommandBarItems,
-                  ),
-                ),
-                // End-aligned button(s)
-                CommandBar(
-                  overflowBehavior: CommandBarOverflowBehavior.noWrap,
-                  primaryItems: [
-                    CommandBarButton(
-                      icon: const Icon(FluentIcons.refresh),
-                      onPressed: () {},
-                    ),
-                  ],
-                ),
-              ],
-            ),
-          ),
-        ),
-        subtitle(
-          content: const Text(
-            'Carded complex command bar with many items (dynamic overflow) (vertical)',
-          ),
-        ),
-        CardHighlight(
-          codeSnippet: '''
-ConstrainedBox(
-  constraints: const BoxConstraints(maxHeight: 330),
-  child: CommandBarCard(
-    child: Column(
-      children: [
-        Expanded(
-          child: CommandBar(
-            direction: Axis.vertical,
-            overflowBehavior:
-                CommandBarOverflowBehavior.dynamicOverflow,
-            overflowItemAlignment: MainAxisAlignment.end,
-            primaryItems: [
-              ...simpleCommandBarItems,
-              const CommandBarSeparator(direction: Axis.horizontal),
-              ...moreCommandBarItems,
-            ],
-            secondaryItems: evenMoreCommandBarItems,
-          ),
-        ),
-        // End-aligned button(s)
-        CommandBar(
-          direction: Axis.vertical,
-          overflowBehavior: CommandBarOverflowBehavior.noWrap,
-          primaryItems: [
-            CommandBarButton(
-              icon: const Icon(FluentIcons.refresh),
-              onPressed: () {},
-            ),
-          ],
-        ),
-      ],
-    ),
-  ),
-);
-''',
-          child: ConstrainedBox(
-            constraints: const BoxConstraints(maxHeight: 330),
-            child: CommandBarCard(
-              child: Column(
-                children: [
-                  Expanded(
-                    child: CommandBar(
-                      direction: Axis.vertical,
-                      overflowBehavior:
-                          CommandBarOverflowBehavior.dynamicOverflow,
-                      overflowItemAlignment: MainAxisAlignment.end,
-                      primaryItems: [
-                        ...simpleCommandBarItems,
-                        const CommandBarSeparator(direction: Axis.horizontal),
-                        ...moreCommandBarItems,
-                      ],
-                      secondaryItems: evenMoreCommandBarItems,
-                    ),
-                  ),
-                  // End-aligned button(s)
-                  CommandBar(
-                    direction: Axis.vertical,
-                    overflowBehavior: CommandBarOverflowBehavior.noWrap,
-                    primaryItems: [
-                      CommandBarButton(
-                        icon: const Icon(FluentIcons.refresh),
-                        onPressed: () {},
-                      ),
-                    ],
-                  ),
-                ],
-              ),
             ),
           ),
         ),

--- a/example/lib/screens/surface/commandbars.dart
+++ b/example/lib/screens/surface/commandbars.dart
@@ -126,6 +126,7 @@ class _CommandBarsPageState extends State<CommandBarsPage> with PageMixin {
         Card(
           child: Wrap(
             spacing: 12.0,
+            runSpacing: 12.0,
             crossAxisAlignment: WrapCrossAlignment.end,
             children: [
               SizedBox(

--- a/example/lib/screens/surface/commandbars.dart
+++ b/example/lib/screens/surface/commandbars.dart
@@ -12,27 +12,17 @@ class CommandBarsPage extends StatefulWidget {
 
 class _CommandBarsPageState extends State<CommandBarsPage> with PageMixin {
   final simpleCommandBarItems = <CommandBarItem>[
-    CommandBarBuilderItem(
-      builder: (context, mode, w) => Tooltip(
-        message: "Create something new!",
-        child: w,
-      ),
-      wrappedItem: CommandBarButton(
-        icon: const Icon(FluentIcons.add),
-        label: const Text('New'),
-        onPressed: () {},
-      ),
+    CommandBarButton(
+      icon: const Icon(FluentIcons.add),
+      label: const Text('New'),
+      tooltip: 'Create something new!',
+      onPressed: () {},
     ),
-    CommandBarBuilderItem(
-      builder: (context, mode, w) => Tooltip(
-        message: "Delete what is currently selected!",
-        child: w,
-      ),
-      wrappedItem: CommandBarButton(
-        icon: const Icon(FluentIcons.delete),
-        label: const Text('Delete'),
-        onPressed: () {},
-      ),
+    CommandBarButton(
+      icon: const Icon(FluentIcons.delete),
+      label: const Text('Delete'),
+      tooltip: 'Delete what is currently selected!',
+      onPressed: () {},
     ),
     CommandBarButton(
       icon: const Icon(FluentIcons.archive),
@@ -140,27 +130,17 @@ class _CommandBarsPageState extends State<CommandBarsPage> with PageMixin {
           codeSnippet: '''
 /// Define list of CommandBarItem
 final simpleCommandBarItems = <CommandBarItem>[
-  CommandBarBuilderItem(
-    builder: (context, mode, w) => Tooltip(
-      message: "Create something new!",
-      child: w,
-    ),
-    wrappedItem: CommandBarButton(
-      icon: const Icon(FluentIcons.add),
-      label: const Text('New'),
-      onPressed: () {},
-    ),
+  CommandBarButton(
+    icon: const Icon(FluentIcons.add),
+    label: const Text('New'),
+    tooltip: 'Create something new!',
+    onPressed: () {},
   ),
-  CommandBarBuilderItem(
-    builder: (context, mode, w) => Tooltip(
-      message: "Delete what is currently selected!",
-      child: w,
-    ),
-    wrappedItem: CommandBarButton(
-      icon: const Icon(FluentIcons.delete),
-      label: const Text('Delete'),
-      onPressed: () {},
-    ),
+  CommandBarButton(
+    icon: const Icon(FluentIcons.delete),
+    label: const Text('Delete'),
+    tooltip: 'Delete what is currently selected!',
+    onPressed: () {},
   ),
   CommandBarButton(
     icon: const Icon(FluentIcons.archive),

--- a/lib/l10n/generated/fluent_localizations.dart
+++ b/lib/l10n/generated/fluent_localizations.dart
@@ -355,6 +355,18 @@ abstract class FluentLocalizations {
   /// **'year'**
   String get year;
 
+  /// The text used by [CommandBar] to show more items.
+  ///
+  /// In en, this message translates to:
+  /// **'See more'**
+  String get seeMore;
+
+  /// The text used by [CommandBar] to show less items.
+  ///
+  /// In en, this message translates to:
+  /// **'See less'**
+  String get seeLess;
+
   /// Label for red color component in color picker
   ///
   /// In en, this message translates to:

--- a/lib/l10n/generated/fluent_localizations_ar.dart
+++ b/lib/l10n/generated/fluent_localizations_ar.dart
@@ -100,6 +100,12 @@ class FluentLocalizationsAr extends FluentLocalizations {
   String get year => 'سنة';
 
   @override
+  String get seeMore => 'See more';
+
+  @override
+  String get seeLess => 'See less';
+
+  @override
   String get redLabel => 'أحمر';
 
   @override

--- a/lib/l10n/generated/fluent_localizations_be.dart
+++ b/lib/l10n/generated/fluent_localizations_be.dart
@@ -100,6 +100,12 @@ class FluentLocalizationsBe extends FluentLocalizations {
   String get year => 'год';
 
   @override
+  String get seeMore => 'See more';
+
+  @override
+  String get seeLess => 'See less';
+
+  @override
   String get redLabel => 'Чырвоны';
 
   @override

--- a/lib/l10n/generated/fluent_localizations_bn.dart
+++ b/lib/l10n/generated/fluent_localizations_bn.dart
@@ -101,6 +101,12 @@ class FluentLocalizationsBn extends FluentLocalizations {
   String get year => 'বছর';
 
   @override
+  String get seeMore => 'See more';
+
+  @override
+  String get seeLess => 'See less';
+
+  @override
   String get redLabel => 'লাল';
 
   @override

--- a/lib/l10n/generated/fluent_localizations_ca.dart
+++ b/lib/l10n/generated/fluent_localizations_ca.dart
@@ -103,6 +103,12 @@ class FluentLocalizationsCa extends FluentLocalizations {
   String get year => 'any';
 
   @override
+  String get seeMore => 'See more';
+
+  @override
+  String get seeLess => 'See less';
+
+  @override
   String get redLabel => 'Vermell';
 
   @override

--- a/lib/l10n/generated/fluent_localizations_cs.dart
+++ b/lib/l10n/generated/fluent_localizations_cs.dart
@@ -101,6 +101,12 @@ class FluentLocalizationsCs extends FluentLocalizations {
   String get year => 'rok';
 
   @override
+  String get seeMore => 'See more';
+
+  @override
+  String get seeLess => 'See less';
+
+  @override
   String get redLabel => 'Červená';
 
   @override

--- a/lib/l10n/generated/fluent_localizations_de.dart
+++ b/lib/l10n/generated/fluent_localizations_de.dart
@@ -103,6 +103,12 @@ class FluentLocalizationsDe extends FluentLocalizations {
   String get year => 'Jahr';
 
   @override
+  String get seeMore => 'See more';
+
+  @override
+  String get seeLess => 'See less';
+
+  @override
   String get redLabel => 'Rot';
 
   @override

--- a/lib/l10n/generated/fluent_localizations_el.dart
+++ b/lib/l10n/generated/fluent_localizations_el.dart
@@ -103,6 +103,12 @@ class FluentLocalizationsEl extends FluentLocalizations {
   String get year => 'έτος';
 
   @override
+  String get seeMore => 'See more';
+
+  @override
+  String get seeLess => 'See less';
+
+  @override
   String get redLabel => 'Κόκκινο';
 
   @override

--- a/lib/l10n/generated/fluent_localizations_en.dart
+++ b/lib/l10n/generated/fluent_localizations_en.dart
@@ -102,6 +102,12 @@ class FluentLocalizationsEn extends FluentLocalizations {
   String get year => 'year';
 
   @override
+  String get seeMore => 'See more';
+
+  @override
+  String get seeLess => 'See less';
+
+  @override
   String get redLabel => 'Red';
 
   @override

--- a/lib/l10n/generated/fluent_localizations_es.dart
+++ b/lib/l10n/generated/fluent_localizations_es.dart
@@ -103,6 +103,12 @@ class FluentLocalizationsEs extends FluentLocalizations {
   String get year => 'año';
 
   @override
+  String get seeMore => 'See more';
+
+  @override
+  String get seeLess => 'See less';
+
+  @override
   String get redLabel => 'Rojo';
 
   @override

--- a/lib/l10n/generated/fluent_localizations_fa.dart
+++ b/lib/l10n/generated/fluent_localizations_fa.dart
@@ -101,6 +101,12 @@ class FluentLocalizationsFa extends FluentLocalizations {
   String get year => 'سال';
 
   @override
+  String get seeMore => 'See more';
+
+  @override
+  String get seeLess => 'See less';
+
+  @override
   String get redLabel => 'قرمز';
 
   @override

--- a/lib/l10n/generated/fluent_localizations_fr.dart
+++ b/lib/l10n/generated/fluent_localizations_fr.dart
@@ -103,6 +103,12 @@ class FluentLocalizationsFr extends FluentLocalizations {
   String get year => 'année';
 
   @override
+  String get seeMore => 'See more';
+
+  @override
+  String get seeLess => 'See less';
+
+  @override
   String get redLabel => 'Rouge';
 
   @override

--- a/lib/l10n/generated/fluent_localizations_he.dart
+++ b/lib/l10n/generated/fluent_localizations_he.dart
@@ -100,6 +100,12 @@ class FluentLocalizationsHe extends FluentLocalizations {
   String get year => 'שנה';
 
   @override
+  String get seeMore => 'See more';
+
+  @override
+  String get seeLess => 'See less';
+
+  @override
   String get redLabel => 'אדום';
 
   @override

--- a/lib/l10n/generated/fluent_localizations_hi.dart
+++ b/lib/l10n/generated/fluent_localizations_hi.dart
@@ -102,6 +102,12 @@ class FluentLocalizationsHi extends FluentLocalizations {
   String get year => 'साल';
 
   @override
+  String get seeMore => 'See more';
+
+  @override
+  String get seeLess => 'See less';
+
+  @override
   String get redLabel => 'लाल';
 
   @override

--- a/lib/l10n/generated/fluent_localizations_hr.dart
+++ b/lib/l10n/generated/fluent_localizations_hr.dart
@@ -102,6 +102,12 @@ class FluentLocalizationsHr extends FluentLocalizations {
   String get year => 'godina';
 
   @override
+  String get seeMore => 'See more';
+
+  @override
+  String get seeLess => 'See less';
+
+  @override
   String get redLabel => 'Crvena';
 
   @override

--- a/lib/l10n/generated/fluent_localizations_hu.dart
+++ b/lib/l10n/generated/fluent_localizations_hu.dart
@@ -101,6 +101,12 @@ class FluentLocalizationsHu extends FluentLocalizations {
   String get year => 'év';
 
   @override
+  String get seeMore => 'See more';
+
+  @override
+  String get seeLess => 'See less';
+
+  @override
   String get redLabel => 'Vörös';
 
   @override

--- a/lib/l10n/generated/fluent_localizations_id.dart
+++ b/lib/l10n/generated/fluent_localizations_id.dart
@@ -102,6 +102,12 @@ class FluentLocalizationsId extends FluentLocalizations {
   String get year => 'tahun';
 
   @override
+  String get seeMore => 'See more';
+
+  @override
+  String get seeLess => 'See less';
+
+  @override
   String get redLabel => 'Merah';
 
   @override

--- a/lib/l10n/generated/fluent_localizations_it.dart
+++ b/lib/l10n/generated/fluent_localizations_it.dart
@@ -100,6 +100,12 @@ class FluentLocalizationsIt extends FluentLocalizations {
   String get year => 'anno';
 
   @override
+  String get seeMore => 'See more';
+
+  @override
+  String get seeLess => 'See less';
+
+  @override
   String get redLabel => 'Rosso';
 
   @override

--- a/lib/l10n/generated/fluent_localizations_ja.dart
+++ b/lib/l10n/generated/fluent_localizations_ja.dart
@@ -100,6 +100,12 @@ class FluentLocalizationsJa extends FluentLocalizations {
   String get year => '年';
 
   @override
+  String get seeMore => 'See more';
+
+  @override
+  String get seeLess => 'See less';
+
+  @override
   String get redLabel => '赤';
 
   @override

--- a/lib/l10n/generated/fluent_localizations_ko.dart
+++ b/lib/l10n/generated/fluent_localizations_ko.dart
@@ -100,6 +100,12 @@ class FluentLocalizationsKo extends FluentLocalizations {
   String get year => '년';
 
   @override
+  String get seeMore => 'See more';
+
+  @override
+  String get seeLess => 'See less';
+
+  @override
   String get redLabel => '빨강';
 
   @override

--- a/lib/l10n/generated/fluent_localizations_ku.dart
+++ b/lib/l10n/generated/fluent_localizations_ku.dart
@@ -102,6 +102,12 @@ class FluentLocalizationsKu extends FluentLocalizations {
   String get year => 'ساڵ';
 
   @override
+  String get seeMore => 'See more';
+
+  @override
+  String get seeLess => 'See less';
+
+  @override
   String get redLabel => 'سوور';
 
   @override

--- a/lib/l10n/generated/fluent_localizations_ms.dart
+++ b/lib/l10n/generated/fluent_localizations_ms.dart
@@ -102,6 +102,12 @@ class FluentLocalizationsMs extends FluentLocalizations {
   String get year => 'year';
 
   @override
+  String get seeMore => 'See more';
+
+  @override
+  String get seeLess => 'See less';
+
+  @override
   String get redLabel => 'Merah';
 
   @override

--- a/lib/l10n/generated/fluent_localizations_my.dart
+++ b/lib/l10n/generated/fluent_localizations_my.dart
@@ -100,6 +100,12 @@ class FluentLocalizationsMy extends FluentLocalizations {
   String get year => 'နှစ်';
 
   @override
+  String get seeMore => 'See more';
+
+  @override
+  String get seeLess => 'See less';
+
+  @override
   String get redLabel => 'အနီ';
 
   @override

--- a/lib/l10n/generated/fluent_localizations_nl.dart
+++ b/lib/l10n/generated/fluent_localizations_nl.dart
@@ -102,6 +102,12 @@ class FluentLocalizationsNl extends FluentLocalizations {
   String get year => 'jaar';
 
   @override
+  String get seeMore => 'See more';
+
+  @override
+  String get seeLess => 'See less';
+
+  @override
   String get redLabel => 'Rood';
 
   @override

--- a/lib/l10n/generated/fluent_localizations_pl.dart
+++ b/lib/l10n/generated/fluent_localizations_pl.dart
@@ -100,6 +100,12 @@ class FluentLocalizationsPl extends FluentLocalizations {
   String get year => 'year';
 
   @override
+  String get seeMore => 'See more';
+
+  @override
+  String get seeLess => 'See less';
+
+  @override
   String get redLabel => 'Czerwony';
 
   @override

--- a/lib/l10n/generated/fluent_localizations_pt.dart
+++ b/lib/l10n/generated/fluent_localizations_pt.dart
@@ -103,6 +103,12 @@ class FluentLocalizationsPt extends FluentLocalizations {
   String get year => 'ano';
 
   @override
+  String get seeMore => 'Mostrar mais';
+
+  @override
+  String get seeLess => 'Mostrar menos';
+
+  @override
   String get redLabel => 'Vermelho';
 
   @override

--- a/lib/l10n/generated/fluent_localizations_ro.dart
+++ b/lib/l10n/generated/fluent_localizations_ro.dart
@@ -102,6 +102,12 @@ class FluentLocalizationsRo extends FluentLocalizations {
   String get year => 'an';
 
   @override
+  String get seeMore => 'See more';
+
+  @override
+  String get seeLess => 'See less';
+
+  @override
   String get redLabel => 'Roșu';
 
   @override

--- a/lib/l10n/generated/fluent_localizations_ru.dart
+++ b/lib/l10n/generated/fluent_localizations_ru.dart
@@ -100,6 +100,12 @@ class FluentLocalizationsRu extends FluentLocalizations {
   String get year => 'year';
 
   @override
+  String get seeMore => 'See more';
+
+  @override
+  String get seeLess => 'See less';
+
+  @override
   String get redLabel => 'Красный';
 
   @override

--- a/lib/l10n/generated/fluent_localizations_sk.dart
+++ b/lib/l10n/generated/fluent_localizations_sk.dart
@@ -102,6 +102,12 @@ class FluentLocalizationsSk extends FluentLocalizations {
   String get year => 'rok';
 
   @override
+  String get seeMore => 'See more';
+
+  @override
+  String get seeLess => 'See less';
+
+  @override
   String get redLabel => 'Červená';
 
   @override

--- a/lib/l10n/generated/fluent_localizations_sv.dart
+++ b/lib/l10n/generated/fluent_localizations_sv.dart
@@ -100,6 +100,12 @@ class FluentLocalizationsSv extends FluentLocalizations {
   String get year => 'år';
 
   @override
+  String get seeMore => 'See more';
+
+  @override
+  String get seeLess => 'See less';
+
+  @override
   String get redLabel => 'Röd';
 
   @override

--- a/lib/l10n/generated/fluent_localizations_ta.dart
+++ b/lib/l10n/generated/fluent_localizations_ta.dart
@@ -104,6 +104,12 @@ class FluentLocalizationsTa extends FluentLocalizations {
   String get year => 'ஆண்டு';
 
   @override
+  String get seeMore => 'See more';
+
+  @override
+  String get seeLess => 'See less';
+
+  @override
   String get redLabel => 'சிவப்பு';
 
   @override

--- a/lib/l10n/generated/fluent_localizations_th.dart
+++ b/lib/l10n/generated/fluent_localizations_th.dart
@@ -100,6 +100,12 @@ class FluentLocalizationsTh extends FluentLocalizations {
   String get year => 'ปี';
 
   @override
+  String get seeMore => 'See more';
+
+  @override
+  String get seeLess => 'See less';
+
+  @override
   String get redLabel => 'แดง';
 
   @override

--- a/lib/l10n/generated/fluent_localizations_tr.dart
+++ b/lib/l10n/generated/fluent_localizations_tr.dart
@@ -100,6 +100,12 @@ class FluentLocalizationsTr extends FluentLocalizations {
   String get year => 'yıl';
 
   @override
+  String get seeMore => 'See more';
+
+  @override
+  String get seeLess => 'See less';
+
+  @override
   String get redLabel => 'Kırmızı';
 
   @override

--- a/lib/l10n/generated/fluent_localizations_uk.dart
+++ b/lib/l10n/generated/fluent_localizations_uk.dart
@@ -100,6 +100,12 @@ class FluentLocalizationsUk extends FluentLocalizations {
   String get year => 'рік';
 
   @override
+  String get seeMore => 'See more';
+
+  @override
+  String get seeLess => 'See less';
+
+  @override
   String get redLabel => 'Червоний';
 
   @override

--- a/lib/l10n/generated/fluent_localizations_ur.dart
+++ b/lib/l10n/generated/fluent_localizations_ur.dart
@@ -103,6 +103,12 @@ class FluentLocalizationsUr extends FluentLocalizations {
   String get year => 'سال';
 
   @override
+  String get seeMore => 'See more';
+
+  @override
+  String get seeLess => 'See less';
+
+  @override
   String get redLabel => 'سرخ';
 
   @override

--- a/lib/l10n/generated/fluent_localizations_uz.dart
+++ b/lib/l10n/generated/fluent_localizations_uz.dart
@@ -101,6 +101,12 @@ class FluentLocalizationsUz extends FluentLocalizations {
   String get year => 'yil';
 
   @override
+  String get seeMore => 'See more';
+
+  @override
+  String get seeLess => 'See less';
+
+  @override
   String get redLabel => 'Qizil';
 
   @override

--- a/lib/l10n/generated/fluent_localizations_vi.dart
+++ b/lib/l10n/generated/fluent_localizations_vi.dart
@@ -101,6 +101,12 @@ class FluentLocalizationsVi extends FluentLocalizations {
   String get year => 'năm';
 
   @override
+  String get seeMore => 'See more';
+
+  @override
+  String get seeLess => 'See less';
+
+  @override
   String get redLabel => 'Đỏ';
 
   @override

--- a/lib/l10n/generated/fluent_localizations_zh.dart
+++ b/lib/l10n/generated/fluent_localizations_zh.dart
@@ -100,6 +100,12 @@ class FluentLocalizationsZh extends FluentLocalizations {
   String get year => '年';
 
   @override
+  String get seeMore => 'See more';
+
+  @override
+  String get seeLess => 'See less';
+
+  @override
   String get redLabel => '红色';
 
   @override

--- a/lib/l10n/intl_en.arb
+++ b/lib/l10n/intl_en.arb
@@ -124,6 +124,14 @@
   "@year": {
     "description": "The text used by [DatePicker] for the year field"
   },
+  "seeMore": "See more",
+  "@seeMore": {
+    "description": "The text used by [CommandBar] to show more items."
+  },
+  "seeLess": "See less",
+  "@seeLess": {
+    "description": "The text used by [CommandBar] to show less items."
+  },
   "redLabel": "Red",
   "@redLabel": {
     "description": "Label for red color component in color picker"

--- a/lib/l10n/intl_pt.arb
+++ b/lib/l10n/intl_pt.arb
@@ -31,6 +31,8 @@
   "month": "mês",
   "day": "dia",
   "year": "ano",
+  "seeMore": "Mostrar mais",
+  "seeLess": "Mostrar menos",
   "redLabel": "Vermelho",
   "greenLabel": "Verde",
   "blueLabel": "Azul",

--- a/lib/l10n/untranslated.json
+++ b/lib/l10n/untranslated.json
@@ -1,7 +1,14 @@
 {
+  "ar": [
+    "seeMore",
+    "seeLess"
+  ],
+
   "be": [
     "am",
     "pm",
+    "seeMore",
+    "seeLess",
     "colorBlack",
     "colorNavy",
     "colorDarkBlue",
@@ -142,7 +149,89 @@
     "colorWhite"
   ],
 
+  "bn": [
+    "seeMore",
+    "seeLess"
+  ],
+
+  "ca": [
+    "seeMore",
+    "seeLess"
+  ],
+
+  "cs": [
+    "seeMore",
+    "seeLess"
+  ],
+
+  "de": [
+    "seeMore",
+    "seeLess"
+  ],
+
+  "el": [
+    "seeMore",
+    "seeLess"
+  ],
+
+  "es": [
+    "seeMore",
+    "seeLess"
+  ],
+
+  "fa": [
+    "seeMore",
+    "seeLess"
+  ],
+
+  "fr": [
+    "seeMore",
+    "seeLess"
+  ],
+
+  "he": [
+    "seeMore",
+    "seeLess"
+  ],
+
+  "hi": [
+    "seeMore",
+    "seeLess"
+  ],
+
+  "hr": [
+    "seeMore",
+    "seeLess"
+  ],
+
+  "hu": [
+    "seeMore",
+    "seeLess"
+  ],
+
+  "id": [
+    "seeMore",
+    "seeLess"
+  ],
+
+  "it": [
+    "seeMore",
+    "seeLess"
+  ],
+
+  "ja": [
+    "seeMore",
+    "seeLess"
+  ],
+
+  "ko": [
+    "seeMore",
+    "seeLess"
+  ],
+
   "ku": [
+    "seeMore",
+    "seeLess",
     "colorBlack",
     "colorNavy",
     "colorDarkBlue",
@@ -290,12 +379,16 @@
     "pm",
     "month",
     "day",
-    "year"
+    "year",
+    "seeMore",
+    "seeLess"
   ],
 
   "my": [
     "am",
     "pm",
+    "seeMore",
+    "seeLess",
     "colorBlack",
     "colorNavy",
     "colorDarkBlue",
@@ -434,6 +527,11 @@
     "colorLightYellow",
     "colorIvory",
     "colorWhite"
+  ],
+
+  "nl": [
+    "seeMore",
+    "seeLess"
   ],
 
   "pl": [
@@ -443,7 +541,14 @@
     "pm",
     "month",
     "day",
-    "year"
+    "year",
+    "seeMore",
+    "seeLess"
+  ],
+
+  "ro": [
+    "seeMore",
+    "seeLess"
   ],
 
   "ru": [
@@ -453,17 +558,53 @@
     "pm",
     "month",
     "day",
-    "year"
+    "year",
+    "seeMore",
+    "seeLess"
+  ],
+
+  "sk": [
+    "seeMore",
+    "seeLess"
+  ],
+
+  "sv": [
+    "seeMore",
+    "seeLess"
+  ],
+
+  "ta": [
+    "seeMore",
+    "seeLess"
+  ],
+
+  "th": [
+    "seeMore",
+    "seeLess"
+  ],
+
+  "tr": [
+    "seeMore",
+    "seeLess"
   ],
 
   "uk": [
     "am",
-    "pm"
+    "pm",
+    "seeMore",
+    "seeLess"
+  ],
+
+  "ur": [
+    "seeMore",
+    "seeLess"
   ],
 
   "uz": [
     "am",
     "pm",
+    "seeMore",
+    "seeLess",
     "colorBlack",
     "colorNavy",
     "colorDarkBlue",
@@ -602,5 +743,20 @@
     "colorLightYellow",
     "colorIvory",
     "colorWhite"
+  ],
+
+  "vi": [
+    "seeMore",
+    "seeLess"
+  ],
+
+  "zh": [
+    "seeMore",
+    "seeLess"
+  ],
+
+  "zh_Hant": [
+    "seeMore",
+    "seeLess"
   ]
 }

--- a/lib/src/controls/flyouts/content.dart
+++ b/lib/src/controls/flyouts/content.dart
@@ -64,7 +64,7 @@ class FlyoutContent extends StatelessWidget {
         RoundedRectangleBorder(
           borderRadius: BorderRadius.circular(6.0),
           side: BorderSide(
-            width: 0.5,
+            width: 1,
             color: theme.inactiveBackgroundColor,
           ),
         );

--- a/lib/src/controls/flyouts/content.dart
+++ b/lib/src/controls/flyouts/content.dart
@@ -64,7 +64,7 @@ class FlyoutContent extends StatelessWidget {
         RoundedRectangleBorder(
           borderRadius: BorderRadius.circular(6.0),
           side: BorderSide(
-            width: 0.25,
+            width: 0.5,
             color: theme.inactiveBackgroundColor,
           ),
         );
@@ -94,7 +94,7 @@ class FlyoutContent extends StatelessWidget {
   }
 }
 
-/// A tile that is used inside of [FlyoutContent]
+/// A tile that is used inside of [FlyoutContent].
 ///
 /// See also:
 ///
@@ -105,6 +105,7 @@ class FlyoutListTile extends StatelessWidget {
   const FlyoutListTile({
     super.key,
     this.onPressed,
+    this.onLongPress,
     this.tooltip,
     this.icon,
     required this.text,
@@ -117,7 +118,11 @@ class FlyoutListTile extends StatelessWidget {
     this.showSelectedIndicator = true,
   });
 
+  /// Called when the tile is tapped or otherwise activated.
   final VoidCallback? onPressed;
+
+  /// Called when the tile is long-pressed.
+  final VoidCallback? onLongPress;
 
   /// The tile tooltip text
   final String? tooltip;
@@ -160,6 +165,7 @@ class FlyoutListTile extends StatelessWidget {
     return HoverButton(
       key: key,
       onPressed: onPressed,
+      onLongPress: onLongPress,
       focusNode: focusNode,
       autofocus: autofocus,
       semanticLabel: semanticLabel,

--- a/lib/src/controls/flyouts/flyout.dart
+++ b/lib/src/controls/flyouts/flyout.dart
@@ -789,9 +789,13 @@ class FlyoutController with ChangeNotifier {
     return result;
   }
 
+  /// Closes the flyout.
+  ///
+  /// The flyout must be open, otherwise an error is thrown.
   void close() {
     _ensureAttached();
     assert(_open);
+    if (!_open) return; // safe for release
     Navigator.of(_attachState!.context).pop();
   }
 }

--- a/lib/src/controls/flyouts/flyout.dart
+++ b/lib/src/controls/flyouts/flyout.dart
@@ -788,6 +788,12 @@ class FlyoutController with ChangeNotifier {
 
     return result;
   }
+
+  void close() {
+    _ensureAttached();
+    assert(_open);
+    Navigator.of(_attachState!.context).pop();
+  }
 }
 
 class _DismissAction extends DismissAction {

--- a/lib/src/controls/flyouts/flyout.dart
+++ b/lib/src/controls/flyouts/flyout.dart
@@ -536,6 +536,11 @@ class FlyoutController with ChangeNotifier {
   /// barrier. It's useful when the flyout is used as a context menu and the
   /// barrier should be dismissed when the user clicks outside of the flyout.
   /// If this is provided, [barrierDismissible] is ignored.
+  ///
+  /// [buildTarget] is a flag that determines whether the target should be built
+  /// or not. This helps when the target needs to be tappable, like the
+  /// [CommandBar] or [MenuBar] widgets. Any context dependencies of the target
+  /// must be available globally. Defaults to false.
   Future<T?> showFlyout<T>({
     required WidgetBuilder builder,
     bool barrierDismissible = true,
@@ -554,6 +559,7 @@ class FlyoutController with ChangeNotifier {
     Offset? position,
     RouteSettings? settings,
     GestureRecognizer? barrierRecognizer,
+    bool buildTarget = false,
   }) async {
     _ensureAttached();
     assert(_attachState!.mounted);
@@ -656,6 +662,11 @@ class FlyoutController with ChangeNotifier {
                     onTap: barrierDismissible ? navigator.pop : null,
                     child: barrier,
                   ),
+                ),
+              if (buildTarget)
+                Positioned.fromRect(
+                  rect: targetRect,
+                  child: _attachState!.build(context),
                 ),
               Positioned.fill(
                 child: SafeArea(

--- a/lib/src/controls/flyouts/menu.dart
+++ b/lib/src/controls/flyouts/menu.dart
@@ -236,6 +236,8 @@ class MenuFlyoutItem extends MenuFlyoutItemBase {
     required this.text,
     this.trailing,
     required this.onPressed,
+    this.onLongPress,
+    this.focusNode,
     this.selected = false,
     this.closeAfterClick = true,
   });
@@ -265,6 +267,12 @@ class MenuFlyoutItem extends MenuFlyoutItemBase {
   ///
   /// If `null`, the item will be marked as disabled.
   final VoidCallback? onPressed;
+
+  /// Called when the item is long pressed.
+  final VoidCallback? onLongPress;
+
+  /// The focus node of the item.
+  final FocusNode? focusNode;
 
   /// Whether this item is selected or not.
   final bool selected;
@@ -301,6 +309,8 @@ class MenuFlyoutItem extends MenuFlyoutItemBase {
                 if (closeAfterClick) Navigator.of(context).maybePop();
                 onPressed?.call();
               },
+        onLongPress: onLongPress,
+        focusNode: focusNode,
       ),
     );
   }

--- a/lib/src/controls/inputs/dropdown_button.dart
+++ b/lib/src/controls/inputs/dropdown_button.dart
@@ -111,7 +111,7 @@ class DropDownButton extends StatefulWidget {
 
   /// Whether the flyout will be closed after an item is tapped.
   ///
-  /// This is only effective on items that are [MenuFlyoutItem]
+  /// This is only effective on items that are [MenuFlyoutItem].
   ///
   /// Defaults to `true`
   final bool closeAfterClick;

--- a/lib/src/controls/navigation/breadcrumb_bar.dart
+++ b/lib/src/controls/navigation/breadcrumb_bar.dart
@@ -166,7 +166,9 @@ class BreadcrumbBarState<T> extends State<BreadcrumbBar<T>> {
     flyoutController.showFlyout(
       barrierColor: Colors.transparent,
       autoModeConfiguration: FlyoutAutoConfiguration(
-        preferredMode: FlyoutPlacementMode.bottomCenter,
+        preferredMode: FlyoutPlacementMode.bottomCenter.resolve(
+          Directionality.of(context),
+        ),
       ),
       builder: (context) {
         return MenuFlyout(

--- a/lib/src/controls/surfaces/commandbar.dart
+++ b/lib/src/controls/surfaces/commandbar.dart
@@ -277,6 +277,7 @@ class CommandBarState extends State<CommandBar> {
     BuildContext context,
     CommandBarItemDisplayMode primaryMode,
   ) {
+    final theme = FluentTheme.of(context);
     final builtItems =
         widget.primaryItems.map((item) => item.build(context, primaryMode));
     Widget? overflowWidget;
@@ -390,6 +391,24 @@ class CommandBarState extends State<CommandBar> {
     if (widget._isExpanded) {
       w = listBuilder.call(children: [Expanded(child: w)]);
     }
+    w = Container(
+      decoration: ShapeDecoration(
+        color: secondaryFlyoutController.isOpen
+            ? theme.menuColor.withValues(alpha: kMenuColorOpacity)
+            : Colors.transparent,
+        shape: RoundedRectangleBorder(
+          borderRadius: BorderRadius.circular(6.0),
+          side: BorderSide(
+            width: 1,
+            color: secondaryFlyoutController.isOpen
+                ? theme.inactiveBackgroundColor
+                : Colors.transparent,
+          ),
+        ),
+      ),
+      child: w,
+    );
+
     return FlyoutTarget(controller: secondaryFlyoutController, child: w);
   }
 
@@ -594,7 +613,7 @@ class CommandBarButton extends CommandBarItem {
           icon: Row(mainAxisSize: MainAxisSize.min, children: [
             if (showIcon)
               IconTheme.merge(
-                data: const IconThemeData(size: 16),
+                data: const IconThemeData(size: 16.0),
                 child: icon!,
               ),
             if (showIcon && showLabel) const SizedBox(width: 10),

--- a/lib/src/controls/surfaces/commandbar.dart
+++ b/lib/src/controls/surfaces/commandbar.dart
@@ -207,9 +207,10 @@ class CommandBarState extends State<CommandBar> {
     final future = secondaryFlyoutController.showFlyout(
       buildTarget: true,
       autoModeConfiguration: FlyoutAutoConfiguration(
-        preferredMode: FlyoutPlacementMode.bottomRight.resolve(
-          Directionality.of(context),
-        ),
+        preferredMode: (widget.direction == Axis.horizontal
+                ? FlyoutPlacementMode.bottomRight
+                : FlyoutPlacementMode.right)
+            .resolve(Directionality.of(context)),
       ),
       builder: (context) {
         return FlyoutContent(

--- a/lib/src/controls/surfaces/commandbar.dart
+++ b/lib/src/controls/surfaces/commandbar.dart
@@ -393,6 +393,7 @@ class CommandBarState extends State<CommandBar> {
       w = listBuilder.call(children: [Expanded(child: w)]);
     }
     w = Container(
+      padding: const EdgeInsets.symmetric(horizontal: 4.0),
       decoration: ShapeDecoration(
         color: secondaryFlyoutController.isOpen
             ? theme.menuColor.withValues(alpha: kMenuColorOpacity)

--- a/lib/src/controls/surfaces/commandbar.dart
+++ b/lib/src/controls/surfaces/commandbar.dart
@@ -541,7 +541,15 @@ class CommandBarButton extends CommandBarItem {
   /// {@macro flutter.widgets.Focus.autofocus}
   final bool autofocus;
 
+  /// The tooltip to show when the button is hovered over.
   final String? tooltip;
+
+  /// Whether the flyout will be closed after an item is tapped.
+  ///
+  /// This only affects items in secondary mode.
+  ///
+  /// Defaults to `true`.
+  final bool closeAfterClick;
 
   /// Creates a command bar button
   const CommandBarButton({
@@ -555,6 +563,7 @@ class CommandBarButton extends CommandBarItem {
     this.focusNode,
     this.autofocus = false,
     this.tooltip,
+    this.closeAfterClick = true,
   });
 
   @override
@@ -600,18 +609,19 @@ class CommandBarButton extends CommandBarItem {
         }
         return button;
       case CommandBarItemDisplayMode.inSecondary:
-        return Padding(
-          padding: const EdgeInsetsDirectional.only(end: 8.0, start: 8.0),
-          child: FlyoutListTile(
-            key: key,
-            onPressed: onPressed,
-            focusNode: focusNode,
-            autofocus: autofocus,
-            icon: icon,
-            text: label ?? const SizedBox.shrink(),
-            tooltip: tooltip,
-          ),
-        );
+        return MenuFlyoutItem(
+          key: key,
+          onPressed: onPressed,
+          onLongPress: onLongPress,
+          leading: icon,
+          text: label ?? const SizedBox.shrink(),
+          trailing: () {
+            if (trailing != null) return trailing!;
+            if (tooltip != null) return Text(tooltip!);
+            return null;
+          }(),
+          closeAfterClick: closeAfterClick,
+        ).build(context);
     }
   }
 }

--- a/lib/src/controls/surfaces/commandbar.dart
+++ b/lib/src/controls/surfaces/commandbar.dart
@@ -245,7 +245,7 @@ class _CommandBarState extends State<CommandBar> {
       void showSecondaryMenu() {
         secondaryFlyoutController.showFlyout(
           autoModeConfiguration: FlyoutAutoConfiguration(
-            preferredMode: FlyoutPlacementMode.topRight.resolve(
+            preferredMode: FlyoutPlacementMode.bottomRight.resolve(
               Directionality.of(context),
             ),
           ),

--- a/lib/src/controls/surfaces/commandbar.dart
+++ b/lib/src/controls/surfaces/commandbar.dart
@@ -697,13 +697,7 @@ class CommandBarSeparator extends CommandBarItem {
           ),
         );
       case CommandBarItemDisplayMode.inSecondary:
-        return Divider(
-          style: DividerThemeData(
-            thickness: thickness,
-            decoration: color != null ? BoxDecoration(color: color) : null,
-            horizontalMargin: const EdgeInsetsDirectional.only(bottom: 5.0),
-          ),
-        );
+        return const MenuFlyoutSeparator().build(context);
     }
   }
 }

--- a/lib/src/controls/surfaces/commandbar.dart
+++ b/lib/src/controls/surfaces/commandbar.dart
@@ -242,8 +242,14 @@ class _CommandBarState extends State<CommandBar> {
         ...widget.secondaryItems,
       ];
 
-      void showSecondaryMenu() {
+      void toggleSecondaryMenu() {
+        if (secondaryFlyoutController.isOpen) {
+          Navigator.of(context).pop();
+          return;
+        }
+
         secondaryFlyoutController.showFlyout(
+          buildTarget: true,
           autoModeConfiguration: FlyoutAutoConfiguration(
             preferredMode: FlyoutPlacementMode.bottomRight.resolve(
               Directionality.of(context),
@@ -269,10 +275,10 @@ class _CommandBarState extends State<CommandBar> {
 
       late CommandBarItem overflowItem;
       if (widget.overflowItemBuilder != null) {
-        overflowItem = widget.overflowItemBuilder!(showSecondaryMenu);
+        overflowItem = widget.overflowItemBuilder!(toggleSecondaryMenu);
       } else {
         overflowItem = CommandBarButton(
-          onPressed: showSecondaryMenu,
+          onPressed: toggleSecondaryMenu,
           icon: const Icon(FluentIcons.more),
         );
       }
@@ -282,10 +288,7 @@ class _CommandBarState extends State<CommandBar> {
           allSecondaryItems.first is CommandBarSeparator) {
         allSecondaryItems.removeAt(0);
       }
-      overflowWidget = FlyoutTarget(
-        controller: secondaryFlyoutController,
-        child: overflowItem.build(context, primaryMode),
-      );
+      overflowWidget = overflowItem.build(context, primaryMode);
     }
 
     var listBuilder =
@@ -374,7 +377,7 @@ class _CommandBarState extends State<CommandBar> {
     if (widget._isExpanded) {
       w = listBuilder.call(children: [Expanded(child: w)]);
     }
-    return w;
+    return FlyoutTarget(controller: secondaryFlyoutController, child: w);
   }
 
   @override

--- a/lib/src/controls/surfaces/commandbar.dart
+++ b/lib/src/controls/surfaces/commandbar.dart
@@ -423,19 +423,25 @@ class CommandBarState extends State<CommandBar> {
       final displayMode = (widget.isCompact ?? false)
           ? CommandBarItemDisplayMode.inPrimaryCompact
           : CommandBarItemDisplayMode.inPrimary;
-      return _buildForPrimaryMode(context, displayMode);
+      return Builder(builder: (context) {
+        return _buildForPrimaryMode(context, displayMode);
+      });
     } else {
       return LayoutBuilder(builder: (context, constraints) {
         if (constraints.maxWidth > widget.compactBreakpointWidth!) {
-          return _buildForPrimaryMode(
-            context,
-            CommandBarItemDisplayMode.inPrimary,
-          );
+          return Builder(builder: (context) {
+            return _buildForPrimaryMode(
+              context,
+              CommandBarItemDisplayMode.inPrimary,
+            );
+          });
         } else {
-          return _buildForPrimaryMode(
-            context,
-            CommandBarItemDisplayMode.inPrimaryCompact,
-          );
+          return Builder(builder: (context) {
+            return _buildForPrimaryMode(
+              context,
+              CommandBarItemDisplayMode.inPrimaryCompact,
+            );
+          });
         }
       });
     }

--- a/lib/src/controls/surfaces/commandbar.dart
+++ b/lib/src/controls/surfaces/commandbar.dart
@@ -393,7 +393,7 @@ class CommandBarState extends State<CommandBar> {
       w = listBuilder.call(children: [Expanded(child: w)]);
     }
     w = Container(
-      padding: const EdgeInsets.symmetric(horizontal: 4.0),
+      padding: const EdgeInsets.all(4.0),
       decoration: ShapeDecoration(
         color: secondaryFlyoutController.isOpen
             ? theme.menuColor.withValues(alpha: kMenuColorOpacity)
@@ -662,7 +662,6 @@ class CommandBarSeparator extends CommandBarItem {
     super.key,
     this.color,
     this.thickness,
-    this.direction = Axis.vertical,
   });
 
   /// Override the color used by the [Divider].
@@ -671,25 +670,27 @@ class CommandBarSeparator extends CommandBarItem {
   /// Override the separator thickness.
   final double? thickness;
 
-  /// The direction of the separator. Defaults to [Axis.vertical].
-  /// This attribute is opposite to [CommandBar. direction].
-  final Axis direction;
-
   @override
   Widget build(BuildContext context, CommandBarItemDisplayMode displayMode) {
+    final parent = context.findAncestorWidgetOfExactType<CommandBar>();
+    final parentDirection = parent?.direction ?? Axis.horizontal;
+    final direction =
+        parentDirection == Axis.horizontal ? Axis.vertical : Axis.horizontal;
     switch (displayMode) {
       case CommandBarItemDisplayMode.inPrimary:
       case CommandBarItemDisplayMode.inPrimaryCompact:
         return CommandBarItemInPrimary(
           child: ConstrainedBox(
             constraints: BoxConstraints(
-              minHeight: direction == Axis.vertical ? 28 : 0,
-              minWidth: direction == Axis.horizontal ? 28 : 0,
+              minWidth: direction == Axis.horizontal ? 24.0 : 0.0,
+              minHeight: direction == Axis.vertical ? 24.0 : 0.0,
             ),
             child: Divider(
               direction: direction,
               style: DividerThemeData(
                 thickness: thickness,
+                horizontalMargin: EdgeInsets.zero,
+                verticalMargin: EdgeInsets.zero,
                 decoration: color != null ? BoxDecoration(color: color) : null,
               ),
             ),


### PR DESCRIPTION
<!-- Add a description of what this PR is changing or adding, and why. Consider mentioning issues -->

* feat: Added `CommandBarButton.closeAfterClick` (Fixes #1149)
* feat: Added `FlyoutController.showFlyout.buildTarget` (Fixes #1173)
  Primary items of the command bar are now accessible through the secondary flyout.
* fix: `CommandBar` secondary menu preferred placement mode
* feat: Added `FlyoutController.close`
* feat: `CommandBarState` is now accessible, making it possible to open/close the secondary flyout
  ```dart
  final commandBarKey = GlobalKey<CommandBarState>();

  CommandBar(
    key: commandBarKey, 
    ...,
  ),
  
  commandBarKey.currentState?.toggleSecondaryMenu();
  commandBarKey.currentState?.secondaryFlyoutController.close();
  ```


## Pre-launch Checklist

<!-- Mark all that applies -->

- [x] I have updated `CHANGELOG.md` with my changes <!-- REQUIRED --> 
- [x] I have run "dart format ." on the project <!-- REQUIRED --> 
- [x] I have added/updated relevant documentation