### PR TITLE
Allow TitleBar to not respond to onDoubleTap to fix visible delay on clicks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
   `MenuBar` now uses `RawMenuBar` under the hood.
 - feat: `Tooltip.enableTapToDismiss` and `Tooltip.onTriggered` ([#1338](https://github.com/bdlukaa/fluent_ui/pull/1338))
   `Tooltip` now uses `RawTooltip` under the hood.
+- refactor(perf): `TitleBar` now doesn't listen for `onDoubleTap` if the caller doesn't provide a callback. Listening for `onDoubleTap` causes a 300ms delay on single taps (see flutter/flutter#110300)
 
 ## 4.16.0
 

--- a/lib/src/controls/navigation/navigation_view/title_bar.dart
+++ b/lib/src/controls/navigation/navigation_view/title_bar.dart
@@ -150,7 +150,7 @@ class TitleBar extends StatelessWidget {
         onPanEnd: (_) => onDragEnded?.call(),
         onPanCancel: () => onDragCancelled?.call(),
         onPanUpdate: (_) => onDragUpdated?.call(),
-        onDoubleTap: () => onDoubleTap?.call(),
+        onDoubleTap: onDoubleTap,
         child: ConstrainedBox(
           constraints: BoxConstraints.tightFor(
             // according to documentation, increase the size of the title bar if


### PR DESCRIPTION
The new `TitleBar` control, which replaces the old `NavigationAppBar`, currently uses a `GestureDetector` to respond to pan (drag) and double tap/click events. However, `GestureDetector` has a [known, currently unresolved, issue](https://github.com/flutter/flutter/issues/110300) where it adds a 300ms delay to single tap events when you listen to `onDoubleTap`, **thus rendering `TitleBar` unusable** in any desktop, mouse & keyboard environment.

There are a few different avenues for fixing this on the library side, notably: 1) depend on a lower level gesture detection abstraction and choose our own algo for differentiating between single and double clicks  - perhaps one better suited for mouse, given the target audience of the library; or 2) redesign the control so that gesture detection does not apply to the whole thing (which would have the added benefit of better aligning to Windows UX standards -- drag should not work when clicking on app icon or caption buttons, for example).

Given that both of those options would not only require non-trivial amount of work, but also a discussion phase, I'm proposing this change as a quick mitigation, so that at the very least it unblocks teams currently blocked by this, such as mine. The change is a one liner: from `onDoubleTap: () => onDoubleTap?.call()` to `onDoubleTap: onDoubleTap`; the idea being that if the caller provides a `null` func to `onDoubleTap`, the `onDoubleTap` callback from `GestureDetector` is never registered.

I categorized the commit as `refactor(perf)` following precedence on the changelog file, and given that the change does not alter the contract nor does it cause any externally visible change in behavior for the caller (beside the improved perf).

## Pre-launch Checklist

<!-- Mark all that applies -->

- [x] I have updated `CHANGELOG.md` with my changes <!-- REQUIRED --> 
- [x] I have run "dart format ." on the project <!-- REQUIRED --> 
- [ ] I have added/updated relevant documentation