### PR TITLE
Fix: outdated usage of ToggleSwitch in documentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## [next]
+
+- fix: `ToggleSwitch` outdated usage in the demo.
+
 ## 4.12.0
 
 - feat: Support Flutter 3.32

--- a/example/lib/screens/inputs/toggle_switch.dart
+++ b/example/lib/screens/inputs/toggle_switch.dart
@@ -38,7 +38,7 @@ class _ToggleSwitchPageState extends State<ToggleSwitchPage> with PageMixin {
 
 ToggleSwitch(
   checked: checked,
-  onPressed: disabled ? null : (v) => setState(() => checked = v),
+  onChanged: disabled ? null : (v) => setState(() => checked = v),
 )''',
           child: Align(
             alignment: AlignmentDirectional.centerStart,
@@ -58,7 +58,7 @@ ToggleSwitch(
 
 ToggleSwitch(
   checked: checked,
-  onPressed: disabled ? null : (v) => setState(() => checked = v),
+  onChanged: disabled ? null : (v) => setState(() => checked = v),
   content: Text(checked ? 'Working' : 'Do work'),
 )''',
           child: Row(children: [


### PR DESCRIPTION
Fix outdated usage of ToggleSwitch in documentation.

## Pre-launch Checklist


- [X] I have updated `CHANGELOG.md` with my changes
- [X] I have run "dart format ." on the project
- [X] I have added/updated relevant documentation