### PR TITLE
chore: update compatibility with Flutter 3.47.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 4.17.0
+
+- refactor: Flutter 3.47.1 support
+- refactor: migrate Material UI imports to the standalone `material_ui` package
+- refactor: migrate Cupertino UI imports to the standalone `cupertino_ui` package
+- refactor: update localization delegates to use `GlobalMaterialLocalizations.delegates` with the new standalone UI packages
+
 ## 4.16.1
 
 - fix: `ComboBox` no longer throws when opening a dropdown with a single item ([#1347](https://github.com/bdlukaa/fluent_ui/pull/1347))

--- a/example/lib/widgets/deferred_widget.dart
+++ b/example/lib/widgets/deferred_widget.dart
@@ -4,7 +4,7 @@
 // Copied from https://github.com/flutter/gallery/blob/d030f1e5316310c48fc725f619eb980a0597366d/lib/deferred_widget.dart
 
 import 'dart:async';
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 
 typedef LibraryLoader = Future<void> Function();
 typedef DeferredWidgetBuilder = Widget Function();

--- a/example/lib/widgets/material_equivalents.dart
+++ b/example/lib/widgets/material_equivalents.dart
@@ -1,8 +1,8 @@
 import 'dart:math';
 
+import 'package:cupertino_ui/cupertino_ui.dart' as c;
 import 'package:fluent_ui/fluent_ui.dart';
-import 'package:flutter/cupertino.dart' as c;
-import 'package:flutter/material.dart' as m;
+import 'package:material_ui/material_ui.dart' as m;
 
 class UIEquivalents extends StatefulWidget {
   const UIEquivalents({super.key});

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -31,6 +31,8 @@ dependencies:
   collection: ^1.19.1
   share_plus: ^13.2.0
 
+  material_ui: any
+  cupertino_ui: any
 dev_dependencies:
   flutter_test:
     sdk: flutter

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -31,8 +31,8 @@ dependencies:
   collection: ^1.19.1
   share_plus: ^13.2.0
 
-  material_ui: any
-  cupertino_ui: any
+  material_ui: ^1.1.1
+  cupertino_ui: ^1.0.2
 dev_dependencies:
   flutter_test:
     sdk: flutter

--- a/lib/fluent_ui.dart
+++ b/lib/fluent_ui.dart
@@ -1,4 +1,5 @@
-export 'package:flutter/material.dart'
+export 'package:flutter/widgets.dart' hide TextBox;
+export 'package:material_ui/material_ui.dart'
     show
         AdaptiveTextSelectionToolbar,
         AnimatedIcon,
@@ -30,7 +31,6 @@ export 'package:flutter/material.dart'
         VisualDensity,
         kElevationToShadow,
         kThemeAnimationDuration;
-export 'package:flutter/widgets.dart' hide TextBox;
 export 'package:scroll_pos/scroll_pos.dart';
 
 export 'l10n/extension/fluent_localizations_extension.dart';

--- a/lib/l10n/generated/fluent_localizations.dart
+++ b/lib/l10n/generated/fluent_localizations.dart
@@ -1,8 +1,7 @@
 import 'dart:async';
 
 import 'package:flutter/foundation.dart';
-import 'package:flutter/widgets.dart';
-import 'package:flutter_localizations/flutter_localizations.dart';
+import 'package:material_ui/material_ui.dart';
 import 'package:intl/intl.dart' as intl;
 
 import 'fluent_localizations_ar.dart';
@@ -125,9 +124,7 @@ abstract class FluentLocalizations {
   static const List<LocalizationsDelegate<dynamic>> localizationsDelegates =
       <LocalizationsDelegate<dynamic>>[
         delegate,
-        GlobalMaterialLocalizations.delegate,
-        GlobalCupertinoLocalizations.delegate,
-        GlobalWidgetsLocalizations.delegate,
+        ...GlobalMaterialLocalizations.delegates,
       ];
 
   /// A list of this localizations delegate's supported locales.

--- a/lib/src/controls/flyouts/tooltip.dart
+++ b/lib/src/controls/flyouts/tooltip.dart
@@ -670,7 +670,7 @@ class _TooltipContent extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return DefaultTextStyle.merge(
-      style: FluentTheme.of(context).typography.body!,
+      style: FluentTheme.of(context).typography.body,
       child: Container(
         decoration: decoration,
         padding: padding,

--- a/lib/src/controls/form/combo_box.dart
+++ b/lib/src/controls/form/combo_box.dart
@@ -60,7 +60,7 @@ class _ComboBoxMenuPainter extends CustomPainter {
   @override
   void paint(Canvas canvas, Size size) {
     final selectedItemOffset = getSelectedItemOffset();
-    final maxTopOffset = math.max(0.0, size.height - scaledItemHeight);
+    final double maxTopOffset = math.max(0, size.height - scaledItemHeight);
     final minBottomOffset = math.min(scaledItemHeight, size.height);
     final top = Tween<double>(
       begin: selectedItemOffset.clamp(0.0, maxTopOffset),
@@ -404,7 +404,7 @@ class _ComboBoxResizeClipper extends CustomClipper<RRect> {
   @override
   RRect getClip(Size size) {
     final selectedItemOffset = getSelectedItemOffset();
-    final maxTopOffset = math.max(0.0, size.height - scaledItemHeight);
+    final double maxTopOffset = math.max(0, size.height - scaledItemHeight);
     final minBottomOffset = math.min(scaledItemHeight, size.height);
     final top = Tween<double>(
       begin: selectedItemOffset.clamp(0.0, maxTopOffset),

--- a/lib/src/controls/form/combo_box.dart
+++ b/lib/src/controls/form/combo_box.dart
@@ -60,7 +60,7 @@ class _ComboBoxMenuPainter extends CustomPainter {
   @override
   void paint(Canvas canvas, Size size) {
     final selectedItemOffset = getSelectedItemOffset();
-    final double maxTopOffset = math.max(0, size.height - scaledItemHeight);
+    final maxTopOffset = math.max<double>(0, size.height - scaledItemHeight);
     final minBottomOffset = math.min(scaledItemHeight, size.height);
     final top = Tween<double>(
       begin: selectedItemOffset.clamp(0.0, maxTopOffset),
@@ -404,7 +404,7 @@ class _ComboBoxResizeClipper extends CustomClipper<RRect> {
   @override
   RRect getClip(Size size) {
     final selectedItemOffset = getSelectedItemOffset();
-    final double maxTopOffset = math.max(0, size.height - scaledItemHeight);
+    final maxTopOffset = math.max<double>(0, size.height - scaledItemHeight);
     final minBottomOffset = math.min(scaledItemHeight, size.height);
     final top = Tween<double>(
       begin: selectedItemOffset.clamp(0.0, maxTopOffset),

--- a/lib/src/controls/inputs/slider.dart
+++ b/lib/src/controls/inputs/slider.dart
@@ -4,8 +4,8 @@ import 'dart:ui';
 
 import 'package:fluent_ui/fluent_ui.dart';
 import 'package:flutter/foundation.dart';
-import 'package:flutter/material.dart' as m;
 import 'package:flutter/rendering.dart';
+import 'package:material_ui/material_ui.dart' as m;
 
 /// A slider lets the user select from a range of values by moving a thumb
 /// control along a track.

--- a/lib/src/controls/navigation/tab_view/tab_view.dart
+++ b/lib/src/controls/navigation/tab_view/tab_view.dart
@@ -624,9 +624,10 @@ class _TabViewState extends State<TabView> {
                         children: [
                           // scroll buttons if needed
                           if (showScrollButtons)
-                            if(direction == TextDirection.ltr)
-                                 backwardButton()
-                                else forwardButton(),
+                            if (direction == TextDirection.ltr)
+                              backwardButton()
+                            else
+                              forwardButton(),
                           // tabs area (flexible/expanded)
                           if (scrollable)
                             Expanded(child: listView)
@@ -634,9 +635,10 @@ class _TabViewState extends State<TabView> {
                             Flexible(child: listView),
                           // scroll buttons if needed
                           if (showScrollButtons)
-                            if(direction == TextDirection.ltr)
-                                 forwardButton()
-                                else backwardButton(),
+                            if (direction == TextDirection.ltr)
+                              forwardButton()
+                            else
+                              backwardButton(),
                           // new tab button
                           if (widget.showNewButton)
                             Padding(

--- a/lib/src/controls/navigation/tab_view/tab_view.dart
+++ b/lib/src/controls/navigation/tab_view/tab_view.dart
@@ -5,8 +5,7 @@ import 'package:flutter/foundation.dart';
 import 'package:flutter/gestures.dart';
 import 'package:flutter/rendering.dart';
 import 'package:flutter/services.dart';
-import 'package:flutter_localizations/flutter_localizations.dart';
-
+import 'package:material_ui/material_ui.dart' as m;
 part 'tab.dart';
 
 const double _kMinTileWidth = 80;
@@ -532,9 +531,7 @@ class _TabViewState extends State<TabView> {
                         },
                         child: Localizations.override(
                           context: context,
-                          delegates: const [
-                            GlobalMaterialLocalizations.delegate,
-                          ],
+                          delegates: m.GlobalMaterialLocalizations.delegates,
                           child: ReorderableListView.builder(
                             buildDefaultDragHandles: false,
                             shrinkWrap: true,
@@ -627,9 +624,9 @@ class _TabViewState extends State<TabView> {
                         children: [
                           // scroll buttons if needed
                           if (showScrollButtons)
-                            direction == TextDirection.ltr
-                                ? backwardButton()
-                                : forwardButton(),
+                            if(direction == TextDirection.ltr)
+                                 backwardButton()
+                                else forwardButton(),
                           // tabs area (flexible/expanded)
                           if (scrollable)
                             Expanded(child: listView)
@@ -637,9 +634,9 @@ class _TabViewState extends State<TabView> {
                             Flexible(child: listView),
                           // scroll buttons if needed
                           if (showScrollButtons)
-                            direction == TextDirection.ltr
-                                ? forwardButton()
-                                : backwardButton(),
+                            if(direction == TextDirection.ltr)
+                                 forwardButton()
+                                else backwardButton(),
                           // new tab button
                           if (widget.showNewButton)
                             Padding(

--- a/lib/src/controls/pickers/color_picker/color_picker.dart
+++ b/lib/src/controls/pickers/color_picker/color_picker.dart
@@ -709,9 +709,10 @@ class _ColorSliders extends StatelessWidget {
       if (isColorSliderVisible)
         _buildValueSlider(theme, localizations, isVertical),
       if (isColorSliderVisible && isAlphaSliderVisible && isAlphaEnabled)
-        if(orientation == Axis.vertical)
-             SizedBox(height: _ColorPickerSpacing.large.size)
-            else SizedBox(width: _ColorPickerSpacing.large.size),
+        if (orientation == Axis.vertical)
+          SizedBox(height: _ColorPickerSpacing.large.size)
+        else
+          SizedBox(width: _ColorPickerSpacing.large.size),
       if (isAlphaSliderVisible && isAlphaEnabled)
         _buildAlphaSlider(theme, localizations, isVertical),
     ];

--- a/lib/src/controls/pickers/color_picker/color_picker.dart
+++ b/lib/src/controls/pickers/color_picker/color_picker.dart
@@ -709,9 +709,9 @@ class _ColorSliders extends StatelessWidget {
       if (isColorSliderVisible)
         _buildValueSlider(theme, localizations, isVertical),
       if (isColorSliderVisible && isAlphaSliderVisible && isAlphaEnabled)
-        orientation == Axis.vertical
-            ? SizedBox(height: _ColorPickerSpacing.large.size)
-            : SizedBox(width: _ColorPickerSpacing.large.size),
+        if(orientation == Axis.vertical)
+             SizedBox(height: _ColorPickerSpacing.large.size)
+            else SizedBox(width: _ColorPickerSpacing.large.size),
       if (isAlphaSliderVisible && isAlphaEnabled)
         _buildAlphaSlider(theme, localizations, isVertical),
     ];

--- a/lib/src/controls/surfaces/acrylic.dart
+++ b/lib/src/controls/surfaces/acrylic.dart
@@ -4,7 +4,7 @@ import 'dart:ui' show ImageFilter;
 
 import 'package:fluent_ui/fluent_ui.dart';
 import 'package:flutter/foundation.dart';
-import 'package:flutter/material.dart' as m;
+import 'package:material_ui/material_ui.dart' as m;
 
 /// The default blur amount applied to [Acrylic] widgets.
 const double kBlurAmount = 30;

--- a/lib/src/controls/surfaces/info_bar.dart
+++ b/lib/src/controls/surfaces/info_bar.dart
@@ -2,7 +2,7 @@ import 'dart:ui';
 
 import 'package:fluent_ui/fluent_ui.dart';
 import 'package:flutter/foundation.dart';
-import 'package:flutter/material.dart' show Icons;
+import 'package:material_ui/material_ui.dart' show Icons;
 
 /// A builder function for creating an [InfoBar] within a popup.
 ///

--- a/lib/src/fluent_app.dart
+++ b/lib/src/fluent_app.dart
@@ -1,11 +1,6 @@
+import 'package:cupertino_ui/cupertino_ui.dart' show CupertinoScrollbar;
 import 'package:fluent_ui/fluent_ui.dart';
-import 'package:flutter/cupertino.dart' show CupertinoScrollbar;
-import 'package:flutter/material.dart' as m;
-import 'package:flutter_localizations/flutter_localizations.dart'
-    show
-        GlobalCupertinoLocalizations,
-        GlobalMaterialLocalizations,
-        GlobalWidgetsLocalizations;
+import 'package:material_ui/material_ui.dart' as m;
 
 /// An application that uses Windows design.
 ///
@@ -394,9 +389,7 @@ class _FluentAppState extends State<FluentApp> {
       yield* localizationsDelegates;
     }
     yield FluentLocalizations.delegate;
-    yield GlobalMaterialLocalizations.delegate;
-    yield GlobalCupertinoLocalizations.delegate;
-    yield GlobalWidgetsLocalizations.delegate;
+    yield* m.GlobalMaterialLocalizations.delegates;
   }
 
   bool get _usesRouter =>

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: fluent_ui
 description: Implements Microsoft's Windows User Interface in Flutter.
-version: 4.16.1
+version: 4.17.0
 homepage: https://bdlukaa.github.io/fluent_ui/#/
 repository: https://github.com/bdlukaa/fluent_ui
 issue_tracker: https://github.com/bdlukaa/fluent_ui/issues
@@ -31,8 +31,8 @@ dependencies:
   # Used on NumberBox
   math_expressions: ^3.2.0
 
-  material_ui: any
-  cupertino_ui: any
+  material_ui: ^1.1.1
+  cupertino_ui: ^1.0.2
 dev_dependencies:
   flutter_test:
     sdk: flutter

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -18,8 +18,6 @@ topics:
 dependencies:
   flutter:
     sdk: flutter
-  flutter_localizations:
-    sdk: flutter
 
   # Used on date and time pickers
   intl: '>=0.20.2 <= 1.0.0'
@@ -33,6 +31,8 @@ dependencies:
   # Used on NumberBox
   math_expressions: ^3.2.0
 
+  material_ui: any
+  cupertino_ui: any
 dev_dependencies:
   flutter_test:
     sdk: flutter

--- a/test/app_test.dart
+++ b/test/app_test.dart
@@ -1,6 +1,6 @@
 import 'package:fluent_ui/fluent_ui.dart';
-import 'package:flutter/material.dart' as m;
 import 'package:flutter_test/flutter_test.dart';
+import 'package:material_ui/material_ui.dart' as m;
 
 Widget wrapApp({required Widget child}) {
   return FluentApp(home: child);

--- a/test/menu_bar_test.dart
+++ b/test/menu_bar_test.dart
@@ -89,7 +89,7 @@ void main() {
   testWidgets('MenuBar animates open and closes on hover switch', (
     tester,
   ) async {
-    const Duration animDuration = Duration(milliseconds: 80);
+    const animDuration = Duration(milliseconds: 80);
     await tester.pumpWidget(
       wrapApp(
         child: FluentTheme(
@@ -136,7 +136,7 @@ void main() {
     await tester.pumpWidget(wrapApp(child: MenuBar(items: manyItems)));
 
     // All items should render (wrapping to multiple lines)
-    for (int i = 0; i < 15; i++) {
+    for (var i = 0; i < 15; i++) {
       expect(find.text('Menu $i'), findsOneWidget);
     }
 
@@ -167,7 +167,7 @@ void main() {
     );
 
     // All items should render (scrollable)
-    for (int i = 0; i < 15; i++) {
+    for (var i = 0; i < 15; i++) {
       expect(find.text('Menu $i'), findsOneWidget);
     }
 
@@ -209,7 +209,6 @@ void main() {
           MenuFlyoutItem(
             text: const Text('Do Something'),
             onPressed: () => pressed = true,
-            closeAfterClick: true,
           ),
         ],
       ),

--- a/test/navigation_view_test.dart
+++ b/test/navigation_view_test.dart
@@ -1,6 +1,6 @@
 import 'package:fluent_ui/fluent_ui.dart';
-import 'package:flutter/material.dart' as material;
 import 'package:flutter_test/flutter_test.dart';
+import 'package:material_ui/material_ui.dart' as material;
 
 void main() {
   group('NavigationView', () {


### PR DESCRIPTION
## Description

This PR updates the package for **Flutter 3.47.1** and migrates the existing Material and Cupertino UI code to the new standalone `material_ui` and `cupertino_ui` packages.

### Changes

* Updated Flutter compatibility to **3.47.1**
* Migrated `package:flutter/material.dart` to `package:material_ui/material_ui.dart`
* Migrated `package:flutter/cupertino.dart` to `package:cupertino_ui/cupertino_ui.dart`
* Updated affected imports to work with the standalone UI packages
* Updated localization handling to use `GlobalMaterialLocalizations.delegates`, which provides the required Material, Cupertino, and Widgets localization delegates through the new standalone package structure

### Validation

* `dart analyze` — **passed**
* `flutter test` — **274 tests passed**

### Notes

This is a compatibility and migration update. No intentional changes have been made to the package's existing behavior or functionality.

## Pre-launch Checklist

* [x] I have updated `CHANGELOG.md` with my changes
* [x] I have run "dart format ." on the project
* [x] I have added/updated relevant documentation
