### PR TITLE
Fix Undo entry in textbox context menu is doubled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## [next]
+
+- fix: Undo entry was doubled in EditableText context menu ([#1218](https://github.com/bdlukaa/fluent_ui/pull/1218))
+
 ## 4.11.4
 
 - feat: Added Tagalog localization support ([#1207](https://github.com/bdlukaa/fluent_ui/pull/1207))

--- a/lib/src/controls/form/selection_controls.dart
+++ b/lib/src/controls/form/selection_controls.dart
@@ -132,8 +132,8 @@ class FluentTextSelectionToolbar extends StatelessWidget {
             item.type == ContextMenuButtonType.custom && item.label == 'Undo'))
         .followedBy(buttonItems
             .where((item) => item.type == ContextMenuButtonType.selectAll))
-        .followedBy(buttonItems
-            .where((item) => item.type == ContextMenuButtonType.custom))
+        .followedBy(buttonItems.where((item) =>
+            item.type == ContextMenuButtonType.custom && item.label != 'Undo'))
         .toList();
 
     return Padding(


### PR DESCRIPTION
<!-- Add a description of what this PR is changing or adding, and why. Consider mentioning issues -->

Because of this PR: #1212 Undo entry is doubled in menu (so it is in version 4.11.4)

Before:

![image](https://github.com/user-attachments/assets/b0077a2b-663f-4d34-b7b3-8c7ee3620bcd)

After:

![image](https://github.com/user-attachments/assets/b7c150b4-1fce-4334-b4eb-eefe0b80bcde)


## Pre-launch Checklist

<!-- Mark all that applies -->

- [x] I have updated `CHANGELOG.md` with my changes <!-- REQUIRED --> 
- [x] I have run "dart format ." on the project <!-- REQUIRED --> 
- [x] I have added/updated relevant documentation