### PR TITLE
Fixed Hovering behaviour with open MenuBar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## [next]
 
-- fix: 'MenuBar' now doesn't throw "Duplicated Global Key" and/or Rendering exceptions when hovering on different 'MenuBarItem'(s) with the flyout open ([#1334](https://github.com/bdlukaa/fluent_ui/issues/1334))
+- fix: `MenuBar` now doesn't throw "Duplicated Global Key" and/or Rendering exceptions when hovering on different `MenuBarItem`(s) with the flyout open ([#1334](https://github.com/bdlukaa/fluent_ui/issues/1334))
 - refactor: Flutter 3.44.0 support
 - fix: `Tooltip` now correctly uses constructor-given style ((#1321)[https://github.com/bdlukaa/fluent_ui/pull/1321])
 - fix: Correctly apply `ButtonStyle.textStyle` to `Button`s content ([#1318](https://github.com/bdlukaa/fluent_ui/issues/1318))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## [next]
 
+- fix: 'MenuBar' now doesn't throw "Duplicated Global Key" and/or Rendering exceptions when hovering on different 'MenuBarItem'(s) with the flyout open ([#1334](https://github.com/bdlukaa/fluent_ui/issues/1334))
 - refactor: Flutter 3.44.0 support
 - fix: `Tooltip` now correctly uses constructor-given style ((#1321)[https://github.com/bdlukaa/fluent_ui/pull/1321])
 - fix: Correctly apply `ButtonStyle.textStyle` to `Button`s content ([#1318](https://github.com/bdlukaa/fluent_ui/issues/1318))

--- a/lib/src/controls/flyouts/menu_bar.dart
+++ b/lib/src/controls/flyouts/menu_bar.dart
@@ -207,7 +207,6 @@ class MenuBarState extends State<MenuBar> {
     return showItem(widget.items[index], closeIfOpen);
   }
 
-
   bool _hoveringClosed = false;
 
   @override
@@ -265,7 +264,8 @@ class MenuBarState extends State<MenuBar> {
                             },
                             onPointerEnter: _controller.isOpen
                                 ? (_) {
-                                    if (_currentOpenItem != item && !_hoveringClosed) {
+                                    if (_currentOpenItem != item &&
+                                        !_hoveringClosed) {
                                       closeFlyout();
                                       _hoveringClosed = true;
                                     }
@@ -275,7 +275,7 @@ class MenuBarState extends State<MenuBar> {
                                       _showFlyout(context, item);
                                       _hoveringClosed = false;
                                     }
-                                },
+                                  },
                             onFocusChange: (focused) {
                               if (focused && _controller.isOpen) {
                                 _showFlyout(context, item);

--- a/lib/src/controls/flyouts/menu_bar.dart
+++ b/lib/src/controls/flyouts/menu_bar.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:fluent_ui/fluent_ui.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/scheduler.dart';
@@ -164,15 +166,12 @@ class MenuBarState extends State<MenuBar> {
   Future<void> closeFlyout() async {
     if (_controller.isOpen) {
       _controller.close<void>();
-      // Waits for the reverse transition duration.
-      //
-      // Even though the duration is zero, it is necessary to wait for the
-      // transition to finish before showing the next flyout. Otherwise, the
-      // flyout will fail to show due to [_locked]. Use SchedulerBinding for
-      // frame-aligned updates instead of arbitrary delay.
+      final completer = Completer<void>();
       SchedulerBinding.instance.addPostFrameCallback((_) {
         if (mounted) setState(() {});
+        completer.complete();
       });
+      await completer.future;
     }
   }
 
@@ -264,18 +263,11 @@ class MenuBarState extends State<MenuBar> {
                             },
                             onPointerEnter: _controller.isOpen
                                 ? (_) {
-                                    if (_currentOpenItem != item &&
-                                        !_hoveringClosed) {
-                                      closeFlyout();
-                                      _hoveringClosed = true;
+                                    if (_currentOpenItem != item) {
+                                      _showFlyout(context, item);
                                     }
                                   }
-                                : (_) {
-                                    if (_hoveringClosed) {
-                                      _showFlyout(context, item);
-                                      _hoveringClosed = false;
-                                    }
-                                  },
+                                : null,
                             onFocusChange: (focused) {
                               if (focused && _controller.isOpen) {
                                 _showFlyout(context, item);

--- a/lib/src/controls/flyouts/menu_bar.dart
+++ b/lib/src/controls/flyouts/menu_bar.dart
@@ -206,8 +206,6 @@ class MenuBarState extends State<MenuBar> {
     return showItem(widget.items[index], closeIfOpen);
   }
 
-  bool _hoveringClosed = false;
-
   @override
   Widget build(BuildContext context) {
     assert(debugCheckHasFluentTheme(context));

--- a/lib/src/controls/flyouts/menu_bar.dart
+++ b/lib/src/controls/flyouts/menu_bar.dart
@@ -207,6 +207,9 @@ class MenuBarState extends State<MenuBar> {
     return showItem(widget.items[index], closeIfOpen);
   }
 
+
+  bool _hoveringClosed = false;
+
   @override
   Widget build(BuildContext context) {
     assert(debugCheckHasFluentTheme(context));
@@ -262,11 +265,17 @@ class MenuBarState extends State<MenuBar> {
                             },
                             onPointerEnter: _controller.isOpen
                                 ? (_) {
-                                    if (_currentOpenItem != item) {
-                                      _showFlyout(context, item);
+                                    if (_currentOpenItem != item && !_hoveringClosed) {
+                                      closeFlyout();
+                                      _hoveringClosed = true;
                                     }
                                   }
-                                : null,
+                                : (_) {
+                                    if (_hoveringClosed) {
+                                      _showFlyout(context, item);
+                                      _hoveringClosed = false;
+                                    }
+                                },
                             onFocusChange: (focused) {
                               if (focused && _controller.isOpen) {
                                 _showFlyout(context, item);


### PR DESCRIPTION
Fixed an exception thrown by the menuBar when hovering on different Tiles with the open flyout.

<!-- Add a description of what this PR is changing or adding, and why. Consider mentioning issues -->
With reference to the issue #1334 and (probably) to issue #1333 regarding multiple exceptions thrown when switching MenuBar tiles with the flyout being open, I'm posting this fix based on the following routine:
1. When the flyout is open and another tile/item is selected, the menu is closed and a `_hoveringClosed` flag is set to true,
2. When the UI is rebuilt, if the `_hoveringClosed` flag is true, then the flyout is shown relative to the newly selected item in the MenuBar.
3. The flag is set to false again and the bar is working as expected.

## Pre-launch Checklist

<!-- Mark all that applies -->

- [x] I have updated `CHANGELOG.md` with my changes <!-- REQUIRED --> 
- [x] I have run "dart format ." on the project <!-- REQUIRED --> 
- [ ] I have added/updated relevant documentation