### PR TITLE
Prevent setState call after dispose in Changelog widget

### DIFF
--- a/example/lib/widgets/changelog.dart
+++ b/example/lib/widgets/changelog.dart
@@ -33,7 +33,9 @@ class _ChangelogState extends State<Changelog> {
 
     if (response.statusCode == 200) {
       final changelogResult = response.body.split('\n')..removeRange(0, 2);
-      setState(() => changelog = changelogResult);
+      if (mounted) {
+        setState(() => changelog = changelogResult);
+      }
     } else {
       debugPrint(response.body);
     }


### PR DESCRIPTION
This pull request fixes a Flutter error where setState() was called after the Changelog widget was disposed. The error occurred because the asynchronous fetchChangelog method could complete after the widget was removed from the widget tree, leading to an attempt to update state on a defunct State object.
What was changed:
Added a check for mounted before calling setState in the fetchChangelog method of the Changelog widget.
Why:
Prevents the "setState() called after dispose()" error, which could cause crashes or memory leaks if the widget is no longer in the tree when the async operation completes.
How to test:
Open and close the Changelog dialog or screen quickly, especially on slow networks, and verify that no FlutterError is thrown regarding setState after dispose.
Error message:
FlutterError (setState() called after dispose(): _ChangelogState#3b25c(lifecycle state: defunct, not mounted) This error happens if you call setState() on a State object for a widget that no longer appears in the widget tree (e.g., whose parent widget no longer includes the widget in its build). This error can occur when code calls setState() from a timer or an animation callback. The preferred solution is to cancel the timer or stop listening to the animation in the dispose() callback. Another solution is to check the "mounted" property of this object before calling setState() to ensure the object is still in the tree. This error might indicate a memory leak if setState() is being called because another object is retaining a reference to this State object after it has been removed from the tree. To avoid memory leaks, consider breaking the reference to this object during dispose().)