### PR TITLE
fix: keep TabView bodies attached to their tabs during reorder

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## [next]
 
+- fix: `TabView` now keeps each tab's body (and its state) attached to its tab when tabs are reordered, instead of leaving a stateful body parked at its old slot while the header moves
 - feat: `MenuBar.overflowBehavior` ([#1337](https://github.com/bdlukaa/fluent_ui/pull/1337))
   `MenuBar` now uses `RawMenuBar` under the hood.
 - feat: `Tooltip.enableTapToDismiss` and `Tooltip.onTriggered` ([#1338](https://github.com/bdlukaa/fluent_ui/pull/1338))

--- a/lib/src/controls/navigation/tab_view/tab.dart
+++ b/lib/src/controls/navigation/tab_view/tab.dart
@@ -139,12 +139,25 @@ class __TabBodyState extends State<_TabBody> {
       physics: const NeverScrollableScrollPhysics(),
       controller: pageController,
       itemCount: widget.tabs.length,
+      // Reorders move a tab to a new index. Report the new index for each
+      // tab-keyed page so the lazy viewport relocates the existing element
+      // (and its state) instead of tearing it down — a plain ValueKey only
+      // guards in-place reuse, so without this a stateful body stayed parked
+      // at its old slot while the header moved, desyncing content from its
+      // tab.
+      findChildIndexCallback: (key) {
+        final tab = (key as ValueKey<Tab>).value;
+        final index = widget.tabs.indexOf(tab);
+        return index == -1 ? null : index;
+      },
       itemBuilder: (context, index) {
         final isSelected = widget.index == index;
         final item = widget.tabs[index];
 
+        // Key the body by tab identity, matching the tab strip
+        // (KeyedSubtree(key: ValueKey<Tab>(tab)) in TabView).
         return ExcludeFocus(
-          key: ValueKey(index),
+          key: ValueKey<Tab>(item),
           excluding: !isSelected,
           child: FocusTraversalGroup(child: item.body),
         );

--- a/lib/src/controls/navigation/tab_view/tab.dart
+++ b/lib/src/controls/navigation/tab_view/tab.dart
@@ -146,8 +146,10 @@ class __TabBodyState extends State<_TabBody> {
       // at its old slot while the header moved, desyncing content from its
       // tab.
       findChildIndexCallback: (key) {
-        final tab = (key as ValueKey<Tab>).value;
-        final index = widget.tabs.indexOf(tab);
+        // Pages are keyed by ValueKey<Tab>; guard the type rather than cast so
+        // an unexpected key can never throw from this framework callback.
+        if (key is! ValueKey<Tab>) return null;
+        final index = widget.tabs.indexOf(key.value);
         return index == -1 ? null : index;
       },
       itemBuilder: (context, index) {

--- a/test/tab_view_test.dart
+++ b/test/tab_view_test.dart
@@ -127,6 +127,31 @@ void main() {
     expect(pressed, isFalse);
   });
 
+  testWidgets('TabView keeps each body glued to its tab across a reorder', (
+    tester,
+  ) async {
+    // PageView parks non-visible pages offstage, so search offstage too.
+    Finder body(String text) => find.text(text, skipOffstage: false);
+
+    await tester.pumpWidget(wrapApp(child: const _ReorderHarness()));
+    await tester.pumpAndSettle();
+    expect(body('B:0'), findsOneWidget);
+
+    // Give tab "B" some state the plain widget config can't carry.
+    await tester.tap(find.widgetWithText(Button, 'inc B'));
+    await tester.pumpAndSettle();
+    expect(body('B:1'), findsOneWidget);
+
+    // Move B in front of A and keep it selected.
+    await tester.tap(find.widgetWithText(Button, 'reorder'));
+    await tester.pumpAndSettle();
+
+    // The reorder changed only the tab order — B's state must ride along, not
+    // stay parked at the slot it used to occupy.
+    expect(body('B:1'), findsOneWidget);
+    expect(body('B:0'), findsNothing);
+  });
+
   testWidgets('TabView supports custom stripBuilder', (tester) async {
     final tabs = [Tab(text: const Text('Tab 1'), body: const Text('Body 1'))];
     await tester.pumpWidget(
@@ -146,4 +171,82 @@ void main() {
     );
     expect(find.text('Custom Strip'), findsOneWidget);
   });
+}
+
+/// Drives a two-tab [TabView] whose bodies hold state (a counter) that no
+/// widget config carries, plus buttons to bump B's counter and to move B in
+/// front of A. Used to prove the body element follows its tab across reorders.
+class _ReorderHarness extends StatefulWidget {
+  const _ReorderHarness();
+
+  @override
+  State<_ReorderHarness> createState() => _ReorderHarnessState();
+}
+
+class _ReorderHarnessState extends State<_ReorderHarness> {
+  late final List<Tab> tabs = [
+    Tab(text: const Text('A'), body: const _CounterBody('A')),
+    Tab(text: const Text('B'), body: const _CounterBody('B')),
+  ];
+  int currentIndex = 1; // start on B so its body is mounted
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      children: [
+        Row(
+          children: [
+            Button(
+              onPressed: () => setState(() {
+                final b = tabs.removeAt(1);
+                tabs.insert(0, b);
+                currentIndex = 0;
+              }),
+              child: const Text('reorder'),
+            ),
+          ],
+        ),
+        Expanded(
+          child: TabView(
+            currentIndex: currentIndex,
+            tabs: tabs,
+            onChanged: (i) => setState(() => currentIndex = i),
+          ),
+        ),
+      ],
+    );
+  }
+}
+
+/// A body whose displayed count lives only in [State] — reused-by-position
+/// reconciliation would strand it while the tab header moves.
+class _CounterBody extends StatefulWidget {
+  final String name;
+  const _CounterBody(this.name);
+
+  @override
+  State<_CounterBody> createState() => _CounterBodyState();
+}
+
+class _CounterBodyState extends State<_CounterBody>
+    with AutomaticKeepAliveClientMixin {
+  int count = 0;
+
+  @override
+  bool get wantKeepAlive => true;
+
+  @override
+  Widget build(BuildContext context) {
+    super.build(context);
+    return Column(
+      mainAxisSize: MainAxisSize.min,
+      children: [
+        Text('${widget.name}:$count'),
+        Button(
+          onPressed: () => setState(() => count++),
+          child: Text('inc ${widget.name}'),
+        ),
+      ],
+    );
+  }
 }


### PR DESCRIPTION
### Description
Currently, `TabView` uses `ValueKey<Tab>(tab)` for its tab-strip items, but uses `ValueKey(index)` for the `PageView` body pages.

Because of this index-based keying, reordering tabs causes stateful bodies to detach from their tabs. While this issue is hidden when using stateless bodies (since they simply rebuild in place), any stateful body - including those utilizing `AutomaticKeepAliveClientMixin` as discussed in #910 - ends up displaying under the wrong tab or losing its state after a reorder.

*(Note: This is unrelated to the keep-alive feature in #910. It does not introduce automatic keep-alive, so there is no performance impact. It only fixes the keying mismatch so developer-managed state correctly follows its tab when reordered.)*

**Repro:** open ≥2 tabs whose bodies hold state (e.g. `AutomaticKeepAliveClientMixin` + a counter), bump one, then drag it to a new position → its content/state no longer matches its tab.

### Solution
- Key each page by tab identity (`ValueKey<Tab>(item)`) to match the tab strip.
- Add `findChildIndexCallback` to the `PageView`. A standard `ValueKey` is not enough to move a child across slots in a lazy sliver; this callback ensures the viewport correctly relocates the existing element (and its state) to the new index.

Note: both changes are required together — the identity key alone can't relocate a child across slots in a lazy sliver, and `findChildIndexCallback` needs a stable per-tab key to map to the new index.

### Testing
- Added a regression test verifying that a stateful, kept-alive body retains its internal state and follows its tab when reordered.

Related: #910