### PR TITLE
fix: MenuFlyoutSubItem no longer errors while building when FlyoutPlacementMode.auto is used

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## 4.11.2
 
 - fix: Use correct scaffold background color when view is provided
+- fix: `MenuFlyoutSubItem` no longer errors while building when `FlyoutPlacementMode.auto` is used
 
 ## 4.11.1
 

--- a/lib/src/controls/flyouts/flyout.dart
+++ b/lib/src/controls/flyouts/flyout.dart
@@ -1088,50 +1088,49 @@ class _FlyoutPageState extends State<_FlyoutPage> {
                 builder: (context, setState) {
                   FlyoutPlacementMode realPlacementMode = widget.placementMode;
                   if (widget.placementMode == FlyoutPlacementMode.auto) {
-                    if (_autoMode == null) {
-                      return Visibility(
-                        visible: false,
-                        maintainSize: true,
-                        maintainAnimation: true,
-                        maintainState: true,
-                        child: widget.builder(context),
-                      );
-                    } else {
+                    if (_autoMode != null) {
                       realPlacementMode = _autoMode!;
                     }
                   } else {
                     realPlacementMode = widget.placementMode;
                   }
 
-                  return Flyout(
-                    rootFlyout: widget.flyoutKey,
-                    additionalOffset: widget.additionalOffset,
-                    margin: widget.margin,
-                    transitionDuration: widget.transitionDuration!,
-                    reverseTransitionDuration:
-                        widget.reverseTransitionDuration!,
-                    root: widget.navigator,
-                    menuKey: null,
-                    transitionBuilder: widget.transitionBuilder,
-                    placementMode: realPlacementMode,
-                    builder: (context) {
-                      Widget flyout = Padding(
-                        key: widget.flyoutKey,
-                        padding: realPlacementMode._getAdditionalOffsetPosition(
-                          widget.position == null
-                              ? widget.additionalOffset
-                              : 0.0,
-                        ),
-                        child: widget.builder(context),
-                      );
+                  return Visibility(
+                    visible: realPlacementMode != FlyoutPlacementMode.auto,
+                    maintainSize: true,
+                    maintainAnimation: true,
+                    maintainState: true,
+                    child: Flyout(
+                      rootFlyout: widget.flyoutKey,
+                      additionalOffset: widget.additionalOffset,
+                      margin: widget.margin,
+                      transitionDuration: widget.transitionDuration!,
+                      reverseTransitionDuration:
+                          widget.reverseTransitionDuration!,
+                      root: widget.navigator,
+                      menuKey: null,
+                      transitionBuilder: widget.transitionBuilder,
+                      placementMode: realPlacementMode,
+                      builder: (context) {
+                        Widget flyout = Padding(
+                          key: widget.flyoutKey,
+                          padding:
+                              realPlacementMode._getAdditionalOffsetPosition(
+                            widget.position == null
+                                ? widget.additionalOffset
+                                : 0.0,
+                          ),
+                          child: widget.builder(context),
+                        );
 
-                      return widget.transitionBuilder(
-                        context,
-                        widget.animation,
-                        realPlacementMode,
-                        flyout,
-                      );
-                    },
+                        return widget.transitionBuilder(
+                          context,
+                          widget.animation,
+                          realPlacementMode,
+                          flyout,
+                        );
+                      },
+                    ),
                   );
                 },
               ),


### PR DESCRIPTION
Fixes issue where _MenuFlyoutSubItemState.didChangeDependencies() does not have a Flyout.of(context) and throws during build before autoMode has a chance to process (in _FlyoutPositionDelegate.getPositionForChild)

<!-- Add a description of what this PR is changing or adding, and why. Consider mentioning issues -->

## Pre-launch Checklist

<!-- Mark all that applies -->

- [x] I have updated `CHANGELOG.md` with my changes <!-- REQUIRED --> 
- [x] I have run "dart format ." on the project <!-- REQUIRED --> 
- [x] I have added/updated relevant documentation