### PR TITLE
fix(numberbox): skip traversal and inline buttons

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 - fix: Correctly forward navigation view theme to flyout items ([#1325](https://github.com/bdlukaa/fluent_ui/issues/1325))
 - fix(mobile): `TitleBar` now accounts for view padding ([05c122b](https://github.com/bdlukaa/fluent_ui/commit/05c122bccb8bbc513c07e8ef238ac17d0f17a6cb))
 - fix: `FluentTextSelectionToolbar` no longer ignores custom `ContextMenuButtonItem`s ([#1317](https://github.com/bdlukaa/fluent_ui/issues/1317))
-- fix: `NumberBox` remove ghost focus and do not focus inline buttons anymoregit
+- fix: `NumberBox` remove ghost focus and do not focus inline buttons anymore
 
 ## 4.15.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 - fix: Correctly forward navigation view theme to flyout items ([#1325](https://github.com/bdlukaa/fluent_ui/issues/1325))
 - fix(mobile): `TitleBar` now accounts for view padding ([05c122b](https://github.com/bdlukaa/fluent_ui/commit/05c122bccb8bbc513c07e8ef238ac17d0f17a6cb))
 - fix: `FluentTextSelectionToolbar` no longer ignores custom `ContextMenuButtonItem`s ([#1317](https://github.com/bdlukaa/fluent_ui/issues/1317))
-- fix: `NumberBox` remove ghost focus and do not focus inline buttons anymore
+- fix: `NumberBox` remove ghost focus and do not focus inline buttons anymore ([#1332](https://github.com/bdlukaa/fluent_ui/pull/1332))
 
 ## 4.15.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - fix: Correctly forward navigation view theme to flyout items ([#1325](https://github.com/bdlukaa/fluent_ui/issues/1325))
 - fix(mobile): `TitleBar` now accounts for view padding ([05c122b](https://github.com/bdlukaa/fluent_ui/commit/05c122bccb8bbc513c07e8ef238ac17d0f17a6cb))
 - fix: `FluentTextSelectionToolbar` no longer ignores custom `ContextMenuButtonItem`s ([#1317](https://github.com/bdlukaa/fluent_ui/issues/1317))
+- fix: `NumberBox` remove ghost focus and do not focus inline buttons anymoregit
 
 ## 4.15.1
 

--- a/lib/src/controls/form/number_box.dart
+++ b/lib/src/controls/form/number_box.dart
@@ -696,6 +696,7 @@ class NumberBoxState<T extends num> extends State<NumberBox<T>> {
     return CompositedTransformTarget(
       link: _layerLink,
       child: Focus(
+        skipTraversal: true,
         onKeyEvent: (node, event) {
           if (event is! KeyDownEvent && event is! KeyRepeatEvent) {
             return KeyEventResult.ignored;
@@ -886,6 +887,7 @@ class _SpinButtonState extends State<_SpinButton> {
       child: IconButton(
         key: widget.buttonKey,
         icon: widget.icon,
+        focusable: false,
         // Empty callback keeps the button in enabled visual state.
         // The actual action is triggered by the Listener's pointer events.
         onPressed: widget.onAction != null ? () {} : null,


### PR DESCRIPTION
I had some focus problems with the NumberBox (some ghost focus, handled by the Focus widget) and I don't think its relevant to have a focus on the inline button (if we works with the keyboard, we usually don't want the focus on the inline button. I may add a parameter for that if its necessary)

<!-- Add a description of what this PR is changing or adding, and why. Consider mentioning issues -->

## Pre-launch Checklist

<!-- Mark all that applies -->

- [x] I have updated `CHANGELOG.md` with my changes <!-- REQUIRED --> 
- [x] I have run "dart format ." on the project <!-- REQUIRED -->  (not on example app, lot of changes)
- [x] I have added/updated relevant documentation


Before:

https://github.com/user-attachments/assets/84ff4eb9-eacd-4f1a-8fbe-4dd4f4b3fb9c

After:


https://github.com/user-attachments/assets/a20a3b4a-876b-4776-802b-bafae1d0cad4


<details>

<summary>Before / After with different Spin Buttons:</summary>

Before (inline mode):

https://github.com/user-attachments/assets/c2c09836-7502-41c7-9307-3ffc4d9a2276

After (compact)

https://github.com/user-attachments/assets/e0e3a80f-f0d8-4369-964f-e5692593acd8

After (inline)

https://github.com/user-attachments/assets/d277e086-eeee-478c-87a7-75482b974e78



</details>




