### PR TITLE
Skip hidden TitleBar children in visitChildrenForSemantics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 ## [next]
+
 - fix(title_bar): skip hidden children when collecting semantics ([#1354](https://github.com/bdlukaa/fluent_ui/pull/1354))
 
 ## 4.16.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## [next]
+- fix(title_bar): skip hidden children when collecting semantics ([#1354](https://github.com/bdlukaa/fluent_ui/pull/1354))
+
 ## 4.16.1
 
 - fix: `ComboBox` no longer throws when opening a dropdown with a single item ([#1347](https://github.com/bdlukaa/fluent_ui/pull/1347))

--- a/lib/src/controls/navigation/navigation_view/title_bar.dart
+++ b/lib/src/controls/navigation/navigation_view/title_bar.dart
@@ -561,6 +561,25 @@ class _RenderTitleSubtitleOverflow extends RenderBox
       child = childAfter(child);
     }
   }
+
+  /// Skips hidden children when collecting semantics.
+  ///
+  /// Hidden children are never laid out (see [performLayout]). If a semantics
+  /// walk visits a hidden child before it is laid out, Flutter asserts on
+  /// `_needsLayout`. Minimizing a maximized window with a screen reader
+  /// running triggers the assert.
+  @override
+  void visitChildrenForSemantics(RenderObjectVisitor visitor) {
+    var child = firstChild;
+    while (child != null) {
+      final childParentData =
+          child.parentData! as _TitleSubtitleOverflowParentData;
+      if (!childParentData.isHidden) {
+        visitor(child);
+      }
+      child = childAfter(child);
+    }
+  }
 }
 
 /// The preferred position for the pane toggle button.

--- a/test/title_bar_test.dart
+++ b/test/title_bar_test.dart
@@ -91,4 +91,86 @@ void main() {
     // Null titleBar should return 0
     expect(TitleBar.calculateHeight(ctx2, null), 0);
   });
+
+  testWidgets('an initially hidden title has no semantics until it fits', (
+    tester,
+  ) async {
+    final handle = tester.ensureSemantics();
+    tester.view.devicePixelRatio = 1;
+    tester.view.physicalSize = const Size(200, 600);
+    addTearDown(tester.view.reset);
+    const searchLabel = 'Search settings';
+
+    try {
+      await tester.pumpWidget(
+        FluentApp(
+          home: NavigationView(
+            titleBar: TitleBar(
+              isBackButtonVisible: false,
+              title: Semantics(
+                label: searchLabel,
+                button: true,
+                child: const SizedBox(
+                  width: searchLabel.length * 16,
+                  height: 32,
+                ),
+              ),
+            ),
+            content: const SizedBox.shrink(),
+          ),
+        ),
+      );
+      expect(tester.takeException(), isNull);
+      expect(find.bySemanticsLabel(searchLabel), findsNothing);
+
+      tester.view.physicalSize = const Size(800, 600);
+      await tester.pump();
+      expect(tester.takeException(), isNull);
+      expect(find.bySemanticsLabel(searchLabel), findsOneWidget);
+    } finally {
+      handle.dispose();
+    }
+  });
+
+  testWidgets(
+    'a dirty title can be hidden and restored with semantics enabled',
+    (tester) async {
+      final handle = tester.ensureSemantics();
+      tester.view.devicePixelRatio = 1;
+      tester.view.physicalSize = const Size(800, 600);
+      addTearDown(tester.view.reset);
+
+      FluentApp buildApp(String title) => FluentApp(
+        home: NavigationView(
+          titleBar: TitleBar(
+            isBackButtonVisible: false,
+            title: Semantics(
+              label: title,
+              button: true,
+              child: SizedBox(width: title.length * 16, height: 32),
+            ),
+          ),
+          content: const SizedBox.shrink(),
+        ),
+      );
+
+      try {
+        await tester.pumpWidget(buildApp('Search'));
+        expect(tester.takeException(), isNull);
+        expect(find.bySemanticsLabel('Search'), findsOneWidget);
+
+        tester.view.physicalSize = const Size(200, 600);
+        await tester.pumpWidget(buildApp('Search settings'));
+        expect(tester.takeException(), isNull);
+        expect(find.bySemanticsLabel('Search settings'), findsNothing);
+
+        tester.view.physicalSize = const Size(800, 600);
+        await tester.pump();
+        expect(tester.takeException(), isNull);
+        expect(find.bySemanticsLabel('Search settings'), findsOneWidget);
+      } finally {
+        handle.dispose();
+      }
+    },
+  );
 }


### PR DESCRIPTION
## Problem

`_TitleSubtitleOverflowBox` hides the title or subtitle when they no longer fit. Hidden children are skipped in `performLayout`, `paint`, and hit testing, but the default `visitChildrenForSemantics` still walks every child. A hidden child that was marked dirty by the size change is never laid out, so the semantics walk hits the assert. Minimizing a maximized window with a screen reader running triggers the `_needsLayout` assert.

Special thanks to @Stasium for helping.

## Pre-launch Checklist

<!-- Mark all that applies -->

- [x] I have updated `CHANGELOG.md` with my changes <!-- REQUIRED --> 
- [X] I have run "dart format ." on the project <!-- REQUIRED --> 
- [ ] I have added/updated relevant documentation