### PR TITLE
Add double tap callback to title bar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - **BREAKING** feat: Rename `RatingBar` to `RatingControl`, and updated its style ([#1274](https://github.com/bdlukaa/fluent_ui/issues/1274))
 - fix: `NumberBox` compact overlay is now positioned correctly on right-to-left directionality ([#1326](https://github.com/bdlukaa/fluent_ui/issues/1326))
 - feat: `TitleBar` now supports double-click to maximize or restore the window ([#1298](https://github.com/bdlukaa/fluent_ui/issues/1298))
+- fix: `TitleBar`'s `isBackButtonEnabled` now works correctly ([#1298](https://github.com/bdlukaa/fluent_ui/issues/1298))
 
 ## 4.14.0
 

--- a/lib/src/controls/navigation/navigation_view/title_bar.dart
+++ b/lib/src/controls/navigation/navigation_view/title_bar.dart
@@ -135,7 +135,11 @@ class TitleBar extends StatelessWidget {
               child: Row(
                 children: [
                   if (isBackButtonVisible)
-                    backButton ?? PaneBackButton(onPressed: onBackRequested),
+                    backButton ??
+                        PaneBackButton(
+                          onPressed: onBackRequested,
+                          enabled: isBackButtonEnabled ?? true,
+                        ),
                   if (isPaneToggleButtonVisible) ?view.pane?.toggleButton,
                   if (leftHeader != null)
                     Padding(


### PR DESCRIPTION
<!-- Add a description of what this PR is changing or adding, and why. Consider mentioning issues -->

Add a double-tap event to the TitleBar. On Windows, double-clicking the title bar maximizes the window; without this event, that behavior cannot be replicated.

## Pre-launch Checklist

<!-- Mark all that applies -->

- [x] I have updated `CHANGELOG.md` with my changes <!-- REQUIRED --> 
- [ ] I have run "dart format ." on the project <!-- REQUIRED --> 
- [ ] I have added/updated relevant documentation