### PR TITLE
fix: keep TabView body state across rebuilds that construct fresh Tab widgets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## [next]
+
+- fix: `TabView` now keys each body page (and strip entry) on the caller-provided `Tab.key` when available, falling back to tab identity. This keeps each tab's body (and its state) attached to its tab both across reorders and across rebuilds that construct fresh `Tab` widgets — the standard Flutter pattern — instead of tearing the visible body down on every rebuild
+
 ## 4.16.1
 
 - fix: `ComboBox` no longer throws when opening a dropdown with a single item ([#1347](https://github.com/bdlukaa/fluent_ui/pull/1347))

--- a/lib/src/controls/navigation/tab_view/tab.dart
+++ b/lib/src/controls/navigation/tab_view/tab.dart
@@ -115,6 +115,19 @@ class __TabBodyState extends State<_TabBody> {
 
   PageController get pageController => _pageController!;
 
+  // A tab's page identity: the caller-provided key when set (stable across
+  // rebuilds that recreate the Tab widget), otherwise the Tab instance itself.
+  static ValueKey<Object?> _pageKeyOf(Tab tab) =>
+      ValueKey<Object?>(tab.key ?? tab);
+
+  int? _indexOfPageKey(Key key) {
+    if (key is! ValueKey<Object?>) return null;
+    for (var i = 0; i < widget.tabs.length; i++) {
+      if (_pageKeyOf(widget.tabs[i]).value == key.value) return i;
+    }
+    return null;
+  }
+
   @override
   void didChangeDependencies() {
     super.didChangeDependencies();
@@ -145,21 +158,17 @@ class __TabBodyState extends State<_TabBody> {
       // guards in-place reuse, so without this a stateful body stayed parked
       // at its old slot while the header moved, desyncing content from its
       // tab.
-      findChildIndexCallback: (key) {
-        // Pages are keyed by ValueKey<Tab>; guard the type rather than cast so
-        // an unexpected key can never throw from this framework callback.
-        if (key is! ValueKey<Tab>) return null;
-        final index = widget.tabs.indexOf(key.value);
-        return index == -1 ? null : index;
-      },
+      findChildIndexCallback: _indexOfPageKey,
       itemBuilder: (context, index) {
         final isSelected = widget.index == index;
         final item = widget.tabs[index];
 
-        // Key the body by tab identity, matching the tab strip
-        // (KeyedSubtree(key: ValueKey<Tab>(tab)) in TabView).
+        // Key the body by the caller-provided tab key when available so the
+        // page element survives rebuilds that construct fresh Tab widgets
+        // (the normal Flutter pattern); fall back to tab identity otherwise,
+        // matching the tab strip (KeyedSubtree(key: ...) in TabView).
         return ExcludeFocus(
-          key: ValueKey<Tab>(item),
+          key: _pageKeyOf(item),
           excluding: !isSelected,
           child: FocusTraversalGroup(child: item.body),
         );

--- a/lib/src/controls/navigation/tab_view/tab_view.dart
+++ b/lib/src/controls/navigation/tab_view/tab_view.dart
@@ -395,11 +395,14 @@ class _TabViewState extends State<TabView> {
           return lockedTabWidth ?? preferredTabWidth;
       }
     }();
+    // Match the body page keying (_pageKeyOf in _TabBody): prefer the
+    // caller-provided tab key so the tab element survives rebuilds that
+    // construct fresh Tab widgets.
     if (minWidth == null) {
-      return KeyedSubtree(key: ValueKey<Tab>(tab), child: child);
+      return KeyedSubtree(key: ValueKey<Object?>(tab.key ?? tab), child: child);
     }
     return AnimatedContainer(
-      key: ValueKey<Tab>(tab),
+      key: ValueKey<Object?>(tab.key ?? tab),
       constraints: BoxConstraints(maxWidth: minWidth, minWidth: minWidth),
       duration: FluentTheme.of(context).fastAnimationDuration,
       curve: FluentTheme.of(context).animationCurve,

--- a/test/tab_view_test.dart
+++ b/test/tab_view_test.dart
@@ -152,6 +152,54 @@ void main() {
     expect(body('B:0'), findsNothing);
   });
 
+  testWidgets(
+    'TabView keeps body state across rebuilds that construct fresh Tab widgets',
+    (tester) async {
+      // PageView parks non-visible pages offstage, so search offstage too.
+      Finder body(String text) => find.text(text, skipOffstage: false);
+
+      await tester.pumpWidget(wrapApp(child: const _FreshInstanceHarness()));
+      await tester.pumpAndSettle();
+      expect(body('A:0'), findsOneWidget);
+
+      // Give tab "A" some state the plain widget config can't carry.
+      await tester.tap(find.widgetWithText(Button, 'inc A'));
+      await tester.pumpAndSettle();
+      expect(body('A:1'), findsOneWidget);
+
+      // The harness rebuilds with brand-new Tab widgets carrying the same
+      // keys — the standard Flutter pattern. A's state must survive.
+      await tester.tap(find.widgetWithText(Button, 'rebuild'));
+      await tester.pumpAndSettle();
+
+      expect(body('A:1'), findsOneWidget);
+      expect(body('A:0'), findsNothing);
+    },
+  );
+
+  testWidgets(
+    'TabView keeps body glued to its tab across a reorder of fresh Tab widgets',
+    (tester) async {
+      Finder body(String text) => find.text(text, skipOffstage: false);
+
+      await tester.pumpWidget(wrapApp(child: const _FreshInstanceHarness()));
+      await tester.pumpAndSettle();
+      expect(body('A:0'), findsOneWidget);
+
+      await tester.tap(find.widgetWithText(Button, 'inc A'));
+      await tester.pumpAndSettle();
+      expect(body('A:1'), findsOneWidget);
+
+      // Move A behind B. The harness constructs fresh Tab widgets (same keys)
+      // on every build, so only the caller-provided keys can identify A.
+      await tester.tap(find.widgetWithText(Button, 'reorder'));
+      await tester.pumpAndSettle();
+
+      expect(body('A:1'), findsOneWidget);
+      expect(body('A:0'), findsNothing);
+    },
+  );
+
   testWidgets('TabView supports custom stripBuilder', (tester) async {
     final tabs = [Tab(text: const Text('Tab 1'), body: const Text('Body 1'))];
     await tester.pumpWidget(
@@ -201,6 +249,57 @@ class _ReorderHarnessState extends State<_ReorderHarness> {
                 final b = tabs.removeAt(1);
                 tabs.insert(0, b);
                 currentIndex = 0;
+              }),
+              child: const Text('reorder'),
+            ),
+          ],
+        ),
+        Expanded(
+          child: TabView(
+            currentIndex: currentIndex,
+            tabs: tabs,
+            onChanged: (i) => setState(() => currentIndex = i),
+          ),
+        ),
+      ],
+    );
+  }
+}
+
+/// Drives a two-tab [TabView] whose bodies hold state (a counter) and whose
+/// [Tab] widgets are constructed fresh on every build with stable caller keys
+/// — the standard Flutter pattern. Buttons bump A's counter and reorder the
+/// tabs. Used to prove the body element is reconciled by caller key, not by
+/// Tab widget identity.
+class _FreshInstanceHarness extends StatefulWidget {
+  const _FreshInstanceHarness();
+
+  @override
+  State<_FreshInstanceHarness> createState() => _FreshInstanceHarnessState();
+}
+
+class _FreshInstanceHarnessState extends State<_FreshInstanceHarness> {
+  List<String> tabIds = ['A', 'B'];
+  int currentIndex = 0;
+
+  @override
+  Widget build(BuildContext context) {
+    final tabs = [
+      for (final id in tabIds)
+        Tab(key: ValueKey<String>(id), text: Text(id), body: _CounterBody(id)),
+    ];
+    return Column(
+      children: [
+        Row(
+          children: [
+            Button(
+              onPressed: () => setState(() {}),
+              child: const Text('rebuild'),
+            ),
+            Button(
+              onPressed: () => setState(() {
+                tabIds = tabIds.reversed.toList();
+                currentIndex = tabIds.indexOf('A');
               }),
               child: const Text('reorder'),
             ),


### PR DESCRIPTION
Fixes #1349. Follow-up to #1344, which fixed the reorder desync but introduced a regression for the most common way of building tabs.

## What this PR changes

#1344 keyed the body `PageView` pages by tab identity (`ValueKey<Tab>(item)`). `Tab` does not implement `==`, so apps that construct their tabs in `build()` — the standard Flutter pattern, e.g. one `Tab` per item derived from app state — get brand-new page keys on every rebuild. The lazy viewport then treats every old page as removed and tears down the visible body, losing scroll positions, text field state and focus on each parent rebuild (described in #1349).

This PR keys each body page (and each strip entry, which had the same identity churn since before #1344) on the caller-provided `Tab.key` when available, falling back to tab identity for keyless tabs:

- **Key stability:** `ValueKey<Object?>(tab.key ?? tab)` compares caller keys by value, so rebuilds that construct fresh `Tab` widgets with stable keys no longer tear the body down.
- **Reorder fix preserved:** `findChildIndexCallback` resolves old page keys to their new index with the same rule, so a body (and its state) still relocates to its tab's new index on reorder — for keyed and keyless (cached-instance) tabs alike.
- For tabs without a key, behavior is unchanged from 4.16.1.

No public API changes; `CHANGELOG.md` updated under `## [next]`.

## Tests

Two regression tests added, both verified to fail on current `master` and pass with this change:

1. `TabView keeps body state across rebuilds that construct fresh Tab widgets` — a stateful body's counter survives a rebuild that constructs brand-new `Tab` widgets carrying the same keys.
2. `TabView keeps body glued to its tab across a reorder of fresh Tab widgets` — the counter still follows its tab when the tabs are reordered and every rebuild constructs fresh `Tab` widgets.

The existing reorder regression test from #1344 (cached `Tab` instances, no caller keys) still passes unchanged. Full suite: `flutter test` — all tests pass. `dart format` clean; no new analyzer findings in touched files.

## Pre-launch Checklist

- [x] I have updated `CHANGELOG.md` with my changes
- [x] I have run "dart format ." on the project
- [x] I have added/updated relevant documentation
