### PR TITLE
NumberBox Focus

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
   `MenuBar` now uses `RawMenuBar` under the hood.
 - feat: `Tooltip.enableTapToDismiss` and `Tooltip.onTriggered` ([#1338](https://github.com/bdlukaa/fluent_ui/pull/1338))
   `Tooltip` now uses `RawTooltip` under the hood.
+- fix: `NumberBox` fix focus (using tab) when `clearButton` is true ([#1341](https://github.com/bdlukaa/fluent_ui/pull/1341))
 
 ## 4.16.0
 

--- a/lib/src/controls/form/number_box.dart
+++ b/lib/src/controls/form/number_box.dart
@@ -610,6 +610,7 @@ class NumberBoxState<T extends num> extends State<NumberBox<T>> {
           key: _clearButtonKey,
           icon: const WindowsIcon(WindowsIcons.clear),
           onPressed: _clearValue,
+          focusable: false,
         ),
         const SizedBox(width: 4),
       ],


### PR DESCRIPTION
During https://github.com/bdlukaa/fluent_ui/pull/1332 I forgot to try with `clearButton: true`.

Before:

https://github.com/user-attachments/assets/4d4c53ca-8d65-4eba-8369-0cf274d6f849

After:

https://github.com/user-attachments/assets/9e828179-e88b-43af-80f8-36d7f1944b99



<!-- Add a description of what this PR is changing or adding, and why. Consider mentioning issues -->

## Pre-launch Checklist

<!-- Mark all that applies -->

- [x] I have updated `CHANGELOG.md` with my changes <!-- REQUIRED --> 
- [x] I have run "dart format ." on the project <!-- REQUIRED --> 
- [x] I have added/updated relevant documentation