### PR TITLE
fix: tree view focus

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## 4.11.2
 
 - fix: Use correct scaffold background color when view is provided
+- fix: The focus should start at the tree item that was pressed last when using the keyboard
 
 ## 4.11.1
 

--- a/lib/src/controls/navigation/tree_view.dart
+++ b/lib/src/controls/navigation/tree_view.dart
@@ -186,6 +186,9 @@ class TreeViewItem with Diagnosticable {
   /// {@macro flutter.widgets.Focus.focusNode}
   final FocusNode focusNode;
 
+  /// Whether the node is focused by press
+  bool _focusedByPress = false;
+
   /// {@macro fluent_ui.controls.inputs.HoverButton.semanticLabel}
   final String? semanticLabel;
 
@@ -956,24 +959,31 @@ class _TreeViewItem extends StatelessWidget {
               },
         onPressed: selectionMode == TreeViewSelectionMode.single
             ? () {
+                item._focusedByPress = true;
+                item.focusNode.requestFocus();
+                FocusTraversalGroup.of(context)
+                    .invalidateScopeData(item.focusNode.nearestScope!);
                 onSelect();
                 onInvoked(TreeViewItemInvokeReason.pressed);
-                FocusScope.of(context).unfocus(
-                  disposition: UnfocusDisposition.previouslyFocusedChild,
-                );
               }
             : () {
+          item._focusedByPress = true;
+                item.focusNode.requestFocus();
+                FocusTraversalGroup.of(context)
+                    .invalidateScopeData(item.focusNode.nearestScope!);
                 onInvoked(TreeViewItemInvokeReason.pressed);
-                FocusScope.of(context).unfocus(
-                  disposition: UnfocusDisposition.previouslyFocusedChild,
-                );
               },
         onFocusTap: _onCheckboxInvoked,
         onFocusChange: selectionMode == TreeViewSelectionMode.single
             ? (focused) {
-                if (focused) onSelect();
+                if (focused && !item._focusedByPress) {
+                  onSelect();
+                }
+                if (!focused) item._focusedByPress = false;
               }
-            : null,
+            : (focused) {
+                if (!focused) item._focusedByPress = false;
+              },
         autofocus: item.autofocus,
         focusNode: item.focusNode,
         semanticLabel: item.semanticLabel,
@@ -987,7 +997,7 @@ class _TreeViewItem extends StatelessWidget {
           );
 
           return FocusBorder(
-            focused: states.isFocused,
+            focused: states.isFocused && !item._focusedByPress,
             child: Stack(children: [
               // Indentation and selection indicator for single selection mode.
               Container(

--- a/lib/src/controls/navigation/tree_view.dart
+++ b/lib/src/controls/navigation/tree_view.dart
@@ -967,7 +967,7 @@ class _TreeViewItem extends StatelessWidget {
                 onInvoked(TreeViewItemInvokeReason.pressed);
               }
             : () {
-          item._focusedByPress = true;
+                item._focusedByPress = true;
                 item.focusNode.requestFocus();
                 FocusTraversalGroup.of(context)
                     .invalidateScopeData(item.focusNode.nearestScope!);


### PR DESCRIPTION
<!-- Add a description of what this PR is changing or adding, and why. Consider mentioning issues -->
Partially fixes #834 
The focus should start at the tree item that was pressed last when using the keyboard

## Pre-launch Checklist

<!-- Mark all that applies -->

- [X] I have updated `CHANGELOG.md` with my changes <!-- REQUIRED --> 
- [X] I have run "dart format ." on the project <!-- REQUIRED --> 
- [ ] I have added/updated relevant documentation